### PR TITLE
Add test for portfolio optimizers.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,10 +91,10 @@ jobs:
       run: |
         if [ "$RUNNER_OS" == "Windows" ]; then
           $CONDA\\python.exe -m pip install --upgrade pip
-          $CONDA\\python.exe -m pip install black pytest
+          $CONDA\\python.exe -m pip install black pytest cvxopt
         else
           sudo $CONDA/bin/python -m pip install --upgrade pip
-          sudo $CONDA/bin/python -m pip install black pytest
+          sudo $CONDA/bin/python -m pip install black pytest cvxopt
         fi
       shell: bash 
 

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ REQUIRED = [
     "tornado",
     "joblib>=0.17.0",
     "ruamel.yaml>=0.16.12",
+    "cvxopt~=1.2.5",
 ]
 
 # Numpy include

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,0 +1,96 @@
+#  Copyright (c) Qingyao Sun.
+#  Licensed under the MIT License.
+
+import unittest
+
+import numpy as np
+from cvxopt import matrix, solvers
+
+from qlib.portfolio.optimizer import PortfolioOptimizer
+
+
+class TestOptimizer(unittest.TestCase):
+    def setUp(self) -> None:
+        print('In method', self._testMethodName)
+
+        np.random.seed(42)
+        self.S = np.cov(np.random.random((50, 1024)))
+        self.u = np.random.random(50)
+        self.w0 = np.random.random(50)
+        self.w0 /= self.w0.sum()
+
+    def test_gmv(self):
+        delta = np.random.random()
+        alpha = np.random.random()
+
+        optimizer = PortfolioOptimizer('gmv', delta=delta, alpha=alpha)
+        w_qlib = optimizer(self.S, w0=self.w0)
+
+        upper_bound = np.minimum(1., self.w0 + delta)
+        lower_bound = np.maximum(0., self.w0 - delta)
+        identity = np.diag(np.repeat(1., self.w0.size))
+        P = alpha * identity + self.S
+        q = np.zeros_like(self.w0)
+        G = np.vstack((identity, -identity))
+        h = np.concatenate((upper_bound, -lower_bound))
+        A = np.expand_dims(np.ones_like(self.w0), 0)
+        b = np.array([1.])
+
+        solvers.options['show_progress'] = False
+        sol = solvers.qp(matrix(P), matrix(q),
+                         matrix(G), matrix(h),
+                         matrix(A), matrix(b),
+                         initvals={'x': matrix(self.w0)})
+        self.assertEqual(sol['status'], 'optimal')
+        w_cvxopt = np.array(sol['x']).squeeze()
+
+        for algo, w in [('Initial', self.w0),
+                        ('Qlib', w_qlib),
+                        ('CVXOPT', w_cvxopt)]:
+            self.assertTrue(np.all(w <= upper_bound), msg=algo)
+            self.assertTrue(np.all(lower_bound <= w), msg=algo)
+            self.assertAlmostEqual(w.sum(), 1., msg=algo)
+            loss = alpha * w.T @ w + w.T @ self.S @ w
+            print(f'{algo=}, {loss=}')
+
+    def test_mvo(self):
+        lamb = np.random.random()
+        delta = np.random.random()
+        alpha = np.random.random()
+
+        optimizer = PortfolioOptimizer('mvo', lamb=lamb, delta=delta, alpha=alpha)
+        w_qlib = optimizer(self.S, self.u, self.w0)
+
+        upper_bound = np.minimum(1., self.w0 + delta)
+        lower_bound = np.maximum(0., self.w0 - delta)
+        identity = np.diag(np.repeat(1., self.w0.size))
+        P = 2 * (alpha * identity + self.S)
+        q = -self.u
+        G = np.vstack((identity, -identity))
+        h = np.concatenate((upper_bound, -lower_bound))
+        A = np.expand_dims(np.ones_like(self.w0), 0)
+        b = np.array([1.])
+
+        solvers.options['show_progress'] = False
+        sol = solvers.qp(matrix(P), matrix(q),
+                         matrix(G), matrix(h),
+                         matrix(A), matrix(b),
+                         initvals={'x': matrix(self.w0)})
+        self.assertEqual(sol['status'], 'optimal')
+        w_cvxopt = np.array(sol['x']).squeeze()
+
+        for algo, w in [('Initial', self.w0),
+                        ('Qlib', w_qlib),
+                        ('CVXOPT', w_cvxopt)]:
+            self.assertTrue(np.all(G @ w <= h))
+            self.assertTrue(np.allclose(A @ w, b))
+
+            self.assertTrue(np.all(w <= upper_bound), msg=algo)
+            self.assertTrue(np.all(lower_bound <= w), msg=algo)
+            self.assertAlmostEqual(w.sum(), 1., msg=algo)
+            loss = alpha * w.T @ w - w.T @ self.u + lamb * w.T @ self.S @ w
+            print(f'{algo=}, {loss=}')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -11,7 +11,7 @@ from qlib.portfolio.optimizer import PortfolioOptimizer
 
 class TestOptimizer(unittest.TestCase):
     def setUp(self) -> None:
