### PR TITLE
Sometimes the set of C.exp_manager["kwargs"]["uri"] will not take effect

### DIFF
--- a/qlib/workflow/__init__.py
+++ b/qlib/workflow/__init__.py
@@ -370,11 +370,11 @@ class QlibRecorder:
             the temporal uri
         """
         prev_uri = self.exp_manager.default_uri
-        C.exp_manager["kwargs"]["uri"] = uri
+        self.set_uri(uri)
         try:
             yield
         finally:
-            C.exp_manager["kwargs"]["uri"] = prev_uri
+            self.set_uri(prev_uri)
 
     def get_recorder(
         self,

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ REQUIRED = [
     "matplotlib>=3.3",
     "tables>=3.6.1",
     "pyyaml>=5.3.1",
-    "mlflow>=1.12.1",
+    "mlflow==1.28.0",
     "tqdm",
     "loguru",
     "lightgbm>=3.3.0",

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ REQUIRED = [
     "matplotlib>=3.3",
     "tables>=3.6.1",
     "pyyaml>=5.3.1",
-    "mlflow==1.30.0",
+    "mlflow>=1.12.1, <=1.30.0",
     "tqdm",
     "loguru",
     "lightgbm>=3.3.0",

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ REQUIRED = [
     "matplotlib>=3.3",
     "tables>=3.6.1",
     "pyyaml>=5.3.1",
-    "mlflow==1.28.0",
+    "mlflow==1.30.0",
     "tqdm",
     "loguru",
     "lightgbm>=3.3.0",


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Sometime with R.uri_context(uri=uri_path): will not be worked.
After digging the problem. The yield self is not set uri to the temporaril uri.

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->
Bug fix

## How Has This Been Tested?
<!---  Put an `x` in all the boxes that apply: --->
- [x] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
