### PR TITLE
fix requirements.txt

### DIFF
--- a/scripts/data_collector/yahoo/requirements.txt
+++ b/scripts/data_collector/yahoo/requirements.txt
@@ -1,4 +1,4 @@
-logure
+loguru
 fire
 requests
 numpy


### PR DESCRIPTION
## Description
Typo "logure", should be "loguru", cause in pip install error.
![image](https://user-images.githubusercontent.com/10728152/94818752-0b094e80-0431-11eb-93e1-6a881e4e6875.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
