### PR TITLE
Fix Chinese punctuation regex comment

### DIFF
--- a/qlib/utils/__init__.py
+++ b/qlib/utils/__init__.py
@@ -274,7 +274,11 @@ def parse_field(field):
 
     if not isinstance(field, str):
         field = str(field)
-    # Chinese Punctuation Regex: \nff08 = (, \nff09 = ), \nff1a = :, \n3001 = 。
+    # Chinese punctuation regex:
+    # \u3001 -> 、
+    # \uff1a -> ：
+    # \uff08 -> (
+    # \uff09 -> )
     chinese_punctuation_regex = r"\u3001\uff1a\uff08\uff09"
     for pattern, new in [
         (rf"\$\$([\w{chinese_punctuation_regex}]+)", r'PFeature("\1")'),  # $$ must be before $


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix Chinese punctuation regex comment.

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->
The previous comment was wrong and not clear enough.

## How Has This Been Tested?
<!---  Put an `x` in all the boxes that apply: --->
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
