### PR TITLE
Skip idx.is_lexsorted() when pandas version is larger than 1.3.0. 

### DIFF
--- a/qlib/utils/__init__.py
+++ b/qlib/utils/__init__.py
@@ -1,40 +1,41 @@
-# Copyright (c) Microsoft Corporation.
+Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
 
 from __future__ import division
 from __future__ import print_function
 
-import bisect
-import collections
-import contextlib
-import copy
-import datetime
-import difflib
-import hashlib
-import importlib
-import inspect
-import json
 import os
 import pickle
 import re
-import struct
 import sys
-from pathlib import Path
-from types import ModuleType
-from typing import List, Dict, Union, Tuple, Any, Optional, Callable
-from urllib.parse import urlparse
-
+import copy
+import json
+import yaml
+import redis
+import bisect
+import shutil
+import struct
+import difflib
+import inspect
+import hashlib
+import warnings
+import datetime
+import requests
+import tempfile
+import importlib
+import contextlib
+import collections
 import numpy as np
 import pandas as pd
-import redis
-import requests
-import yaml
-from packaging import version
-
+from pathlib import Path
+from typing import List, Dict, Union, Tuple, Any, Text, Optional, Callable
+from types import ModuleType
+from urllib.parse import urlparse
 from .file import get_or_create_path, save_multiple_parts_file, unpack_archive_with_buffer, get_tmp_file_with_buffer
 from ..config import C
-from ..log import get_module_logger
+from ..log import get_module_logger, set_log_with_config
+from packaging import version
 
 log = get_module_logger("utils")
 # MultiIndex.is_lexsorted() is a deprecated method in Pandas 1.3.0.

--- a/qlib/utils/__init__.py
+++ b/qlib/utils/__init__.py
@@ -41,6 +41,7 @@ log = get_module_logger("utils")
 # MultiIndex.is_lexsorted() is a deprecated method in Pandas 1.3.0.
 is_deprecated_lexsorted_pandas = version.parse(pd.__version__) > version.parse("1.3.0")
 
+
 #################### Server ####################
 def get_redis_connection():
     """get redis connection instance."""

--- a/qlib/utils/__init__.py
+++ b/qlib/utils/__init__.py
@@ -32,10 +32,10 @@ from pathlib import Path
 from typing import List, Dict, Union, Tuple, Any, Text, Optional, Callable
 from types import ModuleType
 from urllib.parse import urlparse
+from packaging import version
 from .file import get_or_create_path, save_multiple_parts_file, unpack_archive_with_buffer, get_tmp_file_with_buffer
 from ..config import C
 from ..log import get_module_logger, set_log_with_config
-from packaging import version
 
 log = get_module_logger("utils")
 # MultiIndex.is_lexsorted() is a deprecated method in Pandas 1.3.0.

--- a/qlib/utils/__init__.py
+++ b/qlib/utils/__init__.py
@@ -38,7 +38,7 @@ from ..log import get_module_logger
 
 log = get_module_logger("utils")
 # MultiIndex.is_lexsorted() is a deprecated method in Pandas 1.3.0.
-is_deprecated_lexsorted_pandas = version.parse(pd.__version__) > version.parse('1.3.0')
+is_deprecated_lexsorted_pandas = version.parse(pd.__version__) > version.parse("1.3.0")
 
 #################### Server ####################
 def get_redis_connection():
@@ -791,7 +791,8 @@ def lazy_sort_index(df: pd.DataFrame, axis=0) -> pd.DataFrame:
     idx = df.index if axis == 0 else df.columns
     # NOTE: MultiIndex.is_lexsorted() is a deprecated method in Pandas 1.3.0 and is suggested to be replaced by MultiIndex.is_monotonic_increasing (see discussion here: https://github.com/pandas-dev/pandas/issues/32259). However, in case older versions of Pandas is implemented, MultiIndex.is_lexsorted() is necessary to prevent certain fatal errors.
     if idx.is_monotonic_increasing and not (
-            isinstance(idx, pd.MultiIndex) and (is_deprecated_lexsorted_pandas or not idx.is_lexsorted())):
+        isinstance(idx, pd.MultiIndex) and (is_deprecated_lexsorted_pandas or not idx.is_lexsorted())
+    ):
         return df
     else:
         return df.sort_index(axis=axis)

--- a/qlib/utils/__init__.py
+++ b/qlib/utils/__init__.py
@@ -1,4 +1,4 @@
-Copyright (c) Microsoft Corporation.
+# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
 

--- a/qlib/utils/__init__.py
+++ b/qlib/utils/__init__.py
@@ -5,39 +5,40 @@
 from __future__ import division
 from __future__ import print_function
 
+import bisect
+import collections
+import contextlib
+import copy
+import datetime
+import difflib
+import hashlib
+import importlib
+import inspect
+import json
 import os
 import pickle
 import re
-import sys
-import copy
-import json
-import yaml
-import redis
-import bisect
-import shutil
 import struct
-import difflib
-import inspect
-import hashlib
-import warnings
-import datetime
-import requests
-import tempfile
-import importlib
-import contextlib
-import collections
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import List, Dict, Union, Tuple, Any, Optional, Callable
+from urllib.parse import urlparse
+
 import numpy as np
 import pandas as pd
-from pathlib import Path
-from typing import List, Dict, Union, Tuple, Any, Text, Optional, Callable
-from types import ModuleType
-from urllib.parse import urlparse
+import redis
+import requests
+import yaml
+from packaging import version
+
 from .file import get_or_create_path, save_multiple_parts_file, unpack_archive_with_buffer, get_tmp_file_with_buffer
 from ..config import C
-from ..log import get_module_logger, set_log_with_config
+from ..log import get_module_logger
 
 log = get_module_logger("utils")
-
+# MultiIndex.is_lexsorted() is a deprecated method in Pandas 1.3.0.
+is_deprecated_lexsorted_pandas = version.parse(pd.__version__) > version.parse('1.3.0')
 
 #################### Server ####################
 def get_redis_connection():
@@ -789,7 +790,8 @@ def lazy_sort_index(df: pd.DataFrame, axis=0) -> pd.DataFrame:
     """
     idx = df.index if axis == 0 else df.columns
     # NOTE: MultiIndex.is_lexsorted() is a deprecated method in Pandas 1.3.0 and is suggested to be replaced by MultiIndex.is_monotonic_increasing (see discussion here: https://github.com/pandas-dev/pandas/issues/32259). However, in case older versions of Pandas is implemented, MultiIndex.is_lexsorted() is necessary to prevent certain fatal errors.
-    if idx.is_monotonic_increasing and not (isinstance(idx, pd.MultiIndex) and not idx.is_lexsorted()):
+    if idx.is_monotonic_increasing and not (
+            isinstance(idx, pd.MultiIndex) and (is_deprecated_lexsorted_pandas or not idx.is_lexsorted())):
         return df
     else:
         return df.sort_index(axis=axis)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Skip idx.is_lexsorted() when pandas version is larger than 1.3.0. 

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->
The future warning of using is_lexsorted is very annoying. Check the pandas version > 1.3.0 or not. Skip the is_lexsorted when the pandas is new enough.

## How Has This Been Tested?
<! ---  Put an `x` in all the boxes that apply: --->
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:
<img width="1702" alt="Screen Shot 2022-03-12 at 5 37 10 PM" src="https://user-images.githubusercontent.com/2509830/158012750-bb0dd952-d642-41f8-aa6f-0cde3c6901aa.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
