### PR TITLE
Fix `_update_dealt_order_amount` bug.

### DIFF
--- a/qlib/backtest/utils.py
+++ b/qlib/backtest/utils.py
@@ -183,8 +183,8 @@ class TradeCalendarManager:
         Tuple[int, int]:
             the index of the range.  **the left and right are closed**
         """
-        left = np.searchsorted(self._calendar, start_time, side="right") - 1
-        right = np.searchsorted(self._calendar, end_time, side="right") - 1
+        left = int(np.searchsorted(self._calendar, start_time, side="right") - 1)
+        right = int(np.searchsorted(self._calendar, end_time, side="right") - 1)
         left -= self.start_index
         right -= self.start_index
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fix the bug in `SimulatorExecutor._collect_data`. Maintain `self.dealt_order_amount` before dealing with the order.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!---  Put an `x` in all the boxes that apply: --->
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
