### PR TITLE
Update the Wrapper class to have an informative str representation

### DIFF
--- a/qlib/utils/__init__.py
+++ b/qlib/utils/__init__.py
@@ -722,6 +722,10 @@ class Wrapper:
     def register(self, provider):
         self._provider = provider
 
+    def __repr__(self):
+        return ('{name}(provider={provider})'.format(name=self.__class__.__name__,
+                                                     provider=self._provider))
+
     def __getattr__(self, key):
         if self._provider is None:
             raise AttributeError("Please run qlib.init() first using qlib")

--- a/qlib/utils/__init__.py
+++ b/qlib/utils/__init__.py
@@ -723,8 +723,7 @@ class Wrapper:
         self._provider = provider
 
     def __repr__(self):
-        return ('{name}(provider={provider})'.format(name=self.__class__.__name__,
-                                                     provider=self._provider))
+        return "{name}(provider={provider})".format(name=self.__class__.__name__, provider=self._provider)
 
     def __getattr__(self, key):
         if self._provider is None:


### PR DESCRIPTION
Update the Wrapper class to have an informative str representation

## Description
Add the `__repr__` function for Wrapper.

## Motivation and Context
Before this PR, the print output of a Wrapper instance is useless and shows little information.

## Screenshots of Test Results (if appropriate):
![image](https://user-images.githubusercontent.com/9547057/109653173-a8f97480-7b9b-11eb-8ab0-bb49e6a23454.png)
![image](https://user-images.githubusercontent.com/9547057/109662026-91bf8480-7ba5-11eb-8206-48683d22099d.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Fix bugs
- [x] Add new feature
- [ ] Update documentation