### PR TITLE
(1) Fix /0 bug in double_ensemble, (2) remove _default_uri for R/expm, (3) support model size in pytorch models

### DIFF
--- a/qlib/config.py
+++ b/qlib/config.py
@@ -105,7 +105,7 @@ _default_config = {
     "redis_port": 6379,
     "redis_task_db": 1,
     # This value can be reset via qlib.init
-    "logging_level": "INFO",
+    "logging_level": logging.INFO,
     # Global configuration of qlib log
     # logging_level can control the logging level more finely
     "logging_config": {
@@ -124,12 +124,12 @@ _default_config = {
         "handlers": {
             "console": {
                 "class": "logging.StreamHandler",
-                "level": "DEBUG",
+                "level": logging.DEBUG,
                 "formatter": "logger_format",
                 "filters": ["field_not_found"],
             }
         },
-        "loggers": {"qlib": {"level": "DEBUG", "handlers": ["console"]}},
+        "loggers": {"qlib": {"level": logging.DEBUG, "handlers": ["console"]}},
     },
     # Defatult config for experiment manager
     "exp_manager": {
@@ -185,7 +185,7 @@ MODE_CONF = {
         # The nfs should be auto-mounted by qlib on other
         # serversS(such as PAI) [auto_mount:True]
         "timeout": 100,
-        "logging_level": "INFO",
+        "logging_level": logging.INFO,
         "region": REG_CN,
         ## Custom Operator
         "custom_ops": [],

--- a/qlib/contrib/backtest/account.py
+++ b/qlib/contrib/backtest/account.py
@@ -104,10 +104,9 @@ class Account:
             # if suspend, no new price to be updated, profit is 0
             if trader.check_stock_suspended(code, today):
                 continue
-            else:
-                today_close = trader.get_close(code, today)
-                profit += (today_close - self.current.position[code]["price"]) * self.current.position[code]["amount"]
-                self.current.update_stock_price(stock_id=code, price=today_close)
+            today_close = trader.get_close(code, today)
+            profit += (today_close - self.current.position[code]["price"]) * self.current.position[code]["amount"]
+            self.current.update_stock_price(stock_id=code, price=today_close)
         self.rtn += profit
         # update holding day count
         self.current.add_count_all()

--- a/qlib/contrib/model/double_ensemble.py
+++ b/qlib/contrib/model/double_ensemble.py
@@ -184,7 +184,7 @@ class DEnsembleModel(Model):
                     / M
                 )
             loss_feat = self.get_loss(y_train.values.squeeze(), pred.values)
-            g.loc[i_f, "g_value"] = np.mean(loss_feat - loss_values) / np.std(loss_feat - loss_values)
+            g.loc[i_f, "g_value"] = np.mean(loss_feat - loss_values) / (np.std(loss_feat - loss_values) + 1e-7)
             x_train_tmp.loc[:, feat] = x_train.loc[:, feat].copy()
 
         # one column in train features is all-nan # if g['g_value'].isna().any()

--- a/qlib/contrib/model/pytorch_alstm.py
+++ b/qlib/contrib/model/pytorch_alstm.py
@@ -218,7 +218,6 @@ class ALSTM(Model):
         self,
         dataset: DatasetH,
         evals_result=dict(),
-        verbose=True,
         save_path=None,
     ):
 

--- a/qlib/contrib/model/pytorch_alstm.py
+++ b/qlib/contrib/model/pytorch_alstm.py
@@ -23,6 +23,7 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 
+from .pytorch_utils import count_parameters
 from ...model.base import Model
 from ...data.dataset import DatasetH
 from ...data.dataset.handler import DataHandlerLP
@@ -39,8 +40,8 @@ class ALSTM(Model):
         the evaluate metric used in early stop
     optimizer : str
         optimizer name
-    GPU : str
-        the GPU ID(s) used for training
+    GPU : int
+        the GPU ID used for training
     """
 
     def __init__(
@@ -76,7 +77,7 @@ class ALSTM(Model):
         self.early_stop = early_stop
         self.optimizer = optimizer.lower()
         self.loss = loss
-        self.device = torch.device("cuda:%d" % (GPU) if torch.cuda.is_available() else "cpu")
+        self.device = torch.device("cuda:%d" % (GPU) if torch.cuda.is_available() and GPU >= 0 else "cpu")
         self.use_gpu = torch.cuda.is_available()
         self.seed = seed
 
@@ -123,6 +124,9 @@ class ALSTM(Model):
             num_layers=self.num_layers,
             dropout=self.dropout,
         )
+        self.logger.info("model:\n{:}".format(self.ALSTM_model))
+        self.logger.info("model size: {:.4f} MB".format(count_parameters(self.ALSTM_model)))
+
         if optimizer.lower() == "adam":
             self.train_optimizer = optim.Adam(self.ALSTM_model.parameters(), lr=self.lr)
         elif optimizer.lower() == "gd":

--- a/qlib/contrib/model/pytorch_alstm_ts.py
+++ b/qlib/contrib/model/pytorch_alstm_ts.py
@@ -205,7 +205,6 @@ class ALSTM(Model):
         self,
         dataset,
         evals_result=dict(),
-        verbose=True,
         save_path=None,
     ):
         dl_train = dataset.prepare("train", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)

--- a/qlib/contrib/model/pytorch_alstm_ts.py
+++ b/qlib/contrib/model/pytorch_alstm_ts.py
@@ -40,8 +40,8 @@ class ALSTM(Model):
         the evaluate metric used in early stop
     optimizer : str
         optimizer name
-    GPU : str
-        the GPU ID(s) used for training
+    GPU : int
+        the GPU ID used for training
     """
 
     def __init__(
@@ -78,7 +78,7 @@ class ALSTM(Model):
         self.early_stop = early_stop
         self.optimizer = optimizer.lower()
         self.loss = loss
-        self.device = torch.device("cuda:%d" % (GPU) if torch.cuda.is_available() else "cpu")
+        self.device = torch.device("cuda:%d" % (GPU) if torch.cuda.is_available() and GPU >= 0 else "cpu")
         self.n_jobs = n_jobs
         self.use_gpu = torch.cuda.is_available()
         self.seed = seed

--- a/qlib/contrib/model/pytorch_alstm_ts.py
+++ b/qlib/contrib/model/pytorch_alstm_ts.py
@@ -24,6 +24,7 @@ import torch.nn as nn
 import torch.optim as optim
 from torch.utils.data import DataLoader
 
+from .pytorch_utils import count_parameters
 from ...model.base import Model
 from ...data.dataset import DatasetH, TSDatasetH
 from ...data.dataset.handler import DataHandlerLP
@@ -127,7 +128,10 @@ class ALSTM(Model):
             hidden_size=self.hidden_size,
             num_layers=self.num_layers,
             dropout=self.dropout,
-        ).to(self.device)
+        )
+        self.logger.info("model:\n{:}".format(self.ALSTM_model))
+        self.logger.info("model size: {:.4f} MB".format(count_parameters(self.ALSTM_model)))
+
         if optimizer.lower() == "adam":
             self.train_optimizer = optim.Adam(self.ALSTM_model.parameters(), lr=self.lr)
         elif optimizer.lower() == "gd":

--- a/qlib/contrib/model/pytorch_gats.py
+++ b/qlib/contrib/model/pytorch_gats.py
@@ -22,6 +22,7 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 
+from .pytorch_utils import count_parameters
 from ...model.base import Model
 from ...data.dataset import DatasetH
 from ...data.dataset.handler import DataHandlerLP
@@ -42,8 +43,8 @@ class GATs(Model):
         the evaluate metric used in early stop
     optimizer : str
         optimizer name
-    GPU : str
-        the GPU ID(s) used for training
+    GPU : int
+        the GPU ID used for training
     """
 
     def __init__(
@@ -83,7 +84,7 @@ class GATs(Model):
         self.base_model = base_model
         self.with_pretrain = with_pretrain
         self.model_path = model_path
-        self.device = torch.device("cuda:%d" % (GPU) if torch.cuda.is_available() else "cpu")
+        self.device = torch.device("cuda:%d" % (GPU) if torch.cuda.is_available() and GPU >= 0 else "cpu")
         self.use_gpu = torch.cuda.is_available()
         self.seed = seed
 
@@ -135,6 +136,9 @@ class GATs(Model):
             dropout=self.dropout,
             base_model=self.base_model,
         )
+        self.logger.info("model:\n{:}".format(self.GAT_model))
+        self.logger.info("model size: {:.4f} MB".format(count_parameters(self.GAT_model)))
+
         if optimizer.lower() == "adam":
             self.train_optimizer = optim.Adam(self.GAT_model.parameters(), lr=self.lr)
         elif optimizer.lower() == "gd":

--- a/qlib/contrib/model/pytorch_gats.py
+++ b/qlib/contrib/model/pytorch_gats.py
@@ -236,7 +236,6 @@ class GATs(Model):
         self,
         dataset: DatasetH,
         evals_result=dict(),
-        verbose=True,
         save_path=None,
     ):
 

--- a/qlib/contrib/model/pytorch_gats_ts.py
+++ b/qlib/contrib/model/pytorch_gats_ts.py
@@ -249,7 +249,6 @@ class GATs(Model):
         self,
         dataset,
         evals_result=dict(),
-        verbose=True,
         save_path=None,
     ):
 

--- a/qlib/contrib/model/pytorch_gats_ts.py
+++ b/qlib/contrib/model/pytorch_gats_ts.py
@@ -24,6 +24,7 @@ import torch.optim as optim
 from torch.utils.data import DataLoader
 from torch.utils.data import Sampler
 
+from .pytorch_utils import count_parameters
 from ...model.base import Model
 from ...data.dataset import DatasetH
 from ...data.dataset.handler import DataHandlerLP
@@ -62,8 +63,8 @@ class GATs(Model):
         the evaluate metric used in early stop
     optimizer : str
         optimizer name
-    GPU : str
-        the GPU ID(s) used for training
+    GPU : int
+        the GPU ID used for training
     """
 
     def __init__(
@@ -104,7 +105,7 @@ class GATs(Model):
         self.base_model = base_model
         self.with_pretrain = with_pretrain
         self.model_path = model_path
-        self.device = torch.device("cuda:%d" % (GPU) if torch.cuda.is_available() else "cpu")
+        self.device = torch.device("cuda:%d" % (GPU) if torch.cuda.is_available() and GPU >= 0 else "cpu")
         self.n_jobs = n_jobs
         self.use_gpu = torch.cuda.is_available()
         self.seed = seed
@@ -157,6 +158,9 @@ class GATs(Model):
             dropout=self.dropout,
             base_model=self.base_model,
         )
+        self.logger.info("model:\n{:}".format(self.GAT_model))
+        self.logger.info("model size: {:.4f} MB".format(count_parameters(self.GAT_model)))
+
         if optimizer.lower() == "adam":
             self.train_optimizer = optim.Adam(self.GAT_model.parameters(), lr=self.lr)
         elif optimizer.lower() == "gd":

--- a/qlib/contrib/model/pytorch_gru.py
+++ b/qlib/contrib/model/pytorch_gru.py
@@ -218,7 +218,6 @@ class GRU(Model):
         self,
         dataset: DatasetH,
         evals_result=dict(),
-        verbose=True,
         save_path=None,
     ):
 

