### PR TITLE
Config.__getattr__ should raise AttributeError

### DIFF
--- a/qlib/config.py
+++ b/qlib/config.py
@@ -29,7 +29,7 @@ class Config:
     def __getattr__(self, attr):
         if attr in self.__dict__["_config"]:
             return self.__dict__["_config"][attr]
-        
+
         raise AttributeError(f"No such {attr} in self._config")
 
     def __setitem__(self, key, value):

--- a/qlib/config.py
+++ b/qlib/config.py
@@ -27,10 +27,10 @@ class Config:
         return self.__dict__["_config"][key]
 
     def __getattr__(self, attr):
-        try:
+        if attr in self.__dict__["_config"]:
             return self.__dict__["_config"][attr]
-        except KeyError:
-            return AttributeError(f"No such {attr} in self._config")
+        
+        raise AttributeError(f"No such {attr} in self._config")
 
     def __setitem__(self, key, value):
         self.__dict__["_config"][key] = value

--- a/qlib/data/data.py
+++ b/qlib/data/data.py
@@ -1052,7 +1052,7 @@ def register_all_wrappers():
     if getattr(C, "calendar_cache", None) is not None:
         _calendar_provider = init_instance_by_config(C.calendar_cache, module, provide=_calendar_provider)
     register_wrapper(Cal, _calendar_provider, "qlib.data")
-    logger.debug(f"registering Cal {C.calendar_provider}-{C.calenar_cache}")
+    logger.debug(f"registering Cal {C.calendar_provider}-{C.calendar_cache}")
 
     register_wrapper(Inst, C.instrument_provider, "qlib.data")
     logger.debug(f"registering Inst {C.instrument_provider}")


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Make `__getattr__ ` to `raise  AttributeError` instead of `return` it.Avoid using `try except`
## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->
User should be responsible for getting the wrong attribute.To `return AttributeError` might cause unexpected problems.`Raise` it instead.Also, aviod using `try except` syntax 
## How Has This Been Tested?
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
