### PR TITLE
Fix $volume normalization issue

### DIFF
--- a/qlib/contrib/data/handler.py
+++ b/qlib/contrib/data/handler.py
@@ -126,9 +126,9 @@ class Alpha360(DataHandlerLP):
         fields += ["$vwap/$close"]
         names += ["VWAP0"]
         for i in range(59, 0, -1):
-            fields += ["Ref($volume, %d)/$volume" % (i)]
+            fields += ["Ref($volume, %d)/($volume+1e-12)" % (i)]
             names += ["VOLUME%d" % (i)]
-        fields += ["$volume/$volume"]
+        fields += ["($volume+1e-12)/($volume+1e-12)"]
         names += ["VOLUME0"]
 
         return fields, names
@@ -249,7 +249,7 @@ class Alpha158(DataHandlerLP):
                 names += [field.upper() + str(d) for d in windows]
         if "volume" in config:
             windows = config["volume"].get("windows", range(5))
-            fields += ["Ref($volume, %d)/$volume" % d if d != 0 else "$volume/$volume" for d in windows]
+            fields += ["Ref($volume, %d)/($volume+1e-12)" % d if d != 0 else "($volume+1e-12)/($volume+1e-12)" for d in windows]
             names += ["VOLUME" + str(d) for d in windows]
         if "rolling" in config:
             windows = config["rolling"].get("windows", [5, 10, 20, 30, 60])

--- a/qlib/contrib/data/handler.py
+++ b/qlib/contrib/data/handler.py
@@ -61,8 +61,12 @@ class Alpha360(DataHandlerLP):
         inst_processor=None,
         **kwargs,
     ):
-        infer_processors = check_transform_proc(infer_processors, fit_start_time, fit_end_time)
-        learn_processors = check_transform_proc(learn_processors, fit_start_time, fit_end_time)
+        infer_processors = check_transform_proc(
+            infer_processors, fit_start_time, fit_end_time
+        )
+        learn_processors = check_transform_proc(
+            learn_processors, fit_start_time, fit_end_time
+        )
 
         data_loader = {
             "class": "QlibDataLoader",
@@ -128,7 +132,7 @@ class Alpha360(DataHandlerLP):
         for i in range(59, 0, -1):
             fields += ["Ref($volume, %d)/($volume+1e-12)" % (i)]
             names += ["VOLUME%d" % (i)]
-        fields += ["($volume+1e-12)/($volume+1e-12)"]
+        fields += ["$volume+1/($volume+1e-12)"]
         names += ["VOLUME0"]
 
         return fields, names
@@ -155,8 +159,12 @@ class Alpha158(DataHandlerLP):
         inst_processor=None,
         **kwargs,
     ):
-        infer_processors = check_transform_proc(infer_processors, fit_start_time, fit_end_time)
-        learn_processors = check_transform_proc(learn_processors, fit_start_time, fit_end_time)
+        infer_processors = check_transform_proc(
+            infer_processors, fit_start_time, fit_end_time
+        )
+        learn_processors = check_transform_proc(
+            learn_processors, fit_start_time, fit_end_time
+        )
 
         data_loader = {
             "class": "QlibDataLoader",
@@ -242,14 +250,26 @@ class Alpha158(DataHandlerLP):
             ]
         if "price" in config:
             windows = config["price"].get("windows", range(5))
-            feature = config["price"].get("feature", ["OPEN", "HIGH", "LOW", "CLOSE", "VWAP"])
+            feature = config["price"].get(
+                "feature", ["OPEN", "HIGH", "LOW", "CLOSE", "VWAP"]
+            )
             for field in feature:
                 field = field.lower()
-                fields += ["Ref($%s, %d)/$close" % (field, d) if d != 0 else "$%s/$close" % field for d in windows]
+                fields += [
+                    "Ref($%s, %d)/$close" % (field, d)
+                    if d != 0
+                    else "$%s/$close" % field
+                    for d in windows
+                ]
                 names += [field.upper() + str(d) for d in windows]
         if "volume" in config:
             windows = config["volume"].get("windows", range(5))
-            fields += ["Ref($volume, %d)/($volume+1e-12)" % d if d != 0 else "($volume+1e-12)/($volume+1e-12)" for d in windows]
+            fields += [
+                "Ref($volume, %d)/($volume+1e-12)" % d
+                if d != 0
+                else "$volume/($volume+1e-12)"
+                for d in windows
+            ]
             names += ["VOLUME" + str(d) for d in windows]
         if "rolling" in config:
             windows = config["rolling"].get("windows", [5, 10, 20, 30, 60])
@@ -292,7 +312,11 @@ class Alpha158(DataHandlerLP):
                 fields += ["Rank($close, %d)" % d for d in windows]
                 names += ["RANK%d" % d for d in windows]
             if use("RSV"):
-                fields += ["($close-Min($low, %d))/(Max($high, %d)-Min($low, %d)+1e-12)" % (d, d, d) for d in windows]
+                fields += [
+                    "($close-Min($low, %d))/(Max($high, %d)-Min($low, %d)+1e-12)"
+                    % (d, d, d)
+                    for d in windows
+                ]
                 names += ["RSV%d" % d for d in windows]
             if use("IMAX"):
                 fields += ["IdxMax($high, %d)/%d" % (d, d) for d in windows]
