### PR TITLE
Fix errors when SignalRecord is not called before SigAna/PortAna

### DIFF
--- a/qlib/contrib/workflow/record_temp.py
+++ b/qlib/contrib/workflow/record_temp.py
@@ -36,12 +36,13 @@ class SignalMseRecord(SignalRecord):
         mse = mean_squared_error(pred.values[masks], label[masks])
         metrics = {
             "MSE": mse,
+            "RMSE": np.sqrt(mse)
         }
-        objects = {"mse.pkl": mse}
+        objects = {"mse.pkl": mse, "rmse.pkl": np.sqrt(mse)}
         self.recorder.log_metrics(**metrics)
         self.recorder.save_objects(**objects, artifact_path=self.get_path())
         pprint(metrics)
 
     def list(self):
-        paths = [self.get_path("mse.pkl")]
+        paths = [self.get_path("mse.pkl"), self.get_path("rmse.pkl")]
         return paths

--- a/qlib/contrib/workflow/record_temp.py
+++ b/qlib/contrib/workflow/record_temp.py
@@ -1,0 +1,47 @@
+#  Copyright (c) Microsoft Corporation.
+#  Licensed under the MIT License.
+
+import re
+import pandas as pd
+from sklearn.metrics import mean_squared_error
+from pprint import pprint
+import numpy as np
+
+from ...workflow.record_temp import SignalRecord
+from ...log import get_module_logger
+
+logger = get_module_logger("workflow", "INFO")
+
+
+class SignalMseRecord(SignalRecord):
+    """
+    This is the Signal MSE Record class that computes the mean squared error (MSE).
+    This class inherits the ``SignalMseRecord`` class.
+    """
+
+    artifact_path = "sig_analysis"
+
+    def __init__(self, recorder, **kwargs):
+        super().__init__(recorder=recorder, **kwargs)
+
+    def generate(self, **kwargs):
+        try:
+            self.check(parent=True)
+        except FileExistsError:
+            super().generate()
+
+        pred = self.load("pred.pkl")
+        label = self.load("label.pkl")
+        masks = ~np.isnan(label.values)
+        mse = mean_squared_error(pred.values[masks], label[masks])
+        metrics = {
+            "MSE": mse,
+        }
+        objects = {"mse.pkl": mse}
+        self.recorder.log_metrics(**metrics)
+        self.recorder.save_objects(**objects, artifact_path=self.get_path())
+        pprint(metrics)
+
+    def list(self):
+        paths = [self.get_path("mse.pkl")]
+        return paths

--- a/qlib/contrib/workflow/record_temp.py
+++ b/qlib/contrib/workflow/record_temp.py
@@ -34,10 +34,7 @@ class SignalMseRecord(SignalRecord):
         label = self.load("label.pkl")
         masks = ~np.isnan(label.values)
         mse = mean_squared_error(pred.values[masks], label[masks])
-        metrics = {
-            "MSE": mse,
-            "RMSE": np.sqrt(mse)
-        }
+        metrics = {"MSE": mse, "RMSE": np.sqrt(mse)}
         objects = {"mse.pkl": mse, "rmse.pkl": np.sqrt(mse)}
         self.recorder.log_metrics(**metrics)
         self.recorder.save_objects(**objects, artifact_path=self.get_path())

--- a/qlib/workflow/record_temp.py
+++ b/qlib/workflow/record_temp.py
@@ -110,7 +110,7 @@ class SignalRecord(RecordTemp):
     This is the Signal Record class that generates the signal prediction. This class inherits the ``RecordTemp`` class.
     """
 
-    def __init__(self, model=None, dataset=None, recorder=None, **kwargs):
+    def __init__(self, model=None, dataset=None, recorder=None):
         super().__init__(recorder=recorder)
         self.model = model
         self.dataset = dataset
@@ -163,14 +163,16 @@ class SigAnaRecord(SignalRecord):
 
     artifact_path = "sig_analysis"
 
-    def __init__(self, recorder, ana_long_short=False, ann_scaler=252, **kwargs):
+    def __init__(self, recorder, ana_long_short=False, ann_scaler=252):
+        super().__init__(recorder=recorder)
         self.ana_long_short = ana_long_short
         self.ann_scaler = ann_scaler
-        super().__init__(recorder=recorder, **kwargs)
-        # The name must be unique. Otherwise it will be overridden
 
-    def generate(self):
-        self.check(parent=True)
+    def generate(self, **kwargs):
+        try:
+            self.check(parent=True)
+        except:
+            super().generate()
 
         pred = self.load("pred.pkl")
         label = self.load("label.pkl")
@@ -228,7 +230,7 @@ class PortAnaRecord(SignalRecord):
         config["backtest"] : dict
             define the backtest kwargs.
         """
