### PR TITLE
update SigAnaRecord to allow quantile

### DIFF
--- a/qlib/workflow/record_temp.py
+++ b/qlib/workflow/record_temp.py
@@ -296,7 +296,7 @@ class SigAnaRecord(ACRecordTemp):
         self.ann_scaler = ann_scaler
         self.label_col = label_col
 
-    def _generate(self, label: Optional[pd.DataFrame] = None, **kwargs):
+    def _generate(self, label: Optional[pd.DataFrame] = None, quantile: float = 0.2, **kwargs):
         """
         Parameters
         ----------
@@ -318,7 +318,7 @@ class SigAnaRecord(ACRecordTemp):
         }
         objects = {"ic.pkl": ic, "ric.pkl": ric}
         if self.ana_long_short:
-            long_short_r, long_avg_r = calc_long_short_return(pred.iloc[:, 0], label.iloc[:, self.label_col])
+            long_short_r, long_avg_r = calc_long_short_return(pred.iloc[:, 0], label.iloc[:, self.label_col], quantile=quantile)
             metrics.update(
                 {
                     "Long-Short Ann Return": long_short_r.mean() * self.ann_scaler,


### PR DESCRIPTION
Allow use self defined quantile in calc_long_short_return in SigAnaRecord

add quantile parameter 


## Motivation and Context
default quantile of 0.2 is too large for 1000 symbols, which means 200 transactions.

## How Has This Been Tested?
<!---  Put an `x` in all the boxes that apply: --->
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Fix bugs
- [ x] Add new feature
- [ ] Update documentation