@@ -301,13 +325,19 @@ class Alpha158(DataHandlerLP):
                 fields += ["IdxMin($low, %d)/%d" % (d, d) for d in windows]
                 names += ["IMIN%d" % d for d in windows]
             if use("IMXD"):
-                fields += ["(IdxMax($high, %d)-IdxMin($low, %d))/%d" % (d, d, d) for d in windows]
+                fields += [
+                    "(IdxMax($high, %d)-IdxMin($low, %d))/%d" % (d, d, d)
+                    for d in windows
+                ]
                 names += ["IMXD%d" % d for d in windows]
             if use("CORR"):
                 fields += ["Corr($close, Log($volume+1), %d)" % d for d in windows]
                 names += ["CORR%d" % d for d in windows]
             if use("CORD"):
-                fields += ["Corr($close/Ref($close,1), Log($volume/Ref($volume, 1)+1), %d)" % d for d in windows]
+                fields += [
+                    "Corr($close/Ref($close,1), Log($volume/Ref($volume, 1)+1), %d)" % d
+                    for d in windows
+                ]
                 names += ["CORD%d" % d for d in windows]
             if use("CNTP"):
                 fields += ["Mean($close>Ref($close, 1), %d)" % d for d in windows]
@@ -316,17 +346,23 @@ class Alpha158(DataHandlerLP):
                 fields += ["Mean($close<Ref($close, 1), %d)" % d for d in windows]
                 names += ["CNTN%d" % d for d in windows]
             if use("CNTD"):
-                fields += ["Mean($close>Ref($close, 1), %d)-Mean($close<Ref($close, 1), %d)" % (d, d) for d in windows]
+                fields += [
+                    "Mean($close>Ref($close, 1), %d)-Mean($close<Ref($close, 1), %d)"
+                    % (d, d)
+                    for d in windows
+                ]
                 names += ["CNTD%d" % d for d in windows]
             if use("SUMP"):
                 fields += [
-                    "Sum(Greater($close-Ref($close, 1), 0), %d)/(Sum(Abs($close-Ref($close, 1)), %d)+1e-12)" % (d, d)
+                    "Sum(Greater($close-Ref($close, 1), 0), %d)/(Sum(Abs($close-Ref($close, 1)), %d)+1e-12)"
+                    % (d, d)
                     for d in windows
                 ]
                 names += ["SUMP%d" % d for d in windows]
             if use("SUMN"):
                 fields += [
-                    "Sum(Greater(Ref($close, 1)-$close, 0), %d)/(Sum(Abs($close-Ref($close, 1)), %d)+1e-12)" % (d, d)
+                    "Sum(Greater(Ref($close, 1)-$close, 0), %d)/(Sum(Abs($close-Ref($close, 1)), %d)+1e-12)"
+                    % (d, d)
                     for d in windows
                 ]
                 names += ["SUMN%d" % d for d in windows]

--- a/qlib/contrib/data/handler.py
+++ b/qlib/contrib/data/handler.py
@@ -61,12 +61,8 @@ class Alpha360(DataHandlerLP):
         inst_processor=None,
         **kwargs,
     ):
-        infer_processors = check_transform_proc(
-            infer_processors, fit_start_time, fit_end_time
-        )
-        learn_processors = check_transform_proc(
-            learn_processors, fit_start_time, fit_end_time
-        )
+        infer_processors = check_transform_proc(infer_processors, fit_start_time, fit_end_time)
+        learn_processors = check_transform_proc(learn_processors, fit_start_time, fit_end_time)
 
         data_loader = {
             "class": "QlibDataLoader",
@@ -159,12 +155,8 @@ class Alpha158(DataHandlerLP):
         inst_processor=None,
         **kwargs,
     ):
-        infer_processors = check_transform_proc(
-            infer_processors, fit_start_time, fit_end_time
-        )
-        learn_processors = check_transform_proc(
-            learn_processors, fit_start_time, fit_end_time
-        )
+        infer_processors = check_transform_proc(infer_processors, fit_start_time, fit_end_time)
+        learn_processors = check_transform_proc(learn_processors, fit_start_time, fit_end_time)
 
         data_loader = {
             "class": "QlibDataLoader",
@@ -250,26 +242,14 @@ class Alpha158(DataHandlerLP):
             ]
         if "price" in config:
             windows = config["price"].get("windows", range(5))
-            feature = config["price"].get(
-                "feature", ["OPEN", "HIGH", "LOW", "CLOSE", "VWAP"]
-            )
+            feature = config["price"].get("feature", ["OPEN", "HIGH", "LOW", "CLOSE", "VWAP"])
             for field in feature:
                 field = field.lower()
-                fields += [
-                    "Ref($%s, %d)/$close" % (field, d)
-                    if d != 0
-                    else "$%s/$close" % field
-                    for d in windows
-                ]
+                fields += ["Ref($%s, %d)/$close" % (field, d) if d != 0 else "$%s/$close" % field for d in windows]
                 names += [field.upper() + str(d) for d in windows]
         if "volume" in config:
             windows = config["volume"].get("windows", range(5))
