### PR TITLE
Fix unrecognized config bug

### DIFF
--- a/qlib/__init__.py
+++ b/qlib/__init__.py
@@ -45,9 +45,10 @@ def init(default_conf="client", **kwargs):
     C.set_region(kwargs.get("region", C["region"] if "region" in C else REG_CN))
 
     for k, v in kwargs.items():
-        C[k] = v
         if k not in C:
             LOG.warning("Unrecognized config %s" % k)
+        else:
+            C[k] = v
 
     C.resolve_path()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The config key should be checked first instead of assignment, otherwise the if-condition would never be true.
## Description
<!--- Describe your changes in detail -->
Put the assignment statement after the if-statement.
## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
