### PR TITLE
support non-full-fill rate of executor

### DIFF
--- a/qlib/contrib/backtest/exchange.py
+++ b/qlib/contrib/backtest/exchange.py
@@ -208,14 +208,9 @@ class Exchange:
             # If the order can only be deal 0 trade_val. Nothing to be updated
             # Otherwise, it will result some stock with 0 amount in the position
             if trade_account:
-                trade_account.update_order(
-                    order=order,
-                    trade_val=trade_val,
-                    cost=trade_cost,
-                    trade_price=trade_price,
-                )
+                trade_account.update_order(order=order, trade_val=trade_val, cost=trade_cost, trade_price=trade_price)
             elif position:
-                position.update_order(order, trade_price)
+                position.update_order(order=order, trade_val=trade_val, cost=trade_cost, trade_price=trade_price)
 
         return trade_val, trade_cost, trade_price
 

--- a/qlib/contrib/strategy/strategy.py
+++ b/qlib/contrib/strategy/strategy.py
@@ -238,7 +238,6 @@ class TopkDropoutStrategy(BaseStrategy, ListAdjustTimer):
         sell_order_list = []
         buy_order_list = []
         # load score
-        cash = current_temp.get_cash()
         current_stock_list = current_temp.get_stock_list()
         last = score_series.reindex(current_stock_list).sort_values(ascending=False).index
         today = (
@@ -275,8 +274,6 @@ class TopkDropoutStrategy(BaseStrategy, ListAdjustTimer):
                 if trade_exchange.check_order(sell_order):
                     sell_order_list.append(sell_order)
                     trade_val, trade_cost, trade_price = trade_exchange.deal_order(sell_order, position=current_temp)
-                    # update cash
-                    cash += trade_val - trade_cost
                     # sold
                     del self.stock_count[code]
                 else:
@@ -292,7 +289,7 @@ class TopkDropoutStrategy(BaseStrategy, ListAdjustTimer):
         # buy new stock
         # note the current has been changed
         current_stock_list = current_temp.get_stock_list()
-        value = cash * self.risk_degree / len(buy) if len(buy) > 0 else 0
+        value = current_temp.get_cash() * self.risk_degree / len(buy) if len(buy) > 0 else 0
 
         # open_cost should be considered in the real trading environment, while the backtest in evaluate.py does not consider it
         # as the aim of demo is to accomplish same strategy as evaluate.py, so comment out this line


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Support the executor return  a result that the order is not completed 100%.

## Motivation and Context
Some high-frequency executor will return some order execution result that is not 100% completed.
The daily trading mechanism should support such result.

## How Has This Been Tested?
- [X] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Fix bugs
- [X] Add new feature
- [ ] Update documentation
