### PR TITLE
Error when running the example

### DIFF
--- a/docs/FAQ/FAQ.rst
+++ b/docs/FAQ/FAQ.rst
@@ -98,3 +98,15 @@ Also, feel free to post a new issue in our GitHub repository. We always check ea
         python setup.py build_ext --inplace
 
 - If the error occurs when importing ``qlib`` package with command ``python`` , users need to change the running directory to ensure that the script does not run in the project directory.
+
+4. ValueError:instruments not exists for /.qlib/qlib_data/cn_data/instruments/csi300.txt
+------------------------------------------------------------------------------------------------------------------------------------  
+ 
+If you meet this error when running the example, you can delete the data and download it again with:
+   
+.. code-block:: bash
+
+      $ python scripts/get_data.py qlib_data --target_dir ~/.qlib/qlib_data/cn_data --region cn
+      
+.. note::
+   You may need to install catboost and xgboost before running the example.


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Add the solution to ValueError:instruments not exists for /.qlib/qlib_data/cn_data/instruments/csi300.txt

## Motivation and Context
I meet this error when running the example

## How Has This Been Tested?
- [ x] Pass the test by running: python scripts/get_data.py qlib_data --target_dir ~/.qlib/qlib_data/cn_data --region cn

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:
![image](https://user-images.githubusercontent.com/87422961/130075440-996d3ff1-f555-4592-9c7d-88ca81005873.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Fix bugs
- [ ] Add new feature
- [ x] Update documentation
