### PR TITLE
Modify get_exp & get_recorder api

### DIFF
--- a/qlib/workflow/__init__.py
+++ b/qlib/workflow/__init__.py
@@ -202,13 +202,13 @@ class QlibRecorder:
 
                 - no id or name specified, return the active experiment.
 
-                - if id or name is specified, return the specified experiment. If no such exp found, create a new experiment with given id or name, and the experiment is set to be active.
+                - if id or name is specified, return the specified experiment. If no such exp found, create a new experiment with given id or name.
 
             - If `active experiment` not exists:
 
                 - no id or name specified, create a default experiment, and the experiment is set to be active.
 
-                - if id or name is specified, return the specified experiment. If no such exp found, create a new experiment with given name or the default experiment, and the experiment is set to be active.
+                - if id or name is specified, return the specified experiment. If no such exp found, create a new experiment with given name or the default experiment.
 
         - Else If '`create`' is False:
 
@@ -260,7 +260,7 @@ class QlibRecorder:
         -------
         An experiment instance with given id or name.
         """
-        return self.exp_manager.get_exp(experiment_id, experiment_name, create)
+        return self.exp_manager.get_exp(experiment_id, experiment_name, create, start=False)
 
     def delete_exp(self, experiment_id=None, experiment_name=None):
         """
@@ -358,7 +358,7 @@ class QlibRecorder:
         A recorder instance.
         """
         return self.get_exp(experiment_name=experiment_name, create=False).get_recorder(
-            recorder_id, recorder_name, create=False
+            recorder_id, recorder_name, create=False, start=False
         )
 
     def delete_recorder(self, recorder_id=None, recorder_name=None):

--- a/qlib/workflow/exp.py
+++ b/qlib/workflow/exp.py
@@ -107,24 +107,24 @@ class Experiment:
         """
         raise NotImplementedError(f"Please implement the `delete_recorder` method.")
 
-    def get_recorder(self, recorder_id=None, recorder_name=None, create: bool = True):
+    def get_recorder(self, recorder_id=None, recorder_name=None, create: bool = True, start: bool = False):
         """
         Retrieve a Recorder for user. When user specify recorder id and name, the method will try to return the
         specific recorder. When user does not provide recorder id or name, the method will try to return the current
         active recorder. The `create` argument determines whether the method will automatically create a new recorder
-        according to user's specification if the recorder hasn't been created before
+        according to user's specification if the recorder hasn't been created before.
 
         * If `create` is True:
 
             * If `active recorder` exists:
 
                 * no id or name specified, return the active recorder.
-                * if id or name is specified, return the specified recorder. If no such exp found, create a new recorder with given id or name, and the recorder shoud be active.
+                * if id or name is specified, return the specified recorder. If no such exp found, create a new recorder with given id or name. If `start` is set to be True, the recorder is set to be active.
 
             * If `active recorder` not exists:
 
                 * no id or name specified, create a new recorder.
-                * if id or name is specified, return the specified experiment. If no such exp found, create a new recorder with given id or name, and the recorder shoud be active.
+                * if id or name is specified, return the specified experiment. If no such exp found, create a new recorder with given id or name. If `start` is set to be True, the recorder is set to be active.
 
         * Else If `create` is False:
 
@@ -146,6 +146,8 @@ class Experiment:
             the name of the recorder to be deleted.
         create : boolean
             create the recorder if it hasn't been created before.
+        start : boolean
+            start the new recorder if one is created.
 
         Returns
         -------
@@ -163,7 +165,7 @@ class Experiment:
                 self._get_recorder(recorder_id=recorder_id, recorder_name=recorder_name),
                 False,
             )
-        if is_new:
+        if is_new and start:
             self.active_recorder = recorder
             # start the recorder
             self.active_recorder.start_run()

--- a/qlib/workflow/expm.py
+++ b/qlib/workflow/expm.py
@@ -102,10 +102,9 @@ class ExpManager:
         """
         raise NotImplementedError(f"Please implement the `search_records` method.")
 
-    def get_exp(self, experiment_id=None, experiment_name=None, create: bool = True):
+    def get_exp(self, experiment_id=None, experiment_name=None, create: bool = True, start: bool = False):
         """
         Retrieve an experiment. This method includes getting an active experiment, and get_or_create a specific experiment.
-        The returned experiment will be active.
 
         When user specify experiment id and name, the method will try to return the specific experiment.
         When user does not provide recorder id or name, the method will try to return the current active experiment.
@@ -117,12 +116,12 @@ class ExpManager:
             * If `active experiment` exists:
 
                 * no id or name specified, return the active experiment.
-                * if id or name is specified, return the specified experiment. If no such exp found, create a new experiment with given id or name, and the experiment is set to be active.
+                * if id or name is specified, return the specified experiment. If no such exp found, create a new experiment with given id or name. If `start` is set to be True, the experiment is set to be active.
 
             * If `active experiment` not exists:
 
                 * no id or name specified, create a default experiment.
-                * if id or name is specified, return the specified experiment. If no such exp found, create a new experiment with given id or name, and the experiment is set to be active.
+                * if id or name is specified, return the specified experiment. If no such exp found, create a new experiment with given id or name. If `start` is set to be True, the experiment is set to be active.
 
         * Else If `create` is False:
 
@@ -144,6 +143,8 @@ class ExpManager:
             name of the experiment to return.
         create : boolean
             create the experiment it if hasn't been created before.
+        start : boolean
+            start the new experiment if one is created.
 
         Returns
         -------
@@ -163,7 +164,7 @@ class ExpManager:
                 self._get_exp(experiment_id=experiment_id, experiment_name=experiment_name),
                 False,
             )
-        if is_new:
+        if is_new and start:
             self.active_experiment = exp
             # start the recorder
             self.active_experiment.start()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change the API for `ExpManager` and `Experiment`.

I keep the related API under `R` the same to avoid too much complex logics being exposed to users. If uses want to get a running recorder to experiment without starting them, they should be aware about the design of Qlib and calls a lower level API.

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
