### PR TITLE
Fix shared task dict BUG

### DIFF
--- a/qlib/workflow/task/gen.py
+++ b/qlib/workflow/task/gen.py
@@ -162,8 +162,7 @@ class RollingGen(TaskGen):
         List[dict]:
             the following tasks of `task`(`task` itself is excluded)
         """
-        t = copy.deepcopy(task)
-        prev_seg = t["dataset"]["kwargs"]["segments"]
+        prev_seg = task["dataset"]["kwargs"]["segments"]
         while True:
             segments = {}
             try:
@@ -184,6 +183,7 @@ class RollingGen(TaskGen):
                 break
 
             prev_seg = segments
+            t = copy.deepcopy(task)  # deepcopy is necessary to avoid modify task inplace
             self._update_task_segs(t, segments)
             yield t
 


### PR DESCRIPTION
Fix shared task dict BUG #549

## Description
The task t is shared when generating rolling tasks.
Modification on new tasks will affect old tasks

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
