### PR TITLE
The limit threshold in Taiwan stock market is also 10%.

### DIFF
--- a/qlib/backtest/exchange.py
+++ b/qlib/backtest/exchange.py
@@ -18,7 +18,7 @@ import pandas as pd
 from qlib.backtest.position import BasePosition
 
 from ..config import C
-from ..constant import REG_CN
+from ..constant import REG_CN, REG_TW
 from ..data.data import D
 from ..log import get_module_logger
 from .decision import Order, OrderDir, OrderHelper
@@ -151,7 +151,7 @@ class Exchange:
             if C.region == REG_CN:
                 self.logger.warning(f"limit_threshold not set. The stocks hit the limit may be bought/sold")
         elif self.limit_type == self.LT_FLT and abs(cast(float, limit_threshold)) > 0.1:
-            if C.region == REG_CN:
+            if C.region in [REG_CN, REG_TW]:
                 self.logger.warning(f"limit_threshold may not be set to a reasonable value")
 
         if isinstance(deal_price, str):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A simple check for limit threshold in TW exchange.

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->
The limit threshold in Taiwan stock market is also 10%.

## How Has This Been Tested?
<!---  Put an `x` in all the boxes that apply: --->
- [x] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
