### PR TITLE
Add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.8-buster
+
+RUN apt-get update && apt-get install -y git psmisc zip gcc g++
+COPY . /qlib
+RUN  pip install numpy && pip install --upgrade cython && pip install notebook \
+   && cd /qlib/ && pip install . 
+RUN cd /tmp && wget https://github.com/chenditc/investment_data/releases/download/2022-09-05/qlib_bin.tar.gz \
+   && mkdir -p ~/.qlib/qlib_data/cn_data && tar -zxvf qlib_bin.tar.gz -C ~/.qlib/qlib_data/cn_data --strip-components=2 \
+   && rm -f qlib_bin.tar.gz
+ENV JUPYTER_TOKEN=qlib
+WORKDIR /qlib
+CMD [ "jupyter", "notebook", "--allow-root", "--ip", "'*'"]


### PR DESCRIPTION
Add a dockerfile to package latest qlib code, jupyter notebook and qlib dataset. So that user can use one line to start playing with qlib:

```
docker run --rm -it -p 8888:8888 microsoft/qlib
```

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->
Some time I want to experiment some computational expensive model, I would like to use Azure spot instance. If there is a docker image, the process can be much easier. User can user VM's user data to run this one line and start using it.

## How Has This Been Tested?
<!---  Put an `x` in all the boxes that apply: --->
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

I build the image and run locally, which works fine.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Fix bugs
- [x] Add new feature
- [ ] Update documentation