--- a/qlib/contrib/model/pytorch_gru.py
+++ b/qlib/contrib/model/pytorch_gru.py
@@ -23,6 +23,7 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 
+from .pytorch_utils import count_parameters
 from ...model.base import Model
 from ...data.dataset import DatasetH
 from ...data.dataset.handler import DataHandlerLP
@@ -76,7 +77,7 @@ class GRU(Model):
         self.early_stop = early_stop
         self.optimizer = optimizer.lower()
         self.loss = loss
-        self.device = torch.device("cuda:%d" % (GPU) if torch.cuda.is_available() else "cpu")
+        self.device = torch.device("cuda:%d" % (GPU) if torch.cuda.is_available() and GPU >= 0 else "cpu")
         self.use_gpu = torch.cuda.is_available()
         self.seed = seed
 
@@ -123,6 +124,9 @@ class GRU(Model):
             num_layers=self.num_layers,
             dropout=self.dropout,
         )
+        self.logger.info("model:\n{:}".format(self.gru_model))
+        self.logger.info("model size: {:.4f} MB".format(count_parameters(self.gru_model)))
+
         if optimizer.lower() == "adam":
             self.train_optimizer = optim.Adam(self.gru_model.parameters(), lr=self.lr)
         elif optimizer.lower() == "gd":

