### PR TITLE
allow shorting stocks in US stock market

### DIFF
--- a/qlib/contrib/backtest/position.py
+++ b/qlib/contrib/backtest/position.py
@@ -50,22 +50,21 @@ class Position:
         else:
             # exist, add amount
             self.position[stock_id]["amount"] += trade_amount
+            # check if to delete
+            if abs(self.position[stock_id]["amount"]) <= 1e-5:
+                self.del_stock(stock_id)            
 
         self.position["cash"] -= trade_val + cost
 
     def sell_stock(self, stock_id, trade_val, cost, trade_price):
         trade_amount = trade_val / trade_price
         if stock_id not in self.position:
-            raise KeyError("{} not in current position".format(stock_id))
+            self.init_stock(stock_id=stock_id, amount=-trade_amount, price=trade_price)
         else:
             # decrease the amount of stock
             self.position[stock_id]["amount"] -= trade_amount
             # check if to delete
-            if self.position[stock_id]["amount"] < -1e-5:
-                raise ValueError(
-                    "only have {} {}, require {}".format(self.position[stock_id]["amount"], stock_id, trade_amount)
-                )
-            elif abs(self.position[stock_id]["amount"]) <= 1e-5:
+            if abs(self.position[stock_id]["amount"]) <= 1e-5:
                 self.del_stock(stock_id)
 
         self.position["cash"] += trade_val - cost

--- a/qlib/contrib/backtest/position.py
+++ b/qlib/contrib/backtest/position.py
@@ -41,9 +41,7 @@ class Position:
         self.position[stock_id]["count"] = 0  # update count in the end of this date
         self.position[stock_id]["amount"] = amount
         self.position[stock_id]["price"] = price
-        self.position[stock_id][
-            "weight"
-        ] = 0  # update the weight in the end of the trade date
+        self.position[stock_id]["weight"] = 0  # update the weight in the end of the trade date
 
     def buy_stock(self, stock_id, trade_val, cost, trade_price):
         trade_amount = trade_val / trade_price
@@ -83,9 +81,7 @@ class Position:
             # SELL
             self.sell_stock(order.stock_id, trade_val, cost, trade_price)
         else:
-            raise NotImplementedError(
-                "do not suppotr order direction {}".format(order.direction)
-            )
+            raise NotImplementedError("do not suppotr order direction {}".format(order.direction))
 
     def update_stock_price(self, stock_id, price):
         self.position[stock_id]["price"] = price
@@ -103,9 +99,7 @@ class Position:
         stock_list = self.get_stock_list()
         value = 0
         for stock_id in stock_list:
-            value += (
-                self.position[stock_id]["amount"] * self.position[stock_id]["price"]
-            )
+            value += self.position[stock_id]["amount"] * self.position[stock_id]["price"]
         return value
 
     def calculate_value(self):
@@ -155,11 +149,7 @@ class Position:
         d = {}
         stock_list = self.get_stock_list()
         for stock_code in stock_list:
-            d[stock_code] = (
-                self.position[stock_code]["amount"]
-                * self.position[stock_code]["price"]
-                / position_value
-            )
+            d[stock_code] = self.position[stock_code]["amount"] * self.position[stock_code]["price"] / position_value
         return d
 
     def add_count_all(self):
@@ -179,9 +169,7 @@ class Position:
         cash["init_cash"] = self.init_cash
         cash["cash"] = p["cash"]
         cash["today_account_value"] = p["today_account_value"]
-        cash["last_trade_date"] = (
-            str(last_trade_date.date()) if last_trade_date else None
-        )
+        cash["last_trade_date"] = str(last_trade_date.date()) if last_trade_date else None
         del p["cash"]
         del p["today_account_value"]
         positions = pd.DataFrame.from_dict(p, orient="index")

--- a/qlib/contrib/backtest/position.py
+++ b/qlib/contrib/backtest/position.py
@@ -41,7 +41,9 @@ class Position:
         self.position[stock_id]["count"] = 0  # update count in the end of this date
         self.position[stock_id]["amount"] = amount
         self.position[stock_id]["price"] = price
-        self.position[stock_id]["weight"] = 0  # update the weight in the end of the trade date
+        self.position[stock_id][
+            "weight"
+        ] = 0  # update the weight in the end of the trade date
 
     def buy_stock(self, stock_id, trade_val, cost, trade_price):
         trade_amount = trade_val / trade_price
@@ -52,7 +54,7 @@ class Position:
             self.position[stock_id]["amount"] += trade_amount
             # check if to delete
             if abs(self.position[stock_id]["amount"]) <= 1e-5:
-                self.del_stock(stock_id)            
+                self.del_stock(stock_id)
 
         self.position["cash"] -= trade_val + cost
 
@@ -81,7 +83,9 @@ class Position:
             # SELL
             self.sell_stock(order.stock_id, trade_val, cost, trade_price)
         else:
-            raise NotImplementedError("do not suppotr order direction {}".format(order.direction))
+            raise NotImplementedError(
+                "do not suppotr order direction {}".format(order.direction)
+            )
 
     def update_stock_price(self, stock_id, price):
         self.position[stock_id]["price"] = price
@@ -99,7 +103,9 @@ class Position:
         stock_list = self.get_stock_list()
         value = 0
         for stock_id in stock_list:
-            value += self.position[stock_id]["amount"] * self.position[stock_id]["price"]
+            value += (
+                self.position[stock_id]["amount"] * self.position[stock_id]["price"]
+            )
         return value
 
     def calculate_value(self):
@@ -149,7 +155,11 @@ class Position:
         d = {}
         stock_list = self.get_stock_list()
         for stock_code in stock_list:
-            d[stock_code] = self.position[stock_code]["amount"] * self.position[stock_code]["price"] / position_value
+            d[stock_code] = (
+                self.position[stock_code]["amount"]
+                * self.position[stock_code]["price"]
+                / position_value
+            )
         return d
 
     def add_count_all(self):
@@ -169,7 +179,9 @@ class Position:
         cash["init_cash"] = self.init_cash
         cash["cash"] = p["cash"]
         cash["today_account_value"] = p["today_account_value"]
-        cash["last_trade_date"] = str(last_trade_date.date()) if last_trade_date else None
+        cash["last_trade_date"] = (
+            str(last_trade_date.date()) if last_trade_date else None
+        )
         del p["cash"]
         del p["today_account_value"]
         positions = pd.DataFrame.from_dict(p, orient="index")


### PR DESCRIPTION
update position.py to allow short orders (implemented as negative amount in position).



## Description
Allow negative amount in position to represent short orders in US stock.

## Motivation and Context
Allow short orders will allow more flexible strategies.

## How Has This Been Tested?
- [x] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [x] If you are adding a new feature, test on your own test scripts.
tested with xgboost script.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
[pytest.out.txt](https://github.com/microsoft/qlib/files/5853684/pytest.out.txt)

2. Your own tests:
[workflow-xgboost.log.txt](https://github.com/microsoft/qlib/files/5853685/workflow-xgboost.log.txt)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Fix bugs
- [x] Add new feature
- [ ] Update documentation
