### PR TITLE
simplify the code and prevent float when shifting

### DIFF
--- a/qlib/data/cache.py
+++ b/qlib/data/cache.py
@@ -237,7 +237,7 @@ class CacheUtils:
             lock.acquire()
         except redis_lock.AlreadyAcquired:
             raise QlibCacheException(
-                f"""It sees the key(lock:{repr(lock_name)[1:-1]}-wlock) of the redis lock has existed in your redis db now. 
+                f"""It sees the key(lock:{repr(lock_name)[1:-1]}-wlock) of the redis lock has existed in your redis db now.
                     You can use the following command to clear your redis keys and rerun your commands:
                     $ redis-cli
                     > select {C.redis_task_db}
@@ -784,10 +784,10 @@ class DiskDatasetCache(DatasetCache):
         def build_index_from_data(data, start_index=0):
             if data.empty:
                 return pd.DataFrame()
-            line_data = data.iloc[:, 0].fillna(0).groupby("datetime").count()
+            line_data = data.groupby("datetime").size()
             line_data.sort_index(inplace=True)
             index_end = line_data.cumsum()
-            index_start = index_end.shift(1).fillna(0)
+            index_start = index_end.shift(1, fill_value=0)
 
             index_data = pd.DataFrame()
             index_data["start"] = index_start

--- a/qlib/data/dataset/__init__.py
+++ b/qlib/data/dataset/__init__.py
@@ -507,7 +507,9 @@ class TSDatasetH(DatasetH):
         - The dimension of a batch of data <batch_idx, feature, timestep>
     """
 
-    def __init__(self, step_len=30, **kwargs):
+    DEFAULT_STEP_LEN = 30
+
+    def __init__(self, step_len=DEFAULT_STEP_LEN, **kwargs):
         self.step_len = step_len
         super().__init__(**kwargs)
 

--- a/qlib/workflow/online/utils.py
+++ b/qlib/workflow/online/utils.py
@@ -8,8 +8,10 @@ This allows us to use efficient submodels as the market-style changing.
 """
 
 from typing import List, Union
+from qlib.data.dataset import TSDatasetH
 
 from qlib.log import get_module_logger
+from qlib.utils import get_cls_kwargs
 from qlib.workflow.online.update import PredUpdater
 from qlib.workflow.recorder import Recorder
 from qlib.workflow.task.utils import list_recorders
@@ -161,8 +163,9 @@ class OnlineToolR(OnlineTool):
             hist_ref = 0
             task = rec.load_object("task")
             # Special treatment of historical dependencies
-            if task["dataset"]["class"] == "TSDatasetH":
-                hist_ref = task["dataset"]["kwargs"]["step_len"]
+            cls, kwargs = get_cls_kwargs(task["dataset"], default_module="qlib.data.dataset")
+            if issubclass(cls, TSDatasetH):
+                hist_ref = kwargs.get("step_len", TSDatasetH.DEFAULT_STEP_LEN)
             PredUpdater(rec, to_date=to_date, hist_ref=hist_ref).update()
 
         self.logger.info(f"Finished updating {len(online_models)} online model predictions of {self.exp_name}.")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Previous version will get following result when calling `DiskDatasetCache.IndexManager.build_index_from_data(df)`

![image](https://user-images.githubusercontent.com/465606/122666676-60fd6c80-d1e1-11eb-97a7-ade8562c0201.png)

But int type is what we want instead of float.

![image](https://user-images.githubusercontent.com/465606/122666696-84281c00-d1e1-11eb-84d1-9f047fb756b8.png)

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