--- a/qlib/contrib/model/pytorch_gru_ts.py
+++ b/qlib/contrib/model/pytorch_gru_ts.py
@@ -205,7 +205,6 @@ class GRU(Model):
         self,
         dataset,
         evals_result=dict(),
-        verbose=True,
         save_path=None,
     ):
         dl_train = dataset.prepare("train", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)

--- a/qlib/contrib/model/pytorch_gru_ts.py
+++ b/qlib/contrib/model/pytorch_gru_ts.py
@@ -24,6 +24,7 @@ import torch.nn as nn
 import torch.optim as optim
 from torch.utils.data import DataLoader
 
+from .pytorch_utils import count_parameters
 from ...model.base import Model
 from ...data.dataset import DatasetH, TSDatasetH
 from ...data.dataset.handler import DataHandlerLP
@@ -78,7 +79,7 @@ class GRU(Model):
         self.early_stop = early_stop
         self.optimizer = optimizer.lower()
         self.loss = loss
-        self.device = torch.device("cuda:%d" % (GPU) if torch.cuda.is_available() else "cpu")
+        self.device = torch.device("cuda:%d" % (GPU) if torch.cuda.is_available() and GPU >= 0 else "cpu")
         self.n_jobs = n_jobs
         self.use_gpu = torch.cuda.is_available()
         self.seed = seed
@@ -127,7 +128,10 @@ class GRU(Model):
             hidden_size=self.hidden_size,
             num_layers=self.num_layers,
             dropout=self.dropout,
-        ).to(self.device)
+        )
+        self.logger.info("model:\n{:}".format(self.gru_model))
+        self.logger.info("model size: {:.4f} MB".format(count_parameters(self.gru_model)))
+
         if optimizer.lower() == "adam":
             self.train_optimizer = optim.Adam(self.GRU_model.parameters(), lr=self.lr)
         elif optimizer.lower() == "gd":

--- a/qlib/contrib/model/pytorch_lstm.py
+++ b/qlib/contrib/model/pytorch_lstm.py
@@ -214,7 +214,6 @@ class LSTM(Model):
         self,
         dataset: DatasetH,
         evals_result=dict(),
-        verbose=True,
         save_path=None,
     ):
 

--- a/qlib/contrib/model/pytorch_lstm.py
+++ b/qlib/contrib/model/pytorch_lstm.py
@@ -76,7 +76,7 @@ class LSTM(Model):
         self.early_stop = early_stop
         self.optimizer = optimizer.lower()
         self.loss = loss
-        self.device = torch.device("cuda:%d" % (GPU) if torch.cuda.is_available() else "cpu")
+        self.device = torch.device("cuda:%d" % (GPU) if torch.cuda.is_available() and GPU >= 0 else "cpu")
         self.use_gpu = torch.cuda.is_available()
         self.seed = seed
 

--- a/qlib/contrib/model/pytorch_lstm_ts.py
+++ b/qlib/contrib/model/pytorch_lstm_ts.py
@@ -201,7 +201,6 @@ class LSTM(Model):
         self,
         dataset,
         evals_result=dict(),
-        verbose=True,
         save_path=None,
     ):
         dl_train = dataset.prepare("train", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)

--- a/qlib/contrib/model/pytorch_lstm_ts.py
+++ b/qlib/contrib/model/pytorch_lstm_ts.py
@@ -78,7 +78,7 @@ class LSTM(Model):
         self.early_stop = early_stop
         self.optimizer = optimizer.lower()
         self.loss = loss
-        self.device = torch.device("cuda:%d" % (GPU) if torch.cuda.is_available() else "cpu")
+        self.device = torch.device("cuda:%d" % (GPU) if torch.cuda.is_available() and GPU >= 0 else "cpu")
         self.n_jobs = n_jobs
         self.use_gpu = torch.cuda.is_available()
         self.seed = seed

--- a/qlib/contrib/model/pytorch_nn.py
+++ b/qlib/contrib/model/pytorch_nn.py
@@ -15,6 +15,7 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 
+from .pytorch_utils import count_parameters
 from ...model.base import Model
 from ...data.dataset import DatasetH
 from ...data.dataset.handler import DataHandlerLP
