### PR TITLE
better MemCacheUnit implement

### DIFF
--- a/qlib/data/cache.py
+++ b/qlib/data/cache.py
@@ -174,15 +174,15 @@ class MemCache:
         size_limit = C.mem_cache_size_limit if mem_cache_size_limit is None else mem_cache_size_limit
 
         if limit_type == "length":
-            self.__calendar_mem_cache = MemCacheLengthUnit(size_limit)
-            self.__instrument_mem_cache = MemCacheLengthUnit(size_limit)
-            self.__feature_mem_cache = MemCacheLengthUnit(size_limit)
+            klass = MemCacheLengthUnit
         elif limit_type == "sizeof":
-            self.__calendar_mem_cache = MemCacheSizeofUnit(size_limit)
-            self.__instrument_mem_cache = MemCacheSizeofUnit(size_limit)
-            self.__feature_mem_cache = MemCacheSizeofUnit(size_limit)
+            klass = MemCacheSizeofUnit
         else:
             raise ValueError(f"limit_type must be length or sizeof, your limit_type is {limit_type}")
+
+        self.__calendar_mem_cache = klass(size_limit)
+        self.__instrument_mem_cache = klass(size_limit)
+        self.__feature_mem_cache = klass(size_limit)
 
     def __getitem__(self, key):
         if key == "c":

--- a/qlib/data/cache.py
+++ b/qlib/data/cache.py
@@ -174,9 +174,9 @@ class MemCache:
         mem_cache_size_limit: cache max size.
         limit_type: length or sizeof; length(call fun: len), size(call fun: sys.getsizeof).
         """
-        
+
         size_limit = C.mem_cache_size_limit if mem_cache_size_limit is None else mem_cache_size_limit
-        
+
         if limit_type == "length":
             self.__calendar_mem_cache = MemCacheLengthUnit(size_limit)
             self.__instrument_mem_cache = MemCacheLengthUnit(size_limit)

--- a/qlib/data/cache.py
+++ b/qlib/data/cache.py
@@ -47,12 +47,8 @@ class MemCacheUnit(abc.ABC):
         self.size_limit = kwargs.pop("size_limit", 0)
         self.limit_type = kwargs.pop("limit_type", "length")
 
-        assert self.limit_type in ["length", "sizeof"], ValueError(
-            "limit_type shoule be one of ['length', 'sizeof']"
-        )
-        assert self.size_limit >= 0, ValueError(
-            "size_limit shoule not be negative.The default 0 means unlimited!"
-        )
+        assert self.limit_type in ["length", "sizeof"], ValueError("limit_type shoule be one of ['length', 'sizeof']")
+        assert self.size_limit >= 0, ValueError("size_limit shoule not be negative.The default 0 means unlimited!")
 
         # limit_flag: whether to popitem or not
         self._limit_flag = 1 if self.size_limit > 0 else 0

--- a/qlib/data/cache.py
+++ b/qlib/data/cache.py
@@ -108,7 +108,7 @@ class MemCacheUnit(abc.ABC):
 
     def _adjust_size(self, key, value):
         if key in self.od:
-            self._size -= sys.getsizeof(self.od[key])
+            self._size -= self._get_value_size(self.od[key])
 
         self._size += self._get_value_size(value)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
improve the performance fo MemCacheUnit
## Description
<!--- Describe your changes in detail -->
- maintaining the `total size` to improve the performanece at runtime
- make `MemCacheUnit` composed of `OrderDict`, not inherited from `OrderDict`
- the default `size_limit` 0 means unlimit size
- provide new methods `set_limit` and `set_limit_size` to control limit and size.

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->
https://github.com/microsoft/qlib/issues/137#issue-771262875
## How Has This Been Tested?
- [x] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
