### PR TITLE
Fix `get_module_by_module_path` to support pickle module loaded from arbitrage source file

### DIFF
--- a/qlib/utils/__init__.py
+++ b/qlib/utils/__init__.py
@@ -179,7 +179,7 @@ def get_module_by_module_path(module_path: Union[str, ModuleType]):
         module = module_path
     else:
         if module_path.endswith(".py"):
-            module_name = "dummy"
+            module_name = re.sub("^[^a-zA-Z_]+", "", re.sub("[^0-9a-zA-Z_]", "", module_path[:-3].replace("/", "_")))
             module_spec = importlib.util.spec_from_file_location(module_name, module_path)
             module = importlib.util.module_from_spec(module_spec)
             sys.modules[module_name] = module

--- a/qlib/utils/__init__.py
+++ b/qlib/utils/__init__.py
@@ -8,6 +8,7 @@ from __future__ import print_function
 import os
 import pickle
 import re
+import sys
 import copy
 import json
 import yaml
@@ -178,8 +179,10 @@ def get_module_by_module_path(module_path: Union[str, ModuleType]):
         module = module_path
     else:
         if module_path.endswith(".py"):
-            module_spec = importlib.util.spec_from_file_location("", module_path)
+            module_name = "dummy"
+            module_spec = importlib.util.spec_from_file_location(module_name, module_path)
             module = importlib.util.module_from_spec(module_spec)
+            sys.modules[module_name] = module
             module_spec.loader.exec_module(module)
         else:
             module = importlib.import_module(module_path)


### PR DESCRIPTION
## Description
Currently the following script will fail with pickle dump errors:
```python
"""<model.py>
class Model:
    pass
"""
import pickle
from qlib.utils import get_module_by_module_path

model = get_module_by_module_path('model.py').Model()
print(pickle.dumps(model)[:20])
```
![image](https://user-images.githubusercontent.com/10608479/118672152-9dc4f500-b82a-11eb-8fc8-cf9fc3fabc3e.png)

In this commit, the loaded module is added to `sys.modules` to support pickling.

## Types of changes
- [X ] Fix bugs

