### PR TITLE
Issue fix

### DIFF
--- a/qlib/model/trainer.py
+++ b/qlib/model/trainer.py
@@ -12,7 +12,6 @@ In ``DelayTrainer``, the first step is only to save some necessary info to model
 """
 
 import socket
-import time
 from typing import Callable, List
 
 from qlib.data.dataset import Dataset

--- a/qlib/workflow/utils.py
+++ b/qlib/workflow/utils.py
@@ -1,10 +1,14 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-import sys, traceback, signal, atexit, logging
+import atexit
+import logging
+import sys
+import traceback
+
+from ..log import get_module_logger
 from . import R
 from .recorder import Recorder
-from ..log import get_module_logger
 
 logger = get_module_logger("workflow", logging.INFO)
 


### PR DESCRIPTION
<!--- fixing some LGTM issue on ```qlib``` -->

## Description
-  ```qlib/model/trainer.py``` problem which unused imported module of time [lgtm  issue]
- ```qlib/workflows/utils.py``` problem which unused imported module of ```signal``` and change to PEP8 style code lint

## Motivation and Context
unused imported module is make some code not so god, and more litte tricky
and PEP 8 exists to improve the readability of Python code

## How Has This Been Tested?
- [x] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