-        print('In method', self._testMethodName)
+        print("In method", self._testMethodName)
 
         np.random.seed(42)
         self.S = np.cov(np.random.random((50, 1024)))
@@ -23,73 +23,71 @@ class TestOptimizer(unittest.TestCase):
         delta = np.random.random()
         alpha = np.random.random()
 
-        optimizer = PortfolioOptimizer('gmv', delta=delta, alpha=alpha)
+        optimizer = PortfolioOptimizer("gmv", delta=delta, alpha=alpha)
         w_qlib = optimizer(self.S, w0=self.w0)
 
-        upper_bound = np.minimum(1., self.w0 + delta)
-        lower_bound = np.maximum(0., self.w0 - delta)
-        identity = np.diag(np.repeat(1., self.w0.size))
+        upper_bound = np.minimum(1.0, self.w0 + delta)
+        lower_bound = np.maximum(0.0, self.w0 - delta)
+        identity = np.diag(np.repeat(1.0, self.w0.size))
         P = alpha * identity + self.S
         q = np.zeros_like(self.w0)
         G = np.vstack((identity, -identity))
         h = np.concatenate((upper_bound, -lower_bound))
         A = np.expand_dims(np.ones_like(self.w0), 0)
-        b = np.array([1.])
+        b = np.array([1.0])
 
-        solvers.options['show_progress'] = False
-        sol = solvers.qp(matrix(P), matrix(q),
-                         matrix(G), matrix(h),
-                         matrix(A), matrix(b),
-                         initvals={'x': matrix(self.w0)})
-        self.assertEqual(sol['status'], 'optimal')
-        w_cvxopt = np.array(sol['x']).squeeze()
+        solvers.options["show_progress"] = False
+        sol = solvers.qp(
+            matrix(P), matrix(q), matrix(G), matrix(h), matrix(A), matrix(b), initvals={"x": matrix(self.w0)}
+        )
+        self.assertEqual(sol["status"], "optimal")
+        w_cvxopt = np.array(sol["x"]).squeeze()
 
-        for algo, w in [('Initial', self.w0),
-                        ('Qlib', w_qlib),
-                        ('CVXOPT', w_cvxopt)]:
+        for algo, w in [("Initial", self.w0),
+                        ("Qlib", w_qlib),
+                        ("CVXOPT", w_cvxopt)]:
             self.assertTrue(np.all(w <= upper_bound), msg=algo)
             self.assertTrue(np.all(lower_bound <= w), msg=algo)
-            self.assertAlmostEqual(w.sum(), 1., msg=algo)
+            self.assertAlmostEqual(w.sum(), 1.0, msg=algo)
             loss = alpha * w.T @ w + w.T @ self.S @ w
-            print(f'{algo=}, {loss=}')
+            print(f"{algo=}, {loss=}")
 
     def test_mvo(self):
         lamb = np.random.random()
         delta = np.random.random()
         alpha = np.random.random()
 
-        optimizer = PortfolioOptimizer('mvo', lamb=lamb, delta=delta, alpha=alpha)
+        optimizer = PortfolioOptimizer("mvo", lamb=lamb, delta=delta, alpha=alpha)
         w_qlib = optimizer(self.S, self.u, self.w0)
 
