### PR TITLE
fixes #1187 error  "Please install necessary libs for CatBoostModel."

### DIFF
--- a/qlib/contrib/model/__init__.py
+++ b/qlib/contrib/model/__init__.py
@@ -4,7 +4,7 @@ try:
     from .catboost_model import CatBoostModel
 except ModuleNotFoundError:
     CatBoostModel = None
-    print("ModuleNotFoundError. CatBoostModel and CatBoostModel are skipped. (optional: maybe installing lightgbm can fix it.)")
+    print("ModuleNotFoundError. CatBoostModel are skipped. (optional: maybe installing CatBoostModel can fix it.)")
 try:
     from .double_ensemble import DEnsembleModel
     from .gbdt import LGBModel

--- a/qlib/contrib/model/__init__.py
+++ b/qlib/contrib/model/__init__.py
@@ -4,7 +4,7 @@ try:
     from .catboost_model import CatBoostModel
 except ModuleNotFoundError:
     CatBoostModel = None
-    print("Please install necessary libs for CatBoostModel.")
+    print("ModuleNotFoundError. CatBoostModel and CatBoostModel are skipped. (optional: maybe installing lightgbm can fix it.)")
 try:
     from .double_ensemble import DEnsembleModel
     from .gbdt import LGBModel


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When running 'examples/workflow_by_code.ipynb' in jupyter notebook , you get the following misleading error #1187

![177905185-57a43596-b180-4c52-8df9-0e88b95640b4](https://user-images.githubusercontent.com/72355098/182694858-0cf4897a-80c8-4046-b078-b613e1217b86.png)


now the message displayed when running the code is "ModuleNotFoundError. CatBoostModel and CatBoostModel are skipped. (optional: maybe installing lightgbm can fix it.)" that is similar to the other non mandatory packages to install.

## Motivation and Context
check #

## How Has This Been Tested?
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.


## Screenshots of Test Results (if appropriate):


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Fix bugs
- [ ] Add new feature
- [ ] Update documentation


