### PR TITLE
Update Recorder Wrapper to prevent reinitialization

### DIFF
--- a/qlib/utils/exceptions.py
+++ b/qlib/utils/exceptions.py
@@ -1,0 +1,12 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Base exception class
+class QlibException(Exception):
+    def __init__(self, message):
+        super(QlibException, self).__init__(message)
+
+
+# Error type for reinitialization when starting an experiment
+class RecorderInitializationError(QlibException):
+    pass

--- a/qlib/workflow/__init__.py
+++ b/qlib/workflow/__init__.py
@@ -533,9 +533,11 @@ class RecorderWrapper(Wrapper):
 
     def register(self, provider):
         if self._provider is not None:
-            raise RecorderInitializationError(
-                "Please don't reinitialize Qlib if QlibRecorder is already acivated. Otherwise, the experiment stored location will be modified."
-            )
+            expm = getattr(self._provider, "exp_manager")
+            if expm.active_experiment is not None:
+                raise RecorderInitializationError(
+                    "Please don't reinitialize Qlib if QlibRecorder is already acivated. Otherwise, the experiment stored location will be modified."
+                )
         self._provider = provider
 
 

--- a/qlib/workflow/__init__.py
+++ b/qlib/workflow/__init__.py
@@ -525,14 +525,33 @@ class QlibRecorder:
         self.get_exp().get_recorder().set_tags(**kwargs)
 
 
+# error type for reinitialization when starting an experiment
+class RecorderInitializationError(Exception):
+    def __init__(self, message):
+        super(RecorderInitializationError, self).__init__(message)
+
+
+class RecorderWrapper(Wrapper):
+    """
+    Wrapper class for QlibRecorder, which detects whether users reinitialize qlib when already starting an experiment.
+    """
+
+    def register(self, provider):
+        if self._provider is not None:
+            raise RecorderInitializationError(
+                "Please don't reinitialize Qlib if QlibRecorder is already acivated. Otherwise, the experiment stored location will be modified."
+            )
+        self._provider = provider
+
+
 import sys
 
 if sys.version_info >= (3, 9):
     from typing import Annotated
 
-    QlibRecorderWrapper = Annotated[QlibRecorder, Wrapper]
+    QlibRecorderWrapper = Annotated[QlibRecorder, RecorderWrapper]
 else:
     QlibRecorderWrapper = QlibRecorder
 
 # global record
-R: QlibRecorderWrapper = Wrapper()
+R: QlibRecorderWrapper = RecorderWrapper()

--- a/qlib/workflow/__init__.py
+++ b/qlib/workflow/__init__.py
@@ -7,6 +7,7 @@ from .expm import MLflowExpManager
 from .exp import Experiment
 from .recorder import Recorder
 from ..utils import Wrapper
+from ..utils.exceptions import RecorderInitializationError
 
 
 class QlibRecorder:
@@ -523,12 +524,6 @@ class QlibRecorder:
             name1=value1, name2=value2, ...
         """
         self.get_exp().get_recorder().set_tags(**kwargs)
-
-
-# error type for reinitialization when starting an experiment
-class RecorderInitializationError(Exception):
-    def __init__(self, message):
-        super(RecorderInitializationError, self).__init__(message)
 
 
 class RecorderWrapper(Wrapper):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR tries to solve the problem of Qlib reinitialization when having QlibRecorder `R` activated.

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
