### PR TITLE
Update qlib logger

### DIFF
--- a/qlib/contrib/workflow/record_temp.py
+++ b/qlib/contrib/workflow/record_temp.py
@@ -1,10 +1,11 @@
 #  Copyright (c) Microsoft Corporation.
 #  Licensed under the MIT License.
 
+import logging
 import pandas as pd
+import numpy as np
 from sklearn.metrics import mean_squared_error
 from typing import Dict, Text, Any
-import numpy as np
 
 from ...contrib.eva.alpha import calc_ic
 from ...workflow.record_temp import RecordTemp
@@ -12,7 +13,7 @@ from ...workflow.record_temp import SignalRecord
 from ...data import dataset as qlib_dataset
 from ...log import get_module_logger
 
-logger = get_module_logger("workflow", "INFO")
+logger = get_module_logger("workflow", logging.INFO)
 
 
 class MultiSegRecord(RecordTemp):

--- a/qlib/log.py
+++ b/qlib/log.py
@@ -17,9 +17,9 @@ class MetaLogger(type):
         super().__init__(name, bases, dic)
 
     def __new__(cls, name, bases, dict):
-        wrapper_dict = type(logging.getLogger("module_name")).__dict__.copy()
+        wrapper_dict = type(logging.getLogger("MetaLogger")).__dict__.copy()
         wrapper_dict.update(dict)
-        wrapper_dict["__doc__"] = logging.getLogger("module_name").__doc__
+        wrapper_dict["__doc__"] = logging.getLogger("MetaLogger").__doc__
         return type.__new__(cls, name, bases, wrapper_dict)
 
     def __call__(cls, *args, **kwargs):

--- a/qlib/log.py
+++ b/qlib/log.py
@@ -11,6 +11,26 @@ from contextlib import contextmanager
 
 from .config import C
 
+class QlibLogger(Logger，meta=):
+    '''
+    Customized logger for Qlib.
+    '''
+    def __init__(self, module_name):
+        self.module_name = module_name
+        self.level = 0
+
+    @property
+    def logger(self):
+        logger = logging.getLogger(self.module_name)
+        logger.setLevel(self.level)
+        return logger
+
+    def setLevel(self, level):
+        self.level = level
+    
+    def __getattr__(self, name):
+        return self.logger.__getattribute__(name)
+    
 
 def get_module_logger(module_name, level: Optional[int] = None):
     """
@@ -27,7 +47,7 @@ def get_module_logger(module_name, level: Optional[int] = None):
 
     module_name = "qlib.{}".format(module_name)
     # Get logger.
-    module_logger = logging.getLogger(module_name)
+    module_logger = QlibLogger(module_name)
     module_logger.setLevel(level)
     return module_logger
 

--- a/qlib/log.py
+++ b/qlib/log.py
@@ -50,7 +50,7 @@ class QlibLogger(metaclass=MetaLogger):
         return self.logger.__getattribute__(name)
 
 
-def get_module_logger(module_name, level: Optional[int] = None):
+def get_module_logger(module_name, level: Optional[int] = None) -> logging.Logger:
     """
     Get a logger for a specific module.
 

--- a/qlib/log.py
+++ b/qlib/log.py
@@ -11,10 +11,12 @@ from contextlib import contextmanager
 
 from .config import C
 
-class QlibLogger(Logger，meta=):
-    '''
+
+class QlibLogger:
+    """
     Customized logger for Qlib.
-    '''
+    """
+
     def __init__(self, module_name):
         self.module_name = module_name
         self.level = 0
@@ -27,10 +29,10 @@ class QlibLogger(Logger，meta=):
 
     def setLevel(self, level):
         self.level = level
-    
+
     def __getattr__(self, name):
         return self.logger.__getattribute__(name)
-    
+
 
 def get_module_logger(module_name, level: Optional[int] = None):
     """

--- a/qlib/log.py
+++ b/qlib/log.py
@@ -12,7 +12,23 @@ from contextlib import contextmanager
 from .config import C
 
 
-class QlibLogger:
+class MetaLogger(type):
+    def __init__(self, name, bases, dic):
+        super().__init__(name, bases, dic)
+
+    def __new__(cls, name, bases, dict):
+        wrapper_dict = type(logging.getLogger("module_name")).__dict__.copy()
+        wrapper_dict.update(dict)
+        wrapper_dict["__doc__"] = logging.getLogger("module_name").__doc__
+        return type.__new__(cls, name, bases, wrapper_dict)
+
+    def __call__(cls, *args, **kwargs):
+        obj = cls.__new__(cls)
+        cls.__init__(cls, *args, **kwargs)
+        return obj
+
+
+class QlibLogger(metaclass=MetaLogger):
     """
     Customized logger for Qlib.
     """

