### PR TITLE
Skip idx.is_lexsorted() when pandas version is larger than 1.3.0.

### DIFF
--- a/qlib/utils/__init__.py
+++ b/qlib/utils/__init__.py
@@ -32,11 +32,14 @@ from pathlib import Path
 from typing import List, Dict, Union, Tuple, Any, Text, Optional, Callable
 from types import ModuleType
 from urllib.parse import urlparse
+from packaging import version
 from .file import get_or_create_path, save_multiple_parts_file, unpack_archive_with_buffer, get_tmp_file_with_buffer
 from ..config import C
 from ..log import get_module_logger, set_log_with_config
 
 log = get_module_logger("utils")
+# MultiIndex.is_lexsorted() is a deprecated method in Pandas 1.3.0.
+is_deprecated_lexsorted_pandas = version.parse(pd.__version__) > version.parse("1.3.0")
 
 
 #################### Server ####################
@@ -789,7 +792,9 @@ def lazy_sort_index(df: pd.DataFrame, axis=0) -> pd.DataFrame:
     """
     idx = df.index if axis == 0 else df.columns
     # NOTE: MultiIndex.is_lexsorted() is a deprecated method in Pandas 1.3.0 and is suggested to be replaced by MultiIndex.is_monotonic_increasing (see discussion here: https://github.com/pandas-dev/pandas/issues/32259). However, in case older versions of Pandas is implemented, MultiIndex.is_lexsorted() is necessary to prevent certain fatal errors.
-    if idx.is_monotonic_increasing and not (isinstance(idx, pd.MultiIndex) and not idx.is_lexsorted()):
+    if idx.is_monotonic_increasing and not (
+        isinstance(idx, pd.MultiIndex) and (is_deprecated_lexsorted_pandas or not idx.is_lexsorted())
+    ):
         return df
     else:
         return df.sort_index(axis=axis)

--- a/qlib/utils/__init__.py
+++ b/qlib/utils/__init__.py
@@ -791,13 +791,15 @@ def lazy_sort_index(df: pd.DataFrame, axis=0) -> pd.DataFrame:
         sorted dataframe
     """
     idx = df.index if axis == 0 else df.columns
-    # NOTE: MultiIndex.is_lexsorted() is a deprecated method in Pandas 1.3.0 and is suggested to be replaced by MultiIndex.is_monotonic_increasing (see discussion here: https://github.com/pandas-dev/pandas/issues/32259). However, in case older versions of Pandas is implemented, MultiIndex.is_lexsorted() is necessary to prevent certain fatal errors.
-    if idx.is_monotonic_increasing and not (
-        isinstance(idx, pd.MultiIndex) and (is_deprecated_lexsorted_pandas or not idx.is_lexsorted())
-    ):
-        return df
-    else:
+    if (
+        not idx.is_monotonic_increasing
+        or not is_deprecated_lexsorted_pandas
+        and isinstance(idx, pd.MultiIndex)
+        and not idx.is_lexsorted()
+    ):  # this case is for the old version
         return df.sort_index(axis=axis)
+    else:
+        return df
 
 
 FLATTEN_TUPLE = "_FLATTEN_TUPLE"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Skip idx.is_lexsorted() when pandas version is larger than 1.3.0. 

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->
Check the pandas vesrion first. If the version > 1.3.0, skip the use of is_lexsorted.

## How Has This Been Tested?
<! ---  Put an `x` in all the boxes that apply: --->
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

<img width="1600" alt="Screen Shot 2022-03-12 at 9 25 45 PM" src="https://user-images.githubusercontent.com/2509830/158019695-687ab36c-c0c2-4bd1-b1e4-55b3a3288bfe.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