-            fields += [
-                "Ref($volume, %d)/($volume+1e-12)" % d
-                if d != 0
-                else "$volume/($volume+1e-12)"
-                for d in windows
-            ]
+            fields += ["Ref($volume, %d)/($volume+1e-12)" % d if d != 0 else "$volume/($volume+1e-12)" for d in windows]
             names += ["VOLUME" + str(d) for d in windows]
         if "rolling" in config:
             windows = config["rolling"].get("windows", [5, 10, 20, 30, 60])
@@ -312,11 +292,7 @@ class Alpha158(DataHandlerLP):
                 fields += ["Rank($close, %d)" % d for d in windows]
                 names += ["RANK%d" % d for d in windows]
             if use("RSV"):
-                fields += [
-                    "($close-Min($low, %d))/(Max($high, %d)-Min($low, %d)+1e-12)"
-                    % (d, d, d)
-                    for d in windows
-                ]
+                fields += ["($close-Min($low, %d))/(Max($high, %d)-Min($low, %d)+1e-12)" % (d, d, d) for d in windows]
                 names += ["RSV%d" % d for d in windows]
             if use("IMAX"):
                 fields += ["IdxMax($high, %d)/%d" % (d, d) for d in windows]
@@ -325,19 +301,13 @@ class Alpha158(DataHandlerLP):
                 fields += ["IdxMin($low, %d)/%d" % (d, d) for d in windows]
                 names += ["IMIN%d" % d for d in windows]
             if use("IMXD"):
-                fields += [
-                    "(IdxMax($high, %d)-IdxMin($low, %d))/%d" % (d, d, d)
-                    for d in windows
-                ]
+                fields += ["(IdxMax($high, %d)-IdxMin($low, %d))/%d" % (d, d, d) for d in windows]
                 names += ["IMXD%d" % d for d in windows]
             if use("CORR"):
                 fields += ["Corr($close, Log($volume+1), %d)" % d for d in windows]
                 names += ["CORR%d" % d for d in windows]
             if use("CORD"):
-                fields += [
-                    "Corr($close/Ref($close,1), Log($volume/Ref($volume, 1)+1), %d)" % d
-                    for d in windows
-                ]
+                fields += ["Corr($close/Ref($close,1), Log($volume/Ref($volume, 1)+1), %d)" % d for d in windows]
                 names += ["CORD%d" % d for d in windows]
             if use("CNTP"):
                 fields += ["Mean($close>Ref($close, 1), %d)" % d for d in windows]
@@ -346,23 +316,17 @@ class Alpha158(DataHandlerLP):
                 fields += ["Mean($close<Ref($close, 1), %d)" % d for d in windows]
                 names += ["CNTN%d" % d for d in windows]
             if use("CNTD"):
-                fields += [
-                    "Mean($close>Ref($close, 1), %d)-Mean($close<Ref($close, 1), %d)"
-                    % (d, d)
-                    for d in windows
-                ]
+                fields += ["Mean($close>Ref($close, 1), %d)-Mean($close<Ref($close, 1), %d)" % (d, d) for d in windows]
                 names += ["CNTD%d" % d for d in windows]
             if use("SUMP"):
                 fields += [
-                    "Sum(Greater($close-Ref($close, 1), 0), %d)/(Sum(Abs($close-Ref($close, 1)), %d)+1e-12)"
-                    % (d, d)
+                    "Sum(Greater($close-Ref($close, 1), 0), %d)/(Sum(Abs($close-Ref($close, 1)), %d)+1e-12)" % (d, d)
                     for d in windows
                 ]
                 names += ["SUMP%d" % d for d in windows]
             if use("SUMN"):
                 fields += [
-                    "Sum(Greater(Ref($close, 1)-$close, 0), %d)/(Sum(Abs($close-Ref($close, 1)), %d)+1e-12)"
-                    % (d, d)
+                    "Sum(Greater(Ref($close, 1)-$close, 0), %d)/(Sum(Abs($close-Ref($close, 1)), %d)+1e-12)" % (d, d)
                     for d in windows
                 ]
                 names += ["SUMN%d" % d for d in windows]

--- a/qlib/contrib/data/handler.py
+++ b/qlib/contrib/data/handler.py
@@ -132,7 +132,7 @@ class Alpha360(DataHandlerLP):
         for i in range(59, 0, -1):
             fields += ["Ref($volume, %d)/($volume+1e-12)" % (i)]
             names += ["VOLUME%d" % (i)]
-        fields += ["$volume+1/($volume+1e-12)"]
+        fields += ["$volume/($volume+1e-12)"]
         names += ["VOLUME0"]
 
         return fields, names


### PR DESCRIPTION
Fix: https://github.com/microsoft/qlib/issues/765

<!--- Provide a general summary of your changes in the Title above -->

## Description
change $volume to $volume+1e-12 such that low volume stocks will not create infinity in features.

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->https://github.com/microsoft/qlib/issues/765
<!--- Why is this change required? What problem does it solve? -->$volume creates infinity for low volume stocks. 

## How Has This Been Tested?
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
