### PR TITLE
fix the float conversion bug

### DIFF
--- a/qlib/data/data.py
+++ b/qlib/data/data.py
@@ -671,7 +671,8 @@ class LocalExpressionProvider(ExpressionProvider):
         # Ensure that each column type is consistent
         # FIXME: The stock data is currently float. If there is other types of data, this part needs to be re-implemented.
         try:
-            series = series.astype(float)
+            # TODO: the default storage and calculation type should be configurable
+            series = series.astype(np.float32)
         except ValueError:
             pass
         if not series.empty:


### PR DESCRIPTION
fix the float64 conversion bug

## Description
Qlib automatically convert the data to 64 bit float despite the data source accuracy is 32bit.
This PR will fix this 

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->
Related issue #61 


## How Has This Been Tested?
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [*] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