@@ -129,6 +130,9 @@ class DNNModelPytorch(Model):
         self._scorer = mean_squared_error if loss == "mse" else roc_auc_score
 
         self.dnn_model = Net(input_dim, output_dim, layers, loss=self.loss_type)
+        self.logger.info("model:\n{:}".format(self.dnn_model))
+        self.logger.info("model size: {:.4f} MB".format(count_parameters(self.dnn_model)))
+
         if optimizer.lower() == "adam":
             self.train_optimizer = optim.Adam(self.dnn_model.parameters(), lr=self.lr, weight_decay=self.weight_decay)
         elif optimizer.lower() == "gd":

--- a/qlib/contrib/model/pytorch_nn.py
+++ b/qlib/contrib/model/pytorch_nn.py
@@ -42,8 +42,8 @@ class DNNModelPytorch(Model):
         learning rate decay steps
     optimizer : str
         optimizer name
-    GPU : str
-        the GPU ID(s) used for training
+    GPU : int
+        the GPU ID used for training
     """
 
     def __init__(
@@ -80,7 +80,7 @@ class DNNModelPytorch(Model):
         self.lr_decay_steps = lr_decay_steps
         self.optimizer = optimizer.lower()
         self.loss_type = loss
-        self.device = torch.device("cuda:%d" % (GPU) if torch.cuda.is_available() else "cpu")
+        self.device = torch.device("cuda:%d" % (GPU) if torch.cuda.is_available() and GPU >= 0 else "cpu")
         self.use_GPU = torch.cuda.is_available()
         self.seed = seed
         self.weight_decay = weight_decay

--- a/qlib/contrib/model/pytorch_sfm.py
+++ b/qlib/contrib/model/pytorch_sfm.py
@@ -369,7 +369,6 @@ class SFM(Model):
         self,
         dataset: DatasetH,
         evals_result=dict(),
-        verbose=True,
         save_path=None,
     ):
 

--- a/qlib/contrib/model/pytorch_sfm.py
+++ b/qlib/contrib/model/pytorch_sfm.py
@@ -23,6 +23,7 @@ import torch.nn as nn
 import torch.nn.init as init
 import torch.optim as optim
 
+from .pytorch_utils import count_parameters
 from ...model.base import Model
 from ...data.dataset import DatasetH
 from ...data.dataset.handler import DataHandlerLP
@@ -196,8 +197,8 @@ class SFM(Model):
         learning rate
     optimizer : str
         optimizer name
-    GPU : str
-        the GPU ID(s) used for training
+    GPU : int
+        the GPU ID used for training
     """
 
     def __init__(
@@ -216,7 +217,7 @@ class SFM(Model):
         eval_steps=5,
         loss="mse",
         optimizer="gd",
-        GPU="0",
+        GPU=0,
         seed=None,
         **kwargs
     ):
@@ -239,7 +240,7 @@ class SFM(Model):
         self.eval_steps = eval_steps
         self.optimizer = optimizer.lower()
         self.loss = loss
-        self.device = torch.device("cuda:%d" % (GPU) if torch.cuda.is_available() else "cpu")
+        self.device = torch.device("cuda:%d" % (GPU) if torch.cuda.is_available() and GPU >= 0 else "cpu")
         self.use_gpu = torch.cuda.is_available()
         self.seed = seed
 
@@ -295,6 +296,9 @@ class SFM(Model):
             dropout_U=self.dropout_U,
             device=self.device,
         )
+        self.logger.info("model:\n{:}".format(self.sfm_model))
+        self.logger.info("model size: {:.4f} MB".format(count_parameters(self.sfm_model)))
+
         if optimizer.lower() == "adam":
             self.train_optimizer = optim.Adam(self.sfm_model.parameters(), lr=self.lr)
         elif optimizer.lower() == "gd":

--- a/qlib/contrib/model/pytorch_tabnet.py
+++ b/qlib/contrib/model/pytorch_tabnet.py
@@ -162,7 +162,6 @@ class TabnetModel(Model):
         self,
         dataset: DatasetH,
         evals_result=dict(),
-        verbose=True,
         save_path=None,
     ):
         if self.pretrain:

--- a/qlib/contrib/model/pytorch_tabnet.py
+++ b/qlib/contrib/model/pytorch_tabnet.py
@@ -23,6 +23,7 @@ import torch.optim as optim
 import torch.nn.functional as F
 from torch.autograd import Function
 
+from .pytorch_utils import count_parameters
 from ...model.base import Model
 from ...data.dataset import DatasetH
 from ...data.dataset.handler import DataHandlerLP
@@ -49,7 +50,7 @@ class TabnetModel(Model):
         loss="mse",
         metric="",
         early_stop=20,
-        GPU="1",
+        GPU=0,
         pretrain_loss="custom",
         ps=0.3,
         lr=0.01,
@@ -75,7 +76,7 @@ class TabnetModel(Model):
         self.n_epochs = n_epochs
         self.logger = get_module_logger("TabNet")
         self.pretrain_n_epochs = pretrain_n_epochs
-        self.device = "cuda:%s" % (GPU) if torch.cuda.is_available() else "cpu"
+        self.device = "cuda:%s" % (GPU) if torch.cuda.is_available() and GPU >= 0 else "cpu"
         self.loss = loss
         self.metric = metric
         self.early_stop = early_stop
@@ -98,6 +99,8 @@ class TabnetModel(Model):
         self.tabnet_decoder = TabNet_Decoder(self.out_dim, self.d_feat, n_shared, n_ind, vbs, n_steps, self.device).to(
             self.device
         )
