### PR TITLE
fix loc error in double_ensemble sample_reweight()

### DIFF
--- a/qlib/contrib/model/double_ensemble.py
+++ b/qlib/contrib/model/double_ensemble.py
@@ -160,7 +160,7 @@ class DEnsembleModel(Model, FeatureInt):
         h_avg = h.groupby("bins")["h_value"].mean()
         weights = pd.Series(np.zeros(N, dtype=float))
         for i_b, b in enumerate(h_avg.index):
-            weights[h["bins"] == b] = 1.0 / (self.decay**k_th * h_avg[i_b] + 0.1)
+            weights[h["bins"] == b] = 1.0 / (self.decay**k_th * h_avg[b] + 0.1)
         return weights
 
     def feature_selection(self, df_train, loss_values):


### PR DESCRIPTION
I think that's a "[] loc error" in  double_ensemble sample_reweight() function.
Fixed it with slightly changing the index in brackets:  `i_b` -> `b`