--- a/qlib/log.py
+++ b/qlib/log.py
@@ -13,19 +13,12 @@ from .config import C
 
 
 class MetaLogger(type):
-    def __init__(self, name, bases, dic):
-        super().__init__(name, bases, dic)
 
     def __new__(cls, name, bases, dict):
         wrapper_dict = type(logging.getLogger("MetaLogger")).__dict__.copy()
         wrapper_dict.update(dict)
         wrapper_dict["__doc__"] = logging.getLogger("MetaLogger").__doc__
         return type.__new__(cls, name, bases, wrapper_dict)
-
-    def __call__(cls, *args, **kwargs):
-        obj = cls.__new__(cls)
-        cls.__init__(cls, *args, **kwargs)
-        return obj
 
 
 class QlibLogger(metaclass=MetaLogger):

--- a/qlib/log.py
+++ b/qlib/log.py
@@ -13,11 +13,10 @@ from .config import C
 
 
 class MetaLogger(type):
-
     def __new__(cls, name, bases, dict):
-        wrapper_dict = type(logging.getLogger("MetaLogger")).__dict__.copy()
+        wrapper_dict = logging.Logger.__dict__.copy()
         wrapper_dict.update(dict)
-        wrapper_dict["__doc__"] = logging.getLogger("MetaLogger").__doc__
+        wrapper_dict["__doc__"] = logging.Logger.__doc__
         return type.__new__(cls, name, bases, wrapper_dict)
 
 

--- a/qlib/workflow/exp.py
+++ b/qlib/workflow/exp.py
@@ -1,14 +1,14 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-import mlflow
+import mlflow, logging
 from mlflow.entities import ViewType
 from mlflow.exceptions import MlflowException
 from pathlib import Path
 from .recorder import Recorder, MLflowRecorder
 from ..log import get_module_logger
 
-logger = get_module_logger("workflow", "INFO")
+logger = get_module_logger("workflow", logging.INFO)
 
 
 class Experiment:

--- a/qlib/workflow/expm.py
+++ b/qlib/workflow/expm.py
@@ -4,7 +4,7 @@
 import mlflow
 from mlflow.exceptions import MlflowException
 from mlflow.entities import ViewType
-import os
+import os, logging
 from pathlib import Path
 from contextlib import contextmanager
 from typing import Optional, Text
@@ -14,7 +14,7 @@ from ..config import C
 from .recorder import Recorder
 from ..log import get_module_logger
 
-logger = get_module_logger("workflow", "INFO")
+logger = get_module_logger("workflow", logging.INFO)
 
 
 class ExpManager:

--- a/qlib/workflow/record_temp.py
+++ b/qlib/workflow/record_temp.py
@@ -1,7 +1,7 @@
 #  Copyright (c) Microsoft Corporation.
 #  Licensed under the MIT License.
 
-import re
+import re, logging
 import pandas as pd
 from pathlib import Path
 from pprint import pprint
@@ -16,7 +16,7 @@ from ..utils import flatten_dict
 from ..contrib.eva.alpha import calc_ic, calc_long_short_return, calc_long_short_prec
 from ..contrib.strategy.strategy import BaseStrategy
 
-logger = get_module_logger("workflow", "INFO")
+logger = get_module_logger("workflow", logging.INFO)
 
 
 class RecordTemp:

--- a/qlib/workflow/recorder.py
+++ b/qlib/workflow/recorder.py
@@ -1,14 +1,14 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-import mlflow
+import mlflow, logging
 import shutil, os, pickle, tempfile, codecs, pickle
 from pathlib import Path
 from datetime import datetime
 from ..utils.objm import FileManager
 from ..log import get_module_logger
 
-logger = get_module_logger("workflow", "INFO")
+logger = get_module_logger("workflow", logging.INFO)
 
 
 class Recorder:

--- a/qlib/workflow/utils.py
+++ b/qlib/workflow/utils.py
@@ -1,12 +1,12 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-import sys, traceback, signal, atexit
+import sys, traceback, signal, atexit, logging
 from . import R
 from .recorder import Recorder
 from ..log import get_module_logger
 
-logger = get_module_logger("workflow", "INFO")
+logger = get_module_logger("workflow", logging.INFO)
 
 
 # function to handle the experiment when unusual program ending occurs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The first commit solves the problem of pickling logger object under certain python version. But, I'm still figuring out how to maintain the original docstring of the logger.

**First trial**: now use `help` function will print all the docstrings of `QlibLogger`, but the docstring hints won't show up while using IDEs such as VSCode. 

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