+        self.logger.info("model:\n{:}\n{:}".format(self.tabnet_model, self.tabnet_decoder))
+        self.logger.info("model size: {:.4f} MB".format(count_parameters(self.tabnet_model) + count_parameters(self.tabnet_decoder)))
 
         if optimizer.lower() == "adam":
             self.pretrain_optimizer = optim.Adam(

--- a/qlib/contrib/model/pytorch_tabnet.py
+++ b/qlib/contrib/model/pytorch_tabnet.py
@@ -100,7 +100,9 @@ class TabnetModel(Model):
             self.device
         )
         self.logger.info("model:\n{:}\n{:}".format(self.tabnet_model, self.tabnet_decoder))
-        self.logger.info("model size: {:.4f} MB".format(count_parameters(self.tabnet_model) + count_parameters(self.tabnet_decoder)))
+        self.logger.info(
+            "model size: {:.4f} MB".format(count_parameters(self.tabnet_model) + count_parameters(self.tabnet_decoder))
+        )
 
         if optimizer.lower() == "adam":
             self.pretrain_optimizer = optim.Adam(

--- a/qlib/contrib/model/pytorch_tabnet.py
+++ b/qlib/contrib/model/pytorch_tabnet.py
@@ -100,9 +100,7 @@ class TabnetModel(Model):
             self.device
         )
         self.logger.info("model:\n{:}\n{:}".format(self.tabnet_model, self.tabnet_decoder))
