### PR TITLE
Fix exception hook bug

### DIFF
--- a/qlib/workflow/utils.py
+++ b/qlib/workflow/utils.py
@@ -17,7 +17,6 @@ def experiment_exit_handler():
     Thus, if any exception or user interuption occurs beforehead, we should handle them first. Once `R` is
     ended, another call of `R.end_exp` will not take effect.
     """
-    signal.signal(signal.SIGINT, experiment_kill_signal_handler)  # handle user keyboard interupt
     sys.excepthook = experiment_exception_hook  # handle uncaught exception
     atexit.register(R.end_exp, recorder_status=Recorder.STATUS_FI)  # will not take effect if experiment ends
 
@@ -38,11 +37,4 @@ def experiment_exception_hook(type, value, tb):
     traceback.print_tb(tb)
     print(f"{type.__name__}: {value}")
 
-    R.end_exp(recorder_status=Recorder.STATUS_FA)
-
-
-def experiment_kill_signal_handler(signum, frame):
-    """
-    End an experiment when user kill the program through keyboard (CTRL+C, etc.).
-    """
     R.end_exp(recorder_status=Recorder.STATUS_FA)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix the bug of CTRL-C keyboard interruption is not working when running experiments.

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
