### PR TITLE
Set _artifact_uri when mlflow_run is not None.

### DIFF
--- a/qlib/workflow/recorder.py
+++ b/qlib/workflow/recorder.py
@@ -279,6 +279,7 @@ class MLflowRecorder(Recorder):
                 if mlflow_run.info.end_time is not None
                 else None
             )
+            self._artifact_uri = mlflow_run.info.artifact_uri
         self.async_log = None
 
     def __repr__(self):

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -16,8 +16,7 @@ class WorkflowTest(TestAutoData):
             shutil.rmtree(self.TMP_PATH)
 
     def test_get_local_dir(self):
-        """
-        """
+        """ """
         with R.start(uri=str(self.TMP_PATH)):
             pass
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,30 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+import unittest
+from pathlib import Path
+import shutil
+
+from qlib.workflow import R
+from qlib.tests import TestAutoData
+
+
+class WorkflowTest(TestAutoData):
+    TMP_PATH = Path("./.mlruns_tmp/")
+
+    def tearDown(self) -> None:
+        if self.TMP_PATH.exists():
+            shutil.rmtree(self.TMP_PATH)
+
+    def test_get_local_dir(self):
+        """
+        """
+        with R.start(uri=str(self.TMP_PATH)):
+            pass
+
+        with R.uri_context(uri=str(self.TMP_PATH)):
+            resume_recorder = R.get_recorder()
+            resume_recorder.get_local_dir()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The _artifact_uri is forget be set in MLflowRecorder construtor. Set _artifact_uri when mlflow_run is not None.

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->
This bug will cause we can load_object from existed uri_path.


## How Has This Been Tested?
<!---  Put an `x` in all the boxes that apply: --->
- [x] Pass the test by running: `pytest qlib/tests/test_workflow.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
