### PR TITLE
Fixed a few mixed Chinese punctuation typos

### DIFF
--- a/docs/component/strategy.rst
+++ b/docs/component/strategy.rst
@@ -66,7 +66,7 @@ TopkDropoutStrategy
 - Adopt the ``Topk-Drop`` algorithm to calculate the target amount of each stock
 
     .. note::
-        There are two parameters for the ``Topk-Drop`` algorithm：
+        There are two parameters for the ``Topk-Drop`` algorithm:
 
         - `Topk`: The number of stocks held
         - `Drop`: The number of stocks sold on each trading day

--- a/qlib/config.py
+++ b/qlib/config.py
@@ -102,7 +102,7 @@ _default_config = {
     #   "~/.qlib/stock_data/cn_data"
     #   # dict
     #   {"day": "~/.qlib/stock_data/cn_data", "1min": "~/.qlib/stock_data/cn_data_1min"}
-    # NOTE: provider_uri priority：
+    # NOTE: provider_uri priority:
     #   1. backend_config: backend_obj["kwargs"]["provider_uri"]
     #   2. backend_config: backend_obj["kwargs"]["provider_uri_map"]
     #   3. qlib.init: provider_uri

--- a/qlib/contrib/meta/data_selection/dataset.py
+++ b/qlib/contrib/meta/data_selection/dataset.py
@@ -217,7 +217,7 @@ class MetaDatasetDS(MetaTaskDataset):
         ----------
         task_tpl : Union[dict, list]
             Decide what tasks are used.
-            - dict : the task template， the prepared task is generated with `step`, `trunc_days` and `RollingGen`
+            - dict : the task template, the prepared task is generated with `step`, `trunc_days` and `RollingGen`
             - list : when list, use the list of tasks directly
                      the list is supposed to be sorted according timeline
         step : int

--- a/qlib/contrib/model/pytorch_tabnet.py
+++ b/qlib/contrib/model/pytorch_tabnet.py
@@ -53,7 +53,7 @@ class TabnetModel(Model):
         """
         TabNet model for Qlib
 
-        Args：
+        Args:
         ps: probability to generate the bernoulli mask
         """
         # set hyper-parameters.

--- a/qlib/data/storage/file_storage.py
+++ b/qlib/data/storage/file_storage.py
@@ -24,7 +24,7 @@ class FileStorageMixin:
 
     """
 
-    # NOTE: provider_uri priority：
+    # NOTE: provider_uri priority:
     #   1. self._provider_uri : if provider_uri is provided.
     #   2. provider_uri in qlib.config.C
 

--- a/scripts/dump_bin.py
+++ b/scripts/dump_bin.py
@@ -488,7 +488,7 @@ class DumpDataUpdate(DumpDataBase):
                     except Exception:
                         error_code[futures[_future]] = traceback.format_exc()
                     p_bar.update()
-            logger.info(f"dump bin errors： {error_code}")
+            logger.info(f"dump bin errors: {error_code}")
 
         logger.info("end of features dump.\n")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There are a few Chinese punctuations (`：` and `，`) mixed inadvertently in codes and docs.

This PR fixed those typos by replacing the fullwidth punctuations with the halfwidth forms.

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!---  Put an `x` in all the boxes that apply: --->
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
- [x] Fix typos
