### PR TITLE
Fix logger pickling error

### DIFF
--- a/qlib/log.py
+++ b/qlib/log.py
@@ -17,6 +17,7 @@ class MetaLogger(type):
         wrapper_dict = logging.Logger.__dict__.copy()
         wrapper_dict.update(dict)
         wrapper_dict["__doc__"] = logging.Logger.__doc__
+        del wrapper_dict["__reduce__"]  # make Logger object can be pickled
         return type.__new__(cls, name, bases, wrapper_dict)
 
 
@@ -28,6 +29,15 @@ class QlibLogger(metaclass=MetaLogger):
     def __init__(self, module_name):
         self.module_name = module_name
         self.level = 0
+
+    def __getstate__(self):
+        return vars(self)
+
+    def __setstate__(self, state):
+        vars(self).update(state)
+
+    def __reduce__(self):
+        return (QlibLogger, (self.module_name,))
 
     @property
     def logger(self):

--- a/qlib/log.py
+++ b/qlib/log.py
@@ -18,7 +18,6 @@ class MetaLogger(type):
         for key in wrapper_dict:
             if key not in dict and key != "__reduce__":
                 dict[key] = wrapper_dict[key]
-        dict["__doc__"] = logging.Logger.__doc__
         return type.__new__(cls, name, bases, dict)
 
 
@@ -30,9 +29,6 @@ class QlibLogger(metaclass=MetaLogger):
     def __init__(self, module_name):
         self.module_name = module_name
         self.level = 0
-
-    def __reduce__(self):
-        return (QlibLogger, (self.module_name,))
 
     @property
     def logger(self):

--- a/qlib/log.py
+++ b/qlib/log.py
@@ -31,12 +31,6 @@ class QlibLogger(metaclass=MetaLogger):
         self.module_name = module_name
         self.level = 0
 
-    def __getstate__(self):
-        return vars(self)
-
-    def __setstate__(self, state):
-        vars(self).update(state)
-
     def __reduce__(self):
         return (QlibLogger, (self.module_name,))
 
@@ -50,6 +44,9 @@ class QlibLogger(metaclass=MetaLogger):
         self.level = level
 
     def __getattr__(self, name):
+        # During unpickling, python will call __getattr__. Use this line to avoid maximum recursion error.
+        if name in {"__setstate__"}:
+            raise AttributeError
         return self.logger.__getattribute__(name)
 
 

--- a/qlib/log.py
+++ b/qlib/log.py
@@ -15,10 +15,11 @@ from .config import C
 class MetaLogger(type):
     def __new__(cls, name, bases, dict):
         wrapper_dict = logging.Logger.__dict__.copy()
-        wrapper_dict.update(dict)
-        wrapper_dict["__doc__"] = logging.Logger.__doc__
-        del wrapper_dict["__reduce__"]  # make Logger object can be pickled
-        return type.__new__(cls, name, bases, wrapper_dict)
+        for key in wrapper_dict:
+            if key not in dict and key != "__reduce__":
+                dict[key] = wrapper_dict[key]
+        dict["__doc__"] = logging.Logger.__doc__
+        return type.__new__(cls, name, bases, dict)
 
 
 class QlibLogger(metaclass=MetaLogger):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The previous PR [#393](https://github.com/microsoft/qlib/pull/393) did not solve the logger pickling completely. The `QlibLogger` object cannot be saved either. This PR is trying to fix the problem and make everything work.

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