-        super().__init__(recorder=recorder)
+        super().__init__(recorder=recorder, **kwargs)
 
         self.strategy_config = config["strategy"]
         self.backtest_config = config["backtest"]
@@ -236,10 +238,13 @@ class PortAnaRecord(SignalRecord):
 
     def generate(self, **kwargs):
         # check previously stored prediction results
-        self.check(parent=True)  # "Make sure the parent process is completed and store the data properly."
+        try:
+            self.check(parent=True)  # "Make sure the parent process is completed and store the data properly."
+        except:
+            super().generate()
 
         # custom strategy and get backtest
-        pred_score = super().load()
+        pred_score = super().load("pred.pkl")
         report_dict = normal_backtest(pred_score, strategy=self.strategy, **self.backtest_config)
         report_normal = report_dict.get("report_df")
         positions_normal = report_dict.get("positions")

--- a/qlib/workflow/record_temp.py
+++ b/qlib/workflow/record_temp.py
@@ -163,8 +163,8 @@ class SigAnaRecord(SignalRecord):
 
     artifact_path = "sig_analysis"
 
-    def __init__(self, recorder, ana_long_short=False, ann_scaler=252):
-        super().__init__(recorder=recorder)
+    def __init__(self, recorder, ana_long_short=False, ann_scaler=252, **kwargs):
+        super().__init__(recorder=recorder, **kwargs)
         self.ana_long_short = ana_long_short
         self.ann_scaler = ann_scaler
 

--- a/qlib/workflow/record_temp.py
+++ b/qlib/workflow/record_temp.py
@@ -171,7 +171,7 @@ class SigAnaRecord(SignalRecord):
     def generate(self, **kwargs):
         try:
             self.check(parent=True)
-        except:
+        except FileExistsError:
             super().generate()
 
         pred = self.load("pred.pkl")
@@ -240,7 +240,7 @@ class PortAnaRecord(SignalRecord):
         # check previously stored prediction results
         try:
             self.check(parent=True)  # "Make sure the parent process is completed and store the data properly."
-        except:
+        except FileExistsError:
             super().generate()
 
         # custom strategy and get backtest

--- a/tests/test_all_pipeline.py
+++ b/tests/test_all_pipeline.py
@@ -163,6 +163,7 @@ def train_with_sigana():
         sar.generate()
         ic = sar.load(sar.get_path("ic.pkl"))
         ric = sar.load(sar.get_path("ric.pkl"))
+        pred_score = sar.load("pred.pkl")
         uri_path = R.get_uri()
     return pred_score, {"ic": ic, "ric": ric}, uri_path
 

--- a/tests/test_all_pipeline.py
+++ b/tests/test_all_pipeline.py
@@ -19,6 +19,7 @@ from qlib.contrib.evaluate import (
     backtest as normal_backtest,
     risk_analysis,
 )
+from qlib.contrib.workflow.record_temp import SignalMseRecord
 from qlib.utils import exists_qlib_data, init_instance_by_config, flatten_dict
 from qlib.workflow import R
 from qlib.workflow.record_temp import SignalRecord, SigAnaRecord, PortAnaRecord
@@ -164,6 +165,9 @@ def train_with_sigana():
         ic = sar.load(sar.get_path("ic.pkl"))
         ric = sar.load(sar.get_path("ric.pkl"))
         pred_score = sar.load("pred.pkl")
+
+        smr = SignalMseRecord(recorder)
+        smr.generate()
         uri_path = R.get_uri()
     return pred_score, {"ic": ic, "ric": ric}, uri_path
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix errors when SignalRecord is not called before SigAna/PortAna and add unit tests.

## Motivation and Context
- If SignalRecord's generate function is not called before SigAna/PortAna's generate, it will raise an error.
- Add a unit test for it.
- Add SignalMseRecord to compute the MSE metric.

## How Has This Been Tested?
- [x] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.

## Screenshots of Test Results (if appropriate):
![image](https://user-images.githubusercontent.com/9547057/111278934-19f95b80-8675-11eb-81e7-e9fc06c60011.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fix bugs
- [x] Add features