### PR TITLE
[807] Move the REG_CONSTANT/EPS to constant.py.

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ We recommend users to prepare their own data if they have a high-quality dataset
   ```python
   import qlib
   from qlib.data import D
-  from qlib.config import REG_CN
+  from qlib.constant import REG_CN
 
   # Initialization
   mount_path = "~/.qlib/qlib_data/cn_data"  # target_dir

--- a/docs/component/data.rst
+++ b/docs/component/data.rst
@@ -219,7 +219,7 @@ The `trade unit` defines the unit number of stocks can be used in a trade, and t
         
         .. code-block:: python
 
-            from qlib.config import REG_CN
+            from qlib.constant import REG_CN
             qlib.init(provider_uri='~/.qlib/qlib_data/cn_data', region=REG_CN)
         
 

--- a/docs/start/initialization.rst
+++ b/docs/start/initialization.rst
@@ -27,7 +27,7 @@ Initialize Qlib before calling other APIs: run following code in python.
 
         import qlib
         # region in [REG_CN, REG_US]
-        from qlib.config import REG_CN
+        from qlib.constant import REG_CN
         provider_uri = "~/.qlib/qlib_data/cn_data"  # target_dir
         qlib.init(provider_uri=provider_uri, region=REG_CN)
     
@@ -42,10 +42,10 @@ Besides `provider_uri` and `region`, `qlib.init` has other parameters. The follo
 - `provider_uri`
     Type: str. The URI of the Qlib data. For example, it could be the location where the data loaded by ``get_data.py`` are stored.
 - `region`
-    Type: str, optional parameter(default: `qlib.config.REG_CN`).
-        Currently: ``qlib.config.REG_US`` ('us') and ``qlib.config.REG_CN`` ('cn') is supported. Different value of  `region` will result in different stock market mode.
-        - ``qlib.config.REG_US``: US stock market.
-        - ``qlib.config.REG_CN``: China stock market.
+    Type: str, optional parameter(default: `qlib.constant.REG_CN`).
+        Currently: ``qlib.constant.REG_US`` ('us') and ``qlib.constant.REG_CN`` ('cn') is supported. Different value of  `region` will result in different stock market mode.
+        - ``qlib.constant.REG_US``: US stock market.
+        - ``qlib.constant.REG_CN``: China stock market.
 
         Different modes will result in different trading limitations and costs.
         The region is just `shortcuts for defining a batch of configurations <https://github.com/microsoft/qlib/blob/main/qlib/config.py#L239>`_. Users can set the key configurations manually if the existing region setting can't meet their requirements.

--- a/examples/highfreq/highfreq_processor.py
+++ b/examples/highfreq/highfreq_processor.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+from qlib.constant import EPS
 from qlib.data.dataset.processor import Processor
 from qlib.data.dataset.utils import fetch_df_by_index
 
@@ -27,7 +28,7 @@ class HighFreqNorm(Processor):
                 part_values = np.log1p(part_values)
             self.feature_med[name] = np.nanmedian(part_values)
             part_values = part_values - self.feature_med[name]
-            self.feature_std[name] = np.nanmedian(np.absolute(part_values)) * 1.4826 + 1e-12
+            self.feature_std[name] = np.nanmedian(np.absolute(part_values)) * 1.4826 + EPS
             part_values = part_values / self.feature_std[name]
             self.feature_vmax[name] = np.nanmax(part_values)
             self.feature_vmin[name] = np.nanmin(part_values)

--- a/examples/highfreq/workflow.py
+++ b/examples/highfreq/workflow.py
@@ -5,7 +5,8 @@ import fire
 
 import qlib
 import pickle
-from qlib.config import REG_CN, HIGH_FREQ_CONFIG
+from qlib.constant import REG_CN
+from qlib.config import HIGH_FREQ_CONFIG
 
 from qlib.utils import init_instance_by_config
 from qlib.data.dataset.handler import DataHandlerLP

--- a/examples/hyperparameter/LightGBM/hyperparameter_158.py
+++ b/examples/hyperparameter/LightGBM/hyperparameter_158.py
@@ -1,6 +1,6 @@
 import qlib
 import optuna
-from qlib.config import REG_CN
+from qlib.constant import REG_CN
 from qlib.utils import init_instance_by_config
 from qlib.tests.config import CSI300_DATASET_CONFIG
 from qlib.tests.data import GetData

--- a/examples/hyperparameter/LightGBM/hyperparameter_360.py
+++ b/examples/hyperparameter/LightGBM/hyperparameter_360.py
@@ -1,6 +1,6 @@
 import qlib
 import optuna
-from qlib.config import REG_CN
+from qlib.constant import REG_CN
 from qlib.utils import init_instance_by_config
 from qlib.tests.data import GetData
 from qlib.tests.config import get_dataset_config, CSI300_MARKET, DATASET_ALPHA360_CLASS

