### PR TITLE
Add simplified download command

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,19 @@ Also, users can install the latest dev version ``Qlib`` by the source code accor
 
 ## Data Preparation
 Load and prepare data by running the following code:
+
+### Get with module
+  ```bash
+  # get 1d data
+  python -m qlib.run.get_data qlib_data --target_dir ~/.qlib/qlib_data/cn_data --region cn
+
+  # get 1min data
+  python -m qlib.run.get_data qlib_data --target_dir ~/.qlib/qlib_data/cn_data_1min --region cn --interval 1min
+
+  ```
+
+### Get from source
+
   ```bash
   # get 1d data
   python scripts/get_data.py qlib_data --target_dir ~/.qlib/qlib_data/cn_data --region cn

--- a/qlib/run/get_data.py
+++ b/qlib/run/get_data.py
@@ -1,0 +1,9 @@
+#  Copyright (c) Microsoft Corporation.
+#  Licensed under the MIT License.
+
+import fire
+from qlib.tests.data import GetData
+
+
+if __name__ == "__main__":
+    fire.Fire(GetData)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Solve issues "Simplify the command to download the data #1232"

## Description
<!--- Describe your changes in detail -->
Follow the above issue, simplified the command like this:
1. Install Qlib
2. Run qlib module to download data like this `python -m qlib.XXX.get_data qlib_data --target_dir ~/.qlib/qlib_data/cn_data --region cn`

And update documetation.

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!---  Put an `x` in all the boxes that apply: --->
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [X] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:
![simplified_download](https://user-images.githubusercontent.com/32811724/181193426-c82981fe-a625-4bf0-bfdd-09d0606c4b25.PNG)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Fix bugs
- [X] Add new feature
- [X] Update documentation