### PR TITLE
update cli.py

### DIFF
--- a/qlib/workflow/cli.py
+++ b/qlib/workflow/cli.py
@@ -49,15 +49,17 @@ def workflow(config_path, experiment_name="workflow", uri_folder="mlruns"):
     # config the `sys` section
     sys_config(config, config_path)
 
-    if 'exp_manager' in config.get('qlib_init'):
+    if "exp_manager" in config.get("qlib_init"):
         qlib.init(**config.get("qlib_init"))
     else:
         exp_manager = C["exp_manager"]
-        exp_manager["kwargs"]["uri"] = "file:" + str(Path(os.getcwd()).resolve() / uri_folder)
+        exp_manager["kwargs"]["uri"] = "file:" + str(
+            Path(os.getcwd()).resolve() / uri_folder
+        )
         qlib.init(**config.get("qlib_init"), exp_manager=exp_manager)
 
-    if 'experiment_name' in config:
-        experiment_name = config['experiment_name']   
+    if "experiment_name" in config:
+        experiment_name = config["experiment_name"]
     recorder = task_train(config.get("task"), experiment_name=experiment_name)
     recorder.save_objects(config=config)
 

--- a/qlib/workflow/cli.py
+++ b/qlib/workflow/cli.py
@@ -49,10 +49,15 @@ def workflow(config_path, experiment_name="workflow", uri_folder="mlruns"):
     # config the `sys` section
     sys_config(config, config_path)
 
-    exp_manager = C["exp_manager"]
-    exp_manager["kwargs"]["uri"] = "file:" + str(Path(os.getcwd()).resolve() / uri_folder)
-    qlib.init(**config.get("qlib_init"), exp_manager=exp_manager)
+    if 'exp_manager' in config.get('qlib_init'):
+        qlib.init(**config.get("qlib_init"))
+    else:
+        exp_manager = C["exp_manager"]
+        exp_manager["kwargs"]["uri"] = "file:" + str(Path(os.getcwd()).resolve() / uri_folder)
+        qlib.init(**config.get("qlib_init"), exp_manager=exp_manager)
 
+    if 'experiment_name' in config:
+        experiment_name = config['experiment_name']   
     recorder = task_train(config.get("task"), experiment_name=experiment_name)
     recorder.save_objects(config=config)
 

--- a/qlib/workflow/cli.py
+++ b/qlib/workflow/cli.py
@@ -53,9 +53,7 @@ def workflow(config_path, experiment_name="workflow", uri_folder="mlruns"):
         qlib.init(**config.get("qlib_init"))
     else:
         exp_manager = C["exp_manager"]
-        exp_manager["kwargs"]["uri"] = "file:" + str(
-            Path(os.getcwd()).resolve() / uri_folder
-        )
+        exp_manager["kwargs"]["uri"] = "file:" + str(Path(os.getcwd()).resolve() / uri_folder)
         qlib.init(**config.get("qlib_init"), exp_manager=exp_manager)
 
     if "experiment_name" in config:


### PR DESCRIPTION
update cli.py so that one can specify exp_manager uri in "qlib_init" and "experiment_name" in *.yaml file.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In current workflow, the experiment manager uri will be overridden by the default in cli.py. This update allows the user to specify the uri.

Also, one can specify the experiment_name in yaml file.
## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!---  Put an `x` in all the boxes that apply: --->
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Fix bugs
- [x ] Add new feature
- [ ] Update documentation
