### PR TITLE
fix dump_bin

### DIFF
--- a/scripts/dump_bin.py
+++ b/scripts/dump_bin.py
@@ -219,6 +219,9 @@ class DumpDataBase:
             return
         # align index
         _df = self.data_merge_calendar(df, calendar_list)
+        if _df.empty:
+            logger.warning(f"{features_dir.name} data is not in calendars")
+            return
         # used when creating a bin file
         date_index = self.get_datetime_index(_df, calendar_list)
         for field in self.get_dump_fields(_df.columns):


### PR DESCRIPTION
dump_fix data that not in calendar_list, throw error:
```
NaT is not in list
```

if first data with **dump_all** like:
```
date,open
2000-01-04,111
2000-01-05,222
2000-01-06,333
```
and then second with **dump_fix** like:
```
date,open
2000-01-01,111
2000-01-02,222
2000-01-03,333
```
it will cause **_df** to be empty,and cause error(because df not in calendar_list range):
```
_df = self.data_merge_calendar(df, calendar_list)
```

**i know even this pull request ,old data still not be update to bin,it just a way to catch and give message for such data**