--- a/examples/model_interpreter/feature.py
+++ b/examples/model_interpreter/feature.py
@@ -3,7 +3,7 @@
 
 
 import qlib
-from qlib.config import REG_CN
+from qlib.constant import REG_CN
 
 from qlib.utils import init_instance_by_config
 from qlib.tests.data import GetData

--- a/examples/model_rolling/task_manager_rolling.py
+++ b/examples/model_rolling/task_manager_rolling.py
@@ -11,7 +11,7 @@ from pprint import pprint
 
 import fire
 import qlib
-from qlib.config import REG_CN
+from qlib.constant import REG_CN
 from qlib.workflow import R
 from qlib.workflow.task.gen import RollingGen, task_generator
 from qlib.workflow.task.manage import TaskManager, run_task

--- a/examples/nested_decision_execution/workflow.py
+++ b/examples/nested_decision_execution/workflow.py
@@ -100,7 +100,8 @@ from copy import deepcopy
 import qlib
 import fire
 import pandas as pd
-from qlib.config import REG_CN, HIGH_FREQ_CONFIG
+from qlib.constant import REG_CN
+from qlib.config import HIGH_FREQ_CONFIG
 from qlib.data import D
 from qlib.utils import exists_qlib_data, init_instance_by_config, flatten_dict
 from qlib.workflow import R

--- a/examples/online_srv/update_online_pred.py
+++ b/examples/online_srv/update_online_pred.py
@@ -10,7 +10,7 @@ Next, we will finish updating online predictions.
 import copy
 import fire
 import qlib
-from qlib.config import REG_CN
+from qlib.constant import REG_CN
 from qlib.model.trainer import task_train
 from qlib.workflow.online.utils import OnlineToolR
 from qlib.tests.config import CSI300_GBDT_TASK

--- a/examples/rolling_process_data/workflow.py
+++ b/examples/rolling_process_data/workflow.py
@@ -6,7 +6,7 @@ import fire
 import pickle
 
 from datetime import datetime
-from qlib.config import REG_CN
+from qlib.constant import REG_CN
 from qlib.data.dataset.handler import DataHandlerLP
 from qlib.utils import init_instance_by_config
 from qlib.tests.data import GetData

--- a/examples/run_all_model.py
+++ b/examples/run_all_model.py
@@ -20,7 +20,6 @@ from operator import xor
 from pprint import pprint
 
 import qlib
-from qlib.config import REG_CN
 from qlib.workflow import R
 from qlib.tests.data import GetData
 

--- a/examples/workflow_by_code.ipynb
+++ b/examples/workflow_by_code.ipynb
@@ -61,7 +61,7 @@
     "\n",
     "import qlib\n",
     "import pandas as pd\n",
-    "from qlib.config import REG_CN\n",
+    "from qlib.constant import REG_CN\n",
     "from qlib.utils import exists_qlib_data, init_instance_by_config\n",
     "from qlib.workflow import R\n",
     "from qlib.workflow.record_temp import SignalRecord, PortAnaRecord\n",

--- a/examples/workflow_by_code.py
+++ b/examples/workflow_by_code.py
@@ -2,7 +2,7 @@
 #  Licensed under the MIT License.
 
 import qlib
-from qlib.config import REG_CN
+from qlib.constant import REG_CN
 from qlib.utils import init_instance_by_config, flatten_dict
 from qlib.workflow import R
 from qlib.workflow.record_temp import SignalRecord, PortAnaRecord, SigAnaRecord

--- a/qlib/backtest/exchange.py
+++ b/qlib/backtest/exchange.py
@@ -14,7 +14,8 @@ import numpy as np
 import pandas as pd
 
 from ..data.data import D
-from ..config import C, REG_CN
+from ..config import C
+from ..constant import REG_CN
 from ..log import get_module_logger
 from .decision import Order, OrderDir, OrderHelper
 from .high_performance_ds import BaseQuote, PandasQuote, NumpyQuote

--- a/qlib/config.py
+++ b/qlib/config.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import Optional, Union
 from typing import TYPE_CHECKING
 
-from qlib.constant import REG_CN
+from qlib.constant import REG_CN, REG_US
 
 if TYPE_CHECKING:
     from qlib.utils.time import Freq

--- a/qlib/config.py
+++ b/qlib/config.py
@@ -22,6 +22,8 @@ from pathlib import Path
 from typing import Optional, Union
 from typing import TYPE_CHECKING
 
+from qlib.constant import REG_CN
+
 if TYPE_CHECKING:
     from qlib.utils.time import Freq
 
@@ -73,10 +75,6 @@ class Config:
     def set_conf_from_C(self, config_c):
         self.update(**config_c.__dict__["_config"])
 
-
-# REGION CONST
-REG_CN = "cn"
-REG_US = "us"
 
 # pickle.dump protocol version: https://docs.python.org/3/library/pickle.html#data-stream-format
 PROTOCOL_VERSION = 4