-        self.logger.info(
-            "model size: {:.4f} MB".format(count_parameters(self.tabnet_model) + count_parameters(self.tabnet_decoder))
-        )
+        self.logger.info("model size: {:.4f} MB".format(count_parameters([self.tabnet_model, self.tabnet_decoder])))
 
         if optimizer.lower() == "adam":
             self.pretrain_optimizer = optim.Adam(

--- a/qlib/contrib/model/pytorch_utils.py
+++ b/qlib/contrib/model/pytorch_utils.py
@@ -4,7 +4,19 @@
 import torch.nn as nn
 
 
-def count_parameters(models_or_parameters, unit="mb"):
+def count_parameters(models_or_parameters, unit="m"):
+    """
+    This function is to obtain the storage size unit of a (or multiple) models.
+
+    Parameters
+    ----------
+    models_or_parameters : PyTorch model(s) or a list of parameters.
+    unit : the storage size unit.
+
+    Returns
+    -------
+    The number of parameters of the given model(s) or parameters.
+    """
     if isinstance(models_or_parameters, nn.Module):
         counts = sum(v.numel() for v in models_or_parameters.parameters())
     elif isinstance(models_or_parameters, nn.Parameter):
@@ -13,12 +25,13 @@ def count_parameters(models_or_parameters, unit="mb"):
         return sum(count_parameters(x, unit) for x in models_or_parameters)
     else:
         counts = sum(v.numel() for v in models_or_parameters)
-    if unit.lower() == "mb":
-        counts /= 1e6
-    elif unit.lower() == "kb":
-        counts /= 1e3
-    elif unit.lower() == "gb":
-        counts /= 1e9
+    unit = unit.lower()
+    if unit == "kb" or unit == "k":
+        counts /= 2 ** 10
+    elif unit == "mb" or unit == "m":
+        counts /= 2 ** 20
+    elif unit == "gb" or unit == "g":
+        counts /= 2 ** 30
     elif unit is not None:
         raise ValueError("Unknow unit: {:}".format(unit))
     return counts

--- a/qlib/contrib/model/pytorch_utils.py
+++ b/qlib/contrib/model/pytorch_utils.py
@@ -1,15 +1,18 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-import numpy as np
 import torch.nn as nn
 
 
-def count_parameters(model_or_parameters, unit="mb"):
-    if isinstance(model_or_parameters, nn.Module):
-        counts = np.sum(np.prod(v.size()) for v in model_or_parameters.parameters())
+def count_parameters(models_or_parameters, unit="mb"):
+    if isinstance(models_or_parameters, nn.Module):
+        counts = sum(v.numel() for v in models_or_parameters.parameters())
+    elif isinstance(models_or_parameters, nn.Parameter):
+        counts = models_or_parameters.numel()
+    elif isinstance(models_or_parameters, (list, tuple)):
+        return sum(count_parameters(x, unit) for x in model_or_parameters)
     else:
-        counts = np.sum(np.prod(v.size()) for v in model_or_parameters)
+        counts = sum(v.numel() for v in models_or_parameters)
     if unit.lower() == "mb":
         counts /= 1e6
     elif unit.lower() == "kb":

--- a/qlib/contrib/model/pytorch_utils.py
+++ b/qlib/contrib/model/pytorch_utils.py
@@ -1,0 +1,21 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import numpy as np
+import torch.nn as nn
+
+
+def count_parameters(model_or_parameters, unit="mb"):
+    if isinstance(model_or_parameters, nn.Module):
+        counts = np.sum(np.prod(v.size()) for v in model_or_parameters.parameters())
+    else:
+        counts = np.sum(np.prod(v.size()) for v in model_or_parameters)
+    if unit.lower() == "mb":
+        counts /= 1e6
+    elif unit.lower() == "kb":
+        counts /= 1e3
+    elif unit.lower() == "gb":
+        counts /= 1e9
+    elif unit is not None:
+        raise ValueError("Unknow unit: {:}".format(unit))
+    return counts

--- a/qlib/contrib/model/pytorch_utils.py
+++ b/qlib/contrib/model/pytorch_utils.py
@@ -3,6 +3,7 @@
 
 import torch.nn as nn
 
+
 def count_parameters(models_or_parameters, unit="mb"):
     if isinstance(models_or_parameters, nn.Module):
         counts = sum(v.numel() for v in models_or_parameters.parameters())

--- a/qlib/contrib/model/pytorch_utils.py
+++ b/qlib/contrib/model/pytorch_utils.py
@@ -3,14 +3,13 @@
 
 import torch.nn as nn
 
-
 def count_parameters(models_or_parameters, unit="mb"):
     if isinstance(models_or_parameters, nn.Module):
         counts = sum(v.numel() for v in models_or_parameters.parameters())
     elif isinstance(models_or_parameters, nn.Parameter):
         counts = models_or_parameters.numel()
     elif isinstance(models_or_parameters, (list, tuple)):
-        return sum(count_parameters(x, unit) for x in model_or_parameters)
+        return sum(count_parameters(x, unit) for x in models_or_parameters)
     else:
         counts = sum(v.numel() for v in models_or_parameters)
     if unit.lower() == "mb":

--- a/qlib/contrib/online/operator.py
+++ b/qlib/contrib/online/operator.py
@@ -148,7 +148,7 @@ class Operator:
         for user_id, user in um.users.items():
             dates, trade_exchange = prepare(um, trade_date, user_id, exchange_config)
             executor = SimulatorExecutor(trade_exchange=trade_exchange)
-            if not str(dates[0].date()) == str(pred_date.date()):
+            if str(dates[0].date()) != str(pred_date.date()):
                 raise ValueError(
                     "The account data is not newest! last trading date {}, today {}".format(
                         dates[0].date(), trade_date.date()

--- a/qlib/log.py
+++ b/qlib/log.py
@@ -3,8 +3,7 @@
 
 
 import logging
-import logging.handlers
-import os
+from typing import Optional, Text, Dict, Any
 import re
 from logging import config as logging_config
 from time import time
@@ -13,16 +12,13 @@ from contextlib import contextmanager
 from .config import C
 
 
-def get_module_logger(module_name, level=None):
+def get_module_logger(module_name, level: Optional[int] = None):
     """
     Get a logger for a specific module.
 
     :param module_name: str
         Logic module name.
     :param level: int
-    :param sh_level: int
-        Stream handler log level.
-    :param log_format: str
     :return: Logger
         Logger object.
     """
@@ -103,13 +99,34 @@ class TimeInspector:
         cls.log_cost_time(info=f"{name} Done")
 
 
-def set_log_with_config(log_config: dict):
+def set_log_with_config(log_config: Dict[Text, Any]):
     """set log with config
 
     :param log_config:
     :return:
     """
     logging_config.dictConfig(log_config)
+
+
+def set_log_basic_config(filename: Optional[Text] = None, format: Optional[Text] = None, level: Optional[int] = None):
+    """
+    Set the basic configuration for the logging system.
+    See details at https://docs.python.org/3/library/logging.html#logging.basicConfig
+
+    :param filename: str or None
+        The path to save the logs.
+    :param format: the logging format
+    :param level: int
+    :return: Logger
+        Logger object.
+    """
+    if level is None:
+        level = C.logging_level
+
+    if format is None:
+        format = C.logging_config["formatters"]["logger_format"]["format"]
+
+    logging.basicConfig(filename=filename, format=format, level=level)
 
 
 class LogFilter(logging.Filter):

--- a/qlib/log.py
+++ b/qlib/log.py
@@ -108,27 +108,6 @@ def set_log_with_config(log_config: Dict[Text, Any]):
     logging_config.dictConfig(log_config)
 
 
-def set_log_basic_config(filename: Optional[Text] = None, format: Optional[Text] = None, level: Optional[int] = None):
-    """
-    Set the basic configuration for the logging system.
-    See details at https://docs.python.org/3/library/logging.html#logging.basicConfig
-
-    :param filename: str or None
-        The path to save the logs.
-    :param format: the logging format
-    :param level: int
-    :return: Logger
-        Logger object.
-    """
-    if level is None:
-        level = C.logging_level
-
-    if format is None:
-        format = C.logging_config["formatters"]["logger_format"]["format"]
-
-    logging.basicConfig(filename=filename, format=format, level=level)
-
-
 class LogFilter(logging.Filter):
     def __init__(self, param=None):
         self.param = param

--- a/qlib/workflow/__init__.py
+++ b/qlib/workflow/__init__.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 from contextlib import contextmanager
+from typing import Text, Optional
 from .expm import MLflowExpManager
 from .exp import Experiment
 from .recorder import Recorder
@@ -20,7 +21,9 @@ class QlibRecorder:
         return "{name}(manager={manager})".format(name=self.__class__.__name__, manager=self.exp_manager)
 
     @contextmanager
-    def start(self, experiment_name=None, recorder_name=None, uri=None):
+    def start(
+        self, experiment_name: Optional[Text] = None, recorder_name: Optional[Text] = None, uri: Optional[Text] = None
+    ):
         """
         Method to start an experiment. This method can only be called within a Python's `with` statement. Here is the example code:
 
@@ -281,6 +284,12 @@ class QlibRecorder:
         The uri of current experiment manager.
         """
         return self.exp_manager.uri
+
+    def reset_default_uri(self, uri: Text):
+        """
+        Method to reset the default uri of current experiment manager.
+        """
+        self.exp_manager.reset_default_uri(uri)
 
     def get_recorder(self, recorder_id=None, recorder_name=None, experiment_name=None):
         """

--- a/qlib/workflow/__init__.py
+++ b/qlib/workflow/__init__.py
@@ -285,11 +285,11 @@ class QlibRecorder:
         """
         return self.exp_manager.uri
 
-    def reset_default_uri(self, uri: Text):
+    def set_uri(self, uri: Optional[Text]):
         """
-        Method to reset the default uri of current experiment manager.
+        Method to reset the current uri of current experiment manager.
         """
-        self.exp_manager.reset_default_uri(uri)
+        self.exp_manager.set_uri(uri)
 
     def get_recorder(self, recorder_id=None, recorder_name=None, experiment_name=None):
         """

--- a/qlib/workflow/cli.py
+++ b/qlib/workflow/cli.py
@@ -16,7 +16,7 @@ def get_path_list(path):
     if isinstance(path, str):
         return [path]
     else:
-        return [p for p in path]
+        return list(path)
 
 
 def sys_config(config, config_path):

--- a/qlib/workflow/exp.py
+++ b/qlib/workflow/exp.py
@@ -23,7 +23,7 @@ class Experiment:
         self.active_recorder = None  # only one recorder can running each time
 
     def __repr__(self):
-        return "{name}(info={info})".format(name=self.__class__.__name__, info=self.info)
+        return "{name}(id={id}, info={info})".format(name=self.__class__.__name__, id=self.id, info=self.info)
 
     def __str__(self):
         return str(self.info)
@@ -174,6 +174,9 @@ class MLflowExperiment(Experiment):
         self._default_name = None
         self._default_rec_name = "mlflow_recorder"
         self._client = mlflow.tracking.MlflowClient(tracking_uri=self._uri)
+
+    def __repr__(self):
+        return "{name}(id={id}, info={info})".format(name=self.__class__.__name__, id=self.id, info=self.info)
 
     def start(self, recorder_name=None):
         logger.info(f"Experiment {self.id} starts running ...")

--- a/qlib/workflow/expm.py
+++ b/qlib/workflow/expm.py
@@ -33,6 +33,10 @@ class ExpManager:
             name=self.__class__.__name__, duri=self._default_uri, curi=self._current_uri
         )
 
+    def reset_default_uri(self, uri: Text):
+        self._default_uri = uri
+        self.set_uri(None)
+
     def start_exp(
         self,
         experiment_name: Optional[Text] = None,

--- a/qlib/workflow/expm.py
+++ b/qlib/workflow/expm.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager
 from typing import Optional, Text
 
 from .exp import MLflowExperiment, Experiment
+from ..config import C
 from .recorder import Recorder
 from ..log import get_module_logger
 
@@ -23,19 +24,12 @@ class ExpManager:
     """
 
     def __init__(self, uri: Text, default_exp_name: Optional[Text]):
-        self._default_uri = uri
-        self._current_uri = None
+        self._current_uri = uri
         self.default_exp_name = default_exp_name
         self.active_experiment = None  # only one experiment can active each time
 
     def __repr__(self):
-        return "{name}(default_uri={duri}, current_uri={curi})".format(
-            name=self.__class__.__name__, duri=self._default_uri, curi=self._current_uri
-        )
-
-    def reset_default_uri(self, uri: Text):
-        self._default_uri = uri
-        self.set_uri(None)
+        return "{name}(current_uri={curi})".format(name=self.__class__.__name__, curi=self._current_uri)
 
     def start_exp(
         self,
@@ -222,6 +216,15 @@ class ExpManager:
         raise NotImplementedError(f"Please implement the `delete_exp` method.")
 
     @property
+    def default_uri(self):
+        """
+        Get the default tracking URI from qlib.config.C
+        """
+        if "kwargs" not in C.exp_manager or "uri" not in C.exp_manager["kwargs"]:
+            raise ValueError("The default URI is not set in qlib.config.C")
+        return C.exp_manager["kwargs"]["uri"]
+
+    @property
     def uri(self):
         """
         Get the default tracking URI or current URI.
@@ -230,7 +233,7 @@ class ExpManager:
         -------
         The tracking URI string.
         """
-        return self._current_uri or self._default_uri
+        return self._current_uri or self.default_uri
 
     def set_uri(self, uri: Optional[Text] = None):
         """
@@ -243,7 +246,7 @@ class ExpManager:
         """
         if uri is None:
             logger.info("No tracking URI is provided. Use the default tracking URI.")
-            self._current_uri = self._default_uri
+            self._current_uri = self.default_uri
         else:
             # Temporarily re-set the current uri as the uri argument.
             self._current_uri = uri

--- a/qlib/workflow/recorder.py
+++ b/qlib/workflow/recorder.py
@@ -11,7 +11,7 @@ from ..log import get_module_logger
 logger = get_module_logger("workflow", "INFO")
 
 
-class Recorder(object):
+class Recorder:
     """
     This is the `Recorder` class for logging the experiments. The API is designed similar to mlflow.
     (The link: https://mlflow.org/docs/latest/python_api/mlflow.html)
@@ -201,7 +201,7 @@ class MLflowRecorder(Recorder):
     def __init__(self, experiment_id, uri, name=None, mlflow_run=None):
         super(MLflowRecorder, self).__init__(experiment_id, name)
         self._uri = uri
-        self.artifact_uri = None
+        self._artifact_uri = None
         self.client = mlflow.tracking.MlflowClient(tracking_uri=self._uri)
         # construct from mlflow run
         if mlflow_run is not None:
@@ -220,14 +220,45 @@ class MLflowRecorder(Recorder):
                 else None
             )
 
+    def __repr__(self):
+        name = self.__class__.__name__
+        space_length = len(name) + 1
+        return "{name}(info={info},\n{space}uri={uri},\n{space}artifact_uri={artifact_uri},\n{space}client={client})".format(
+            name=name,
+            space=" " * space_length,
+            info=self.info,
+            uri=self.uri,
+            artifact_uri=self.artifact_uri,
+            client=self.client,
+        )
+
+    @property
+    def uri(self):
+        return self._uri
+
+    @property
+    def artifact_uri(self):
+        return self._artifact_uri
+
+    @property
+    def root_uri(self):
+        start_str = "file:"
+        if self.artifact_uri is not None:
+            xpath = self.artifact_uri.strip(start_str)
+            return (Path(xpath) / "..").resolve()
+        else:
+            raise Exception(
+                "Please make sure the recorder has been created and started properly before getting artifact uri."
+            )
+
     def start_run(self):
         # set the tracking uri
-        mlflow.set_tracking_uri(self._uri)
+        mlflow.set_tracking_uri(self.uri)
         # start the run
         run = mlflow.start_run(self.id, self.experiment_id, self.name)
         # save the run id and artifact_uri
         self.id = run.info.run_id
-        self.artifact_uri = run.info.artifact_uri
+        self._artifact_uri = run.info.artifact_uri
         self.start_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         self.status = Recorder.STATUS_R
         logger.info(f"Recorder {self.id} starts running under Experiment {self.experiment_id} ...")
@@ -247,7 +278,7 @@ class MLflowRecorder(Recorder):
             self.status = status
 
     def save_objects(self, local_path=None, artifact_path=None, **kwargs):
-        assert self._uri is not None, "Please start the experiment and recorder first before using recorder directly."
+        assert self.uri is not None, "Please start the experiment and recorder first before using recorder directly."
         if local_path is not None:
             self.client.log_artifacts(self.id, local_path, artifact_path)
         else:
@@ -259,7 +290,7 @@ class MLflowRecorder(Recorder):
             shutil.rmtree(temp_dir)
 
     def load_object(self, name):
-        assert self._uri is not None, "Please start the experiment and recorder first before using recorder directly."
+        assert self.uri is not None, "Please start the experiment and recorder first before using recorder directly."
         path = self.client.download_artifacts(self.id, name)
         with Path(path).open("rb") as f:
             return pickle.load(f)
@@ -289,7 +320,7 @@ class MLflowRecorder(Recorder):
             )
 
     def list_artifacts(self, artifact_path=None):
-        assert self._uri is not None, "Please start the experiment and recorder first before using recorder directly."
+        assert self.uri is not None, "Please start the experiment and recorder first before using recorder directly."
         artifacts = self.client.list_artifacts(self.id, artifact_path)
         return [art.path for art in artifacts]
 

--- a/qlib/workflow/recorder.py
+++ b/qlib/workflow/recorder.py
@@ -240,12 +240,18 @@ class MLflowRecorder(Recorder):
     def artifact_uri(self):
         return self._artifact_uri
 
-    @property
-    def root_uri(self):
-        start_str = "file:"
+    def get_local_dir(self):
+        """
+        This function will return the directory path of this recorder.
+        """
         if self.artifact_uri is not None:
-            xpath = self.artifact_uri.strip(start_str)
-            return (Path(xpath) / "..").resolve()
+            local_file_prefix = "file:"
+            if self.artifact_uri.startswith(local_file_prefix):
+                xpath = self.artifact_uri.lstrip(local_file_prefix)
+                return (Path(xpath) / "..").resolve()
+            else:
+                raise RuntimeError("This recorder is not saved in the local file system.")
+
         else:
             raise Exception(
                 "Please make sure the recorder has been created and started properly before getting artifact uri."

--- a/qlib/workflow/recorder.py
+++ b/qlib/workflow/recorder.py
@@ -245,10 +245,10 @@ class MLflowRecorder(Recorder):
         This function will return the directory path of this recorder.
         """
         if self.artifact_uri is not None:
-            local_file_prefix = "file:"
-            if self.artifact_uri.startswith(local_file_prefix):
-                xpath = self.artifact_uri.lstrip(local_file_prefix)
-                return (Path(xpath) / "..").resolve()
+            local_dir_path = Path(self.artifact_uri.lstrip("file:")) / ".."
+            local_dir_path = str(local_dir_path.resolve())
+            if os.path.isdir(local_dir_path):
+                return local_dir_path
             else:
                 raise RuntimeError("This recorder is not saved in the local file system.")
 

--- a/tests/test_all_pipeline.py
+++ b/tests/test_all_pipeline.py
@@ -123,6 +123,8 @@ def train():
         recorder = R.get_recorder()
         # To test __repr__
         print(recorder)
+        # To test get_local_dir
+        print(recorder.get_local_dir())
         rid = recorder.id
         sr = SignalRecord(model, dataset, recorder)
         sr.generate()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Four changes:
- Fix /0 bug in double_ensemble
- simplify the logic of default_uri for R/expm
- support model size in pytorch models

## Description
- In double_ensemble models, it might potentially divide zero and raise an error.
- Currently, _default_uri for R maybe inconsistent with that in C.
- In pytorch-based contrib codes, there are some useless kwargs, such as verbose.
- In pytorch-based contrib codes, add a function to count the number of parameters.

## Motivation and Context
Make it more friendly for researchers.

## How Has This Been Tested?
- [x] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.

## Screenshots of Test Results (if appropriate):
I run `pytest -W ignore::DeprecationWarning qlib/tests/test_all_pipeline.py`, below is the screenshot:
![image](https://user-images.githubusercontent.com/9547057/110283073-72e44680-801a-11eb-9678-4f2968948e1e.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fix bugs
- [x] Add new feature
