### PR TITLE
fix topkdropn strategy logic error

### DIFF
--- a/qlib/contrib/strategy/model_strategy.py
+++ b/qlib/contrib/strategy/model_strategy.py
@@ -96,6 +96,8 @@ class TopkDropoutStrategy(ModelStrategy):
             def get_first_n(l, n, reverse=False):
                 cur_n = 0
                 res = []
+                if n == 0:
+                    return res
                 for si in reversed(l) if reverse else l:
                     if self.trade_exchange.is_stock_tradable(
                         stock_id=si, start_time=trade_start_time, end_time=trade_end_time
@@ -169,9 +171,7 @@ class TopkDropoutStrategy(ModelStrategy):
                 sell = candi
         else:
             raise NotImplementedError(f"This type of input is not supported")
-
-        # Get the stock list we really want to buy
-        buy = today[: len(sell) + self.topk - len(last)]
+                
         for code in current_stock_list:
             if not self.trade_exchange.is_stock_tradable(
                 stock_id=code, start_time=trade_start_time, end_time=trade_end_time
@@ -203,6 +203,11 @@ class TopkDropoutStrategy(ModelStrategy):
                     )
                     # update cash
                     cash += trade_val - trade_cost
+        
+        # Get the stock list we really want to buy
+        sell_size = len(sell_order_list)
+        buy = today[: self.topk - len(last) + sell_size]
+        
         # buy new stock
         # note the current has been changed
         current_stock_list = current_temp.get_stock_list()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
1. fix Topkdropn holding stocks could be larger than k; 
2. fix Topkdropn turnover rate could be larger than  2*n/k

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