--- a/qlib/constant.py
+++ b/qlib/constant.py
@@ -1,0 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# REGION CONST
+REG_CN = "cn"
+REG_US = "us"

--- a/qlib/constant.py
+++ b/qlib/constant.py
@@ -4,3 +4,6 @@
 # REGION CONST
 REG_CN = "cn"
 REG_US = "us"
+
+# Epsilon for avoiding division by zero.
+EPS = 1e-12

--- a/qlib/contrib/model/pytorch_tra.py
+++ b/qlib/contrib/model/pytorch_tra.py
@@ -25,6 +25,7 @@ except:
 from tqdm import tqdm
 
 from qlib.utils import get_or_create_path
+from qlib.constant import EPS
 from qlib.log import get_module_logger
 from qlib.model.base import Model
 from qlib.contrib.data.dataset import MTSDatasetH
@@ -791,7 +792,7 @@ def minmax_norm(x):
     xmin = x.min(dim=-1, keepdim=True).values
     xmax = x.max(dim=-1, keepdim=True).values
     mask = (xmin == xmax).squeeze()
-    x = (x - xmin) / (xmax - xmin + 1e-12)
+    x = (x - xmin) / (xmax - xmin + EPS)
     x[mask] = 1
     return x
 

--- a/qlib/data/dataset/processor.py
+++ b/qlib/data/dataset/processor.py
@@ -5,14 +5,11 @@ import abc
 from typing import Union, Text
 import numpy as np
 import pandas as pd
-import copy
 
-from ...log import TimeInspector
+from ...constant import EPS
 from .utils import fetch_df_by_index
 from ...utils.serial import Serializable
 from ...utils.paral import datetime_groupby_apply
-
-EPS = 1e-12
 
 
 def get_group_columns(df: pd.DataFrame, group: Union[Text, None]):

--- a/qlib/tests/__init__.py
+++ b/qlib/tests/__init__.py
@@ -1,7 +1,7 @@
 import unittest
 from .data import GetData
 from .. import init
-from ..config import REG_CN
+from ..constant import REG_CN
 
 
 class TestAutoData(unittest.TestCase):

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -62,7 +62,8 @@ qlib.init(provider_uri=provider_uri, region=REG_US)
 
 ```python
 import qlib
-from qlib.config import REG_CN
+from qlib.constant import REG_CN
+
 provider_uri = "~/.qlib/qlib_data/cn_data"  # target_dir
 qlib.init(provider_uri=provider_uri, region=REG_CN)
 ```

--- a/scripts/data_collector/fund/collector.py
+++ b/scripts/data_collector/fund/collector.py
@@ -13,7 +13,7 @@ import requests
 import pandas as pd
 from loguru import logger
 from dateutil.tz import tzlocal
-from qlib.config import REG_CN as REGION_CN
+from qlib.constant import REG_CN as REGION_CN
 
 CUR_DIR = Path(__file__).resolve().parent
 sys.path.append(str(CUR_DIR.parent.parent))

--- a/scripts/data_collector/yahoo/collector.py
+++ b/scripts/data_collector/yahoo/collector.py
@@ -22,7 +22,7 @@ from dateutil.tz import tzlocal
 
 from qlib.tests.data import GetData
 from qlib.utils import code_to_fname, fname_to_code, exists_qlib_data
-from qlib.config import REG_CN as REGION_CN
+from qlib.constant import REG_CN as REGION_CN
 
 CUR_DIR = Path(__file__).resolve().parent
 sys.path.append(str(CUR_DIR.parent.parent))

--- a/tests/backtest/test_high_freq_trading.py
+++ b/tests/backtest/test_high_freq_trading.py
@@ -5,7 +5,6 @@ from qlib.backtest.decision import BaseTradeDecision, TradeRangeByTime
 import qlib
 from qlib.tests import TestAutoData
 import unittest
-from qlib.config import REG_CN, HIGH_FREQ_CONFIG
 import pandas as pd
 
 

--- a/tests/rolling_tests/test_update_pred.py
+++ b/tests/rolling_tests/test_update_pred.py
@@ -5,7 +5,6 @@ import fire
 import pandas as pd
 
 import qlib
-from qlib.config import REG_CN
 from qlib.data import D
 from qlib.model.trainer import task_train
 from qlib.tests import TestAutoData


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->
After check the global variables in config.py, only REG_CONSTANT is speard around the files.
So I move the REG_CONSTANT to constant.py.
EPS(1e-12) is also suitable to move to constant.

## How Has This Been Tested?
- [x] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):

1. Pipeline test:
<img width="1636" alt="Screen Shot 2022-01-07 at 10 45 40 AM" src="https://user-images.githubusercontent.com/2509830/148483194-1079ccdd-a852-4450-9b07-22c012eaab97.png">

2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
