### PR TITLE
did not require pymongo

### DIFF
--- a/qlib/workflow/exp.py
+++ b/qlib/workflow/exp.py
@@ -65,13 +65,13 @@ class Experiment:
         """
         raise NotImplementedError(f"Please implement the `end` method.")
 
-    def create_recorder(self, recorder_name=None):
+    def create_recorder(self, name=None):
         """
         Create a recorder for each experiment.
 
         Parameters
         ----------
-        recorder_name : str
+        name : str
             the name of the recorder to be created.
 
         Returns

--- a/scripts/collect_info.py
+++ b/scripts/collect_info.py
@@ -33,7 +33,6 @@ class InfoCollector:
             "scipy",
             "requests",
             "sacred",
-            "pymongo",
             "python-socketio",
             "redis",
             "python-redis-lock",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ REQUIRED = [
     "scipy>=1.0.0",
     "requests>=2.18.0",
     "sacred>=0.7.4",
-    "pymongo==3.7.2",
     "python-socketio==3.1.2",
     "redis>=3.0.1",
     "python-redis-lock>=3.3.1",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
pip install -U xxxxx

```shell
ERROR: After October 2020 you may experience errors when installing or updating packages. This is because pip will change the way that it resolves dependency conflicts.

We recommend you use --use-feature=2020-resolver to test your packages with the new resolver before it becomes the default.

pyqlib 0.6.1.dev0 requires pymongo==3.7.2, but you'll have pymongo 3.11.2 which is incompatible.
```

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
