### PR TITLE
Use verbose eval callback

### DIFF
--- a/qlib/contrib/model/gbdt.py
+++ b/qlib/contrib/model/gbdt.py
@@ -69,16 +69,17 @@ class LGBModel(ModelFT, LightGBMFInt):
         ds_l = self._prepare_data(dataset, reweighter)
         ds, names = list(zip(*ds_l))
         early_stopping_callback = lgb.early_stopping(
-            stopping_rounds=self.early_stopping_rounds if early_stopping_rounds is None else early_stopping_rounds)
+            stopping_rounds=self.early_stopping_rounds if early_stopping_rounds is None else early_stopping_rounds
+        )
+        verbose_eval_callback = lgb.log_evaluation(period=verbose_eval)
         self.model = lgb.train(
             self.params,
             ds[0],  # training dataset
             num_boost_round=self.num_boost_round if num_boost_round is None else num_boost_round,
             valid_sets=ds,
             valid_names=names,
-            verbose_eval=verbose_eval,
             evals_result=evals_result,
-            callbacks= [early_stopping_callback],
+            callbacks=[early_stopping_callback, verbose_eval_callback],
             **kwargs,
         )
         for k in names:
@@ -110,6 +111,7 @@ class LGBModel(ModelFT, LightGBMFInt):
         dtrain, _ = self._prepare_data(dataset, reweighter)  # pylint: disable=W0632
         if dtrain.empty:
             raise ValueError("Empty data from dataset, please check your dataset config.")
+        verbose_eval_callback = lgb.log_evaluation(period=verbose_eval)
         self.model = lgb.train(
             self.params,
             dtrain,
@@ -117,5 +119,5 @@ class LGBModel(ModelFT, LightGBMFInt):
             init_model=self.model,
             valid_sets=[dtrain],
             valid_names=["train"],
-            verbose_eval=verbose_eval,
+            callbacks=[verbose_eval_callback],
         )

--- a/qlib/contrib/model/gbdt.py
+++ b/qlib/contrib/model/gbdt.py
@@ -68,17 +68,17 @@ class LGBModel(ModelFT, LightGBMFInt):
             evals_result = {}  # in case of unsafety of Python default values
         ds_l = self._prepare_data(dataset, reweighter)
         ds, names = list(zip(*ds_l))
+        early_stopping_callback = lgb.early_stopping(
+            stopping_rounds=self.early_stopping_rounds if early_stopping_rounds is None else early_stopping_rounds)
         self.model = lgb.train(
             self.params,
             ds[0],  # training dataset
             num_boost_round=self.num_boost_round if num_boost_round is None else num_boost_round,
             valid_sets=ds,
             valid_names=names,
-            early_stopping_rounds=(
-                self.early_stopping_rounds if early_stopping_rounds is None else early_stopping_rounds
-            ),
             verbose_eval=verbose_eval,
             evals_result=evals_result,
+            callbacks= [early_stopping_callback],
             **kwargs,
         )
         for k in names:

--- a/qlib/contrib/model/highfreq_gdbt_model.py
+++ b/qlib/contrib/model/highfreq_gdbt_model.py
@@ -113,15 +113,16 @@ class HFLGBModel(ModelFT, LightGBMFInt):
         evals_result=dict(),
     ):
         dtrain, dvalid = self._prepare_data(dataset)
+        verbose_eval_callback = lgb.log_evaluation(period=verbose_eval)
+        early_stopping_callback = lgb.early_stopping(
+            stopping_rounds=self.early_stopping_rounds if early_stopping_rounds is None else early_stopping_rounds)
         self.model = lgb.train(
             self.params,
             dtrain,
             num_boost_round=num_boost_round,
             valid_sets=[dtrain, dvalid],
             valid_names=["train", "valid"],
-            early_stopping_rounds=early_stopping_rounds,
-            verbose_eval=verbose_eval,
-            evals_result=evals_result,
+            callbacks=[early_stopping_callback, verbose_eval_callback],
         )
         evals_result["train"] = list(evals_result["train"].values())[0]
         evals_result["valid"] = list(evals_result["valid"].values())[0]
@@ -147,6 +148,7 @@ class HFLGBModel(ModelFT, LightGBMFInt):
         """
         # Based on existing model and finetune by train more rounds
         dtrain, _ = self._prepare_data(dataset)
+        verbose_eval_callback = lgb.log_evaluation(period=verbose_eval)
         self.model = lgb.train(
             self.params,
             dtrain,
@@ -155,4 +157,5 @@ class HFLGBModel(ModelFT, LightGBMFInt):
             valid_sets=[dtrain],
             valid_names=["train"],
             verbose_eval=verbose_eval,
+            callbacks=[verbose_eval_callback],
         )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use verbose_eval_callback to replace the augment early_stopping_rounds.

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->
The augument, verbose_eval, is suggested to be replaced with verbose_eval_callback in LGBM.

## How Has This Been Tested?
<! ---  Put an `x` in all the boxes that apply: --->
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:
<img width="1606" alt="Screen Shot 2022-03-12 at 7 04 02 PM" src="https://user-images.githubusercontent.com/2509830/158015513-dd9eade8-e877-43bd-a4fe-6911d09e833e.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
