### PR TITLE
Add customized alpha for customized EMA.

### DIFF
--- a/qlib/data/ops.py
+++ b/qlib/data/ops.py
@@ -1368,8 +1368,9 @@ class EMA(Rolling):
         a feature instance with regression r-value square of given window
     """
 
-    def __init__(self, feature, N):
+    def __init__(self, feature, N, alpha: float = None):
         super(EMA, self).__init__(feature, N, "ema")
+        self.alpha = alpha
 
     def _load_internal(self, instrument, start_index, end_index, *args):
         series = self.feature.load(instrument, start_index, end_index, *args)
@@ -1384,6 +1385,8 @@ class EMA(Rolling):
             series = series.expanding(min_periods=1).apply(exp_weighted_mean, raw=True)
         elif 0 < self.N < 1:
             series = series.ewm(alpha=self.N, min_periods=1).mean()
+        elif self.alpha and 0 < self.alpha < 1:
+            series = series.ewm(alpha=self.alpha, min_periods=1).mean()
         else:
             series = series.ewm(span=self.N, min_periods=1).mean()
         return series


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add customized alpha for EMA.

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->
Some SW use ema to calculate RSI. But they use alpha=1/N, N=period not spans=N.
See https://github.com/ChiahungTai/MyTT/blob/main/MyTT.py#L150 and https://github.com/ChiahungTai/MyTT/blob/main/MyTT.py#L65.
I also confirm the SW I used for TW stock market use the same formula to calculate RSI.

## How Has This Been Tested?
<!---  Put an `x` in all the boxes that apply: --->
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Fix bugs
- [x] Add new feature
- [ ] Update documentation