-        upper_bound = np.minimum(1., self.w0 + delta)
-        lower_bound = np.maximum(0., self.w0 - delta)
-        identity = np.diag(np.repeat(1., self.w0.size))
+        upper_bound = np.minimum(1.0, self.w0 + delta)
+        lower_bound = np.maximum(0.0, self.w0 - delta)
+        identity = np.diag(np.repeat(1.0, self.w0.size))
         P = 2 * (alpha * identity + self.S)
         q = -self.u
         G = np.vstack((identity, -identity))
         h = np.concatenate((upper_bound, -lower_bound))
         A = np.expand_dims(np.ones_like(self.w0), 0)
-        b = np.array([1.])
+        b = np.array([1.0])
 
-        solvers.options['show_progress'] = False
-        sol = solvers.qp(matrix(P), matrix(q),
-                         matrix(G), matrix(h),
-                         matrix(A), matrix(b),
-                         initvals={'x': matrix(self.w0)})
-        self.assertEqual(sol['status'], 'optimal')
-        w_cvxopt = np.array(sol['x']).squeeze()
+        solvers.options["show_progress"] = False
+        sol = solvers.qp(
+            matrix(P), matrix(q), matrix(G), matrix(h), matrix(A), matrix(b), initvals={"x": matrix(self.w0)}
+        )
+        self.assertEqual(sol["status"], "optimal")
+        w_cvxopt = np.array(sol["x"]).squeeze()
 
-        for algo, w in [('Initial', self.w0),
-                        ('Qlib', w_qlib),
-                        ('CVXOPT', w_cvxopt)]:
+        for algo, w in [("Initial", self.w0),
+                        ("Qlib", w_qlib),
+                        ("CVXOPT", w_cvxopt)]:
             self.assertTrue(np.all(G @ w <= h))
             self.assertTrue(np.allclose(A @ w, b))
 
             self.assertTrue(np.all(w <= upper_bound), msg=algo)
             self.assertTrue(np.all(lower_bound <= w), msg=algo)
-            self.assertAlmostEqual(w.sum(), 1., msg=algo)
+            self.assertAlmostEqual(w.sum(), 1.0, msg=algo)
             loss = alpha * w.T @ w - w.T @ self.u + lamb * w.T @ self.S @ w
-            print(f'{algo=}, {loss=}')
+            print(f"{algo=}, {loss=}")
 
 
 if __name__ == "__main__":

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -43,9 +43,7 @@ class TestOptimizer(unittest.TestCase):
         self.assertEqual(sol["status"], "optimal")
         w_cvxopt = np.array(sol["x"]).squeeze()
 
-        for algo, w in [("Initial", self.w0),
-                        ("Qlib", w_qlib),
-                        ("CVXOPT", w_cvxopt)]:
+        for algo, w in [("Initial", self.w0), ("Qlib", w_qlib), ("CVXOPT", w_cvxopt)]:
             self.assertTrue(np.all(w <= upper_bound), msg=algo)
             self.assertTrue(np.all(lower_bound <= w), msg=algo)
             self.assertAlmostEqual(w.sum(), 1.0, msg=algo)
@@ -77,9 +75,7 @@ class TestOptimizer(unittest.TestCase):
         self.assertEqual(sol["status"], "optimal")
         w_cvxopt = np.array(sol["x"]).squeeze()
 
-        for algo, w in [("Initial", self.w0),
-                        ("Qlib", w_qlib),
-                        ("CVXOPT", w_cvxopt)]:
+        for algo, w in [("Initial", self.w0), ("Qlib", w_qlib), ("CVXOPT", w_cvxopt)]:
             self.assertTrue(np.all(G @ w <= h))
             self.assertTrue(np.allclose(A @ w, b))
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add test for portfolio optimizers. The tests double as alternative implementations.

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->
Currently there are no tests for the portfolio optimizers, so I wrote some for you.

In addition, in addition, the implementations with `cvxopt` in my tests appear to reach a lower loss than the current ones with `scipy.optimize` :).

## How Has This Been Tested?
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [x] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
