### PR TITLE
Bug fix: ClientProvider not set connection to calendar and instrument provider when initializing.

### DIFF
--- a/qlib/data/data.py
+++ b/qlib/data/data.py
@@ -1028,13 +1028,21 @@ class ClientProvider(BaseProvider):
     """
 
     def __init__(self):
+        def is_instance_of_provider(instance: object, cls: type):
+            if isinstance(instance, Wrapper):
+                p = getattr(instance, "_provider", None)
+
+                return False if p is None else isinstance(p, cls)
+
+            return isinstance(instance, cls)
+
         from .client import Client
 
         self.client = Client(C.flask_server, C.flask_port)
         self.logger = get_module_logger(self.__class__.__name__)
-        if isinstance(Cal, ClientCalendarProvider):
+        if is_instance_of_provider(Cal, ClientCalendarProvider):
             Cal.set_conn(self.client)
-        if isinstance(Inst, ClientInstrumentProvider):
+        if is_instance_of_provider(Inst, ClientInstrumentProvider):
             Inst.set_conn(self.client)
         if hasattr(DatasetD, "provider"):
             DatasetD.provider.set_conn(self.client)

--- a/scripts/dump_bin.py
+++ b/scripts/dump_bin.py
@@ -244,6 +244,10 @@ class DumpDataBase:
         if df is None or df.empty:
             logger.warning(f"{code} data is None or empty")
             return
+
+        # try to remove dup rows or it will cause exception when reindex.
+        df = df.drop_duplicates(self.date_field_name)
+
         # features save dir
         features_dir = self._features_dir.joinpath(code_to_fname(code).lower())
         features_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
The isinstance checking for client calendar and client instrument provider are not correct, here is a little patch to fix it.

And fix the dump script to drop duplicates.

## Description

When use qlib online mode, with following configuration (from qlib-server document), will cause exception "qlib/data/data.py", line 817, in list_instruments. AttributeError: 'NoneType' object has no attribute 'send_request'".

```yaml

calendar_provider:
  class: LocalCalendarProvider
  kwargs:
    remote: True

feature_provider:
  class: LocalFeatureProvider
  kwargs:
    remote: True

instrument_provider: ClientInstrumentProvider

expression_provider: LocalExpressionProvider

dataset_provider: ClientDatasetProvider

provider: ClientProvider

expression_cache: null
dataset_cache: null
calendar_cache: null

```

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
