### PR TITLE
fix SepDataFrame when we del it to empty

### DIFF
--- a/qlib/contrib/data/utils/sepdf.py
+++ b/qlib/contrib/data/utils/sepdf.py
@@ -24,6 +24,10 @@ class SepDataFrame:
     SepDataFrame tries to act like a DataFrame whose column with multiindex
     """
 
+    # TODO:
+    # SepDataFrame try to behave like pandas dataframe,  but it is still not them same
+    # Contributions are welcome to make it more complete.
+
     def __init__(self, df_dict: Dict[str, pd.DataFrame], join: str, skip_align=False):
         """
         initialize the data based on the dataframe dictionary
@@ -77,7 +81,11 @@ class SepDataFrame:
 
     def _update_join(self):
         if self.join not in self:
-            self.join = next(iter(self._df_dict.keys()))
+            if len(self._df_dict) > 0:
+                self.join = next(iter(self._df_dict.keys()))
+            else:
+                # NOTE: this will change the behavior of previous reindex when all the keys are empty
+                self.join = None
 
     def __getitem__(self, item):
         # TODO: behave more like pandas when multiindex

--- a/tests/misc/test_sepdf.py
+++ b/tests/misc/test_sepdf.py
@@ -47,8 +47,13 @@ class SepDF(unittest.TestCase):
             two -0.600639 -0.291694}
         """
         self.assertEqual(self.to_str(sdf._df_dict), self.to_str(exp))
-        # self.assertEqual(self.to_str(data.tail()), self.to_str(res))
 
+        del df["g1"]
+        del df["g2"]
+        # it will not raise error, and df will be an empty dataframe
+
+        del sdf["g1"]
+        del sdf["g2"] # sdf should support deleting all the columns
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!---  Put an `x` in all the boxes that apply: --->
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
