### PR TITLE
bugfix: Fix the problem that caused highfreq's yaml to be unusable

### DIFF
--- a/examples/highfreq/workflow_config_High_Freq_Tree_Alpha158.yaml
+++ b/examples/highfreq/workflow_config_High_Freq_Tree_Alpha158.yaml
@@ -59,7 +59,7 @@ task:
     record: 
         - class: "SignalRecord"
           module_path: "qlib.workflow.record_temp"
-          kwargs: 
+          kwargs: {}
         - class: "HFSignalRecord"
           module_path: "qlib.workflow.record_temp"
           kwargs: {}


### PR DESCRIPTION
Otherwise there will be an error as shown in the figure below:
![微信截图_20211109143059](https://user-images.githubusercontent.com/22796589/140876337-2e9fa60e-0667-42ef-b07e-dac6fbfc0541.png)

