### PR TITLE
optimize_yahoo_collector

### DIFF
--- a/scripts/data_collector/yahoo/collector.py
+++ b/scripts/data_collector/yahoo/collector.py
@@ -222,8 +222,8 @@ class YahooCollectorCN1d(YahooCollectorCN):
         # TODO: from MSN
         _format = "%Y%m%d"
         _begin = self.start_datetime.strftime(_format)
-        _end = (self.end_datetime + pd.Timedelta(days=-1)).strftime(_format)
-        for _index_name, _index_code in {"csi300": "000300", "csi100": "000903"}.items():
+        _end = self.end_datetime.strftime(_format)
+        for _index_name, _index_code in {"csi300": "000300", "csi100": "000903", "csi500": "000905"}.items():
             logger.info(f"get bench data: {_index_name}({_index_code})......")
             try:
                 df = pd.DataFrame(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pr is optimized for two problems:
1. The index data obtained by yahoo collector has a maximum date that is two days ahead of the end_data passed in the command line.
2. The index data obtained by yahoo collector does not include the csi500 data ([issue1323](https://github.com/microsoft/qlib/issues/1323)).