### PR TITLE
Don't disable existing logger when initializing qlib.

### DIFF
--- a/qlib/config.py
+++ b/qlib/config.py
@@ -172,6 +172,7 @@ _default_config = {
             }
         },
         "loggers": {"qlib": {"level": logging.DEBUG, "handlers": ["console"]}},
+        "disable_existing_loggers": False
     },
     # Default config for experiment manager
     "exp_manager": {

--- a/qlib/config.py
+++ b/qlib/config.py
@@ -172,6 +172,8 @@ _default_config = {
             }
         },
         "loggers": {"qlib": {"level": logging.DEBUG, "handlers": ["console"]}},
+        # To let qlib work with other packages, we shouldn't disable existing loggers.
+        # Note that this param is default to True according to the documentation of logging.
         "disable_existing_loggers": False,
     },
     # Default config for experiment manager

--- a/qlib/config.py
+++ b/qlib/config.py
@@ -172,7 +172,7 @@ _default_config = {
             }
         },
         "loggers": {"qlib": {"level": logging.DEBUG, "handlers": ["console"]}},
-        "disable_existing_loggers": False
+        "disable_existing_loggers": False,
     },
     # Default config for experiment manager
     "exp_manager": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add following config line to logging_config to prevent disabling the existing logger.
```
"disable_existing_loggers": False
```
Without this line, loggers from other code will be disabled.

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->
When using qlib with other services and apps, loggers from other services will be disabled after qlib initialization. This is not friendly to collaborate with other packages.

## How Has This Been Tested?
<!---  Put an `x` in all the boxes that apply: --->
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
