### PR TITLE
Update the Sign operation in ops.py

### DIFF
--- a/qlib/data/ops.py
+++ b/qlib/data/ops.py
@@ -143,6 +143,11 @@ class Sign(ElemOperator):
     def __init__(self, feature):
         super(Sign, self).__init__(feature, "sign")
 
+    def _load_internal(self, instrument, start_index, end_index, freq):
+        series = self.feature.load(instrument, start_index, end_index, freq)
+        series = series.astype(np.float32)
+        return getattr(np, self.func)(series)
+
 
 class Log(ElemOperator):
     """Feature Log

--- a/qlib/data/ops.py
+++ b/qlib/data/ops.py
@@ -144,7 +144,11 @@ class Sign(ElemOperator):
         super(Sign, self).__init__(feature, "sign")
 
     def _load_internal(self, instrument, start_index, end_index, freq):
+        """
+        To avoid error raised by bool type input, we transform the data into float32.
+        """
         series = self.feature.load(instrument, start_index, end_index, freq)
+        # TODO:  More precision types should be configurable
         series = series.astype(np.float32)
         return getattr(np, self.func)(series)
 


### PR DESCRIPTION
Fix the bug when Sign followed by True/False value.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
During the alpha generation exps, I found that when the Sign operation meets True/False value, it will raise a MaybeEncodingError. Here I transform the True/False value to np.float32.
## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [x ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
