### PR TITLE
Fix ZScoreNorm processor bug

### DIFF
--- a/.github/workflows/test_qlib_from_source.yml
+++ b/.github/workflows/test_qlib_from_source.yml
@@ -140,8 +140,7 @@ jobs:
 
     - name: Test workflow by config (install from source)
       run: |
-        # Version 0.52.0 of numba must be installed manually in CI, otherwise it will cause incompatibility with the latest version of numpy.
-        python -m pip install numba==0.52.0
+        python -m pip install numba
         # You must update numpy manually, because when installing python tools, it will try to uninstall numpy and cause CI to fail.
         python -m pip install --upgrade numpy
         python qlib/workflow/cli.py examples/benchmarks/LightGBM/workflow_config_lightgbm_Alpha158.yaml

--- a/.github/workflows/test_qlib_from_source.yml
+++ b/.github/workflows/test_qlib_from_source.yml
@@ -141,8 +141,6 @@ jobs:
     - name: Test workflow by config (install from source)
       run: |
         python -m pip install numba
-        # You must update numpy manually, because when installing python tools, it will try to uninstall numpy and cause CI to fail.
-        python -m pip install --upgrade numpy
         python qlib/workflow/cli.py examples/benchmarks/LightGBM/workflow_config_lightgbm_Alpha158.yaml
 
     - name: Unit tests with Pytest

--- a/qlib/data/dataset/processor.py
+++ b/qlib/data/dataset/processor.py
@@ -250,7 +250,7 @@ class ZScoreNorm(Processor):
                 return (x - mean_train) / std_train
             for i in range(ignore.size):
                 if not ignore[i]:
-                    x[i] = (x[i] - mean_train) / std_train
+                    x[:, i] = (x[:, i] - mean_train[i]) / std_train[i]
             return x
 
         df.loc(axis=1)[self.cols] = normalize(df[self.cols].values)

--- a/qlib/data/dataset/processor.py
+++ b/qlib/data/dataset/processor.py
@@ -244,7 +244,6 @@ class ZScoreNorm(Processor):
         cols = get_group_columns(df, self.fields_group)
         self.mean_train = np.nanmean(df[cols].values, axis=0)
         self.std_train = np.nanstd(df[cols].values, axis=0)
-        print("Processors.py", self.mean_train, self.std_train)
         self.ignore = self.std_train == 0
         # To improve the speed, we set the value of `std_train` to `1` for the columns that do not need to be processed,
         # and the value of `mean_train` to `0`, when using `(x - mean_train) / std_train` for uniform calculation,

--- a/qlib/data/dataset/processor.py
+++ b/qlib/data/dataset/processor.py
@@ -211,8 +211,8 @@ class MinMaxNorm(Processor):
         self.min_val = np.nanmin(df[cols].values, axis=0)
         self.max_val = np.nanmax(df[cols].values, axis=0)
         self.ignore = self.min_val == self.max_val
-        for _i in range(len(self.ignore)):
-            if self.ignore[_i]:
+        for _i, _con in enumerate(self.ignore):
+            if _con:
                 self.min_val[_i] = 0
                 self.max_val[_i] = 1
         self.cols = cols
@@ -241,8 +241,8 @@ class ZScoreNorm(Processor):
         self.mean_train = np.nanmean(df[cols].values, axis=0)
         self.std_train = np.nanstd(df[cols].values, axis=0)
         self.ignore = self.std_train == 0
-        for _i in range(len(self.ignore)):
-            if self.ignore[_i]:
+        for _i, _con in enumerate(self.ignore):
+            if _con:
                 self.std_train[_i] = 1
                 self.mean_train[_i] = 0
         self.cols = cols

--- a/qlib/data/dataset/processor.py
+++ b/qlib/data/dataset/processor.py
@@ -367,7 +367,7 @@ class CSZFillna(Processor):
 
     def __call__(self, df):
         cols = get_group_columns(df, self.fields_group)
-        df[cols] = df[cols].groupby("datetime", group_keys=False).apply(lambda x: x.fillna(df[cols].mean()))
+        df[cols] = df[cols].groupby("datetime", group_keys=False).apply(lambda x: x.fillna(x.mean()))
         return df
 
 

--- a/qlib/data/dataset/processor.py
+++ b/qlib/data/dataset/processor.py
@@ -244,6 +244,7 @@ class ZScoreNorm(Processor):
         cols = get_group_columns(df, self.fields_group)
         self.mean_train = np.nanmean(df[cols].values, axis=0)
         self.std_train = np.nanstd(df[cols].values, axis=0)
+        print("Processors.py", self.mean_train, self.std_train)
         self.ignore = self.std_train == 0
         # To improve the speed, we set the value of `std_train` to `1` for the columns that do not need to be processed,
         # and the value of `mean_train` to `0`, when using `(x - mean_train) / std_train` for uniform calculation,

--- a/setup.py
+++ b/setup.py
@@ -156,7 +156,14 @@ setup(
             "baostock",
             "yahooquery",
             "beautifulsoup4",
-            "tianshou",
+            # In version 0.4.11 of tianshou, the code:
+            # logits, hidden = self.actor(batch.obs, state=state, info=batch.info)
+            # was changed in PR787,
+            # which causes pytest errors(AttributeError: 'dict' object has no attribute 'info') in CI,
+            # so we restricted the version of tianshou.
+            # References:
+            # https://github.com/thu-ml/tianshou/releases
+            "tianshou<=0.4.10",
             "gym>=0.24",  # If you do not put gym at the end, gym will degrade causing pytest results to fail.
         ],
         "rl": [

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -29,7 +29,8 @@ class TestProcessor(TestAutoData):
         assert (df.tail(5).iloc[:, :-1] != origin_df.tail(5).iloc[:, :-1]).all().all()
 
     def test_CSZFillna(self):
-        origin_df = D.features([self.TEST_INST], fields=["$high", "$open", "$low", "$close"])[113:118]
+        origin_df = D.features(D.instruments(market="csi300"), fields=["$high", "$open", "$low", "$close"])
+        origin_df = origin_df.groupby("datetime", group_keys=False).apply(lambda x: x[97:99])[228:238]
         df = origin_df.copy()
         CSZFillna(fields_group=None).__call__(df)
         assert ~((origin_df == df)[1:2].all().all())

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,0 +1,66 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import io
+import unittest
+import pandas as pd
+from qlib.data import D
+from qlib.tests import TestAutoData
+from qlib.data.dataset.processor import MinMaxNorm, ZScoreNorm, CSZScoreNorm, CSZFillna
+
+
+class TestProcessor(TestAutoData):
+    TEST_INST = "SH600519"
+
+    def test_MinMaxNorm(self):
+        origin_df = D.features([self.TEST_INST], ["$high", "$open", "$low", "$close"]).tail(10)
+        origin_df["test"] = 0
+        df = origin_df.copy()
+        mmn = MinMaxNorm(fields_group=None, fit_start_time="2021-05-31", fit_end_time="2021-06-11")
+        mmn.fit(df)
+        mmn.__call__(df)
+        assert (df.tail(5).iloc[:, :-1] != origin_df.tail(5).iloc[:, :-1]).all().all()
+
+    def test_ZScoreNorm(self):
+        origin_df = D.features([self.TEST_INST], ["$high", "$open", "$low", "$close"]).tail(10)
+        origin_df["test"] = 0
+        df = origin_df.copy()
+        zsn = ZScoreNorm(fields_group=None, fit_start_time="2021-05-31", fit_end_time="2021-06-11")
+        zsn.fit(df)
+        zsn.__call__(df)
+        assert (df.tail(5).iloc[:, :-1] != origin_df.tail(5).iloc[:, :-1]).all().all()
+
+    def test_CSZFillna(self):
+        st = """
+        2000-01-01,1,2
+        2000-01-02,,4
+        2000-01-03,5,6
+        """
+        origin_df = pd.read_csv(io.StringIO(st), header=None)
+        origin_df.columns = ["datetime", "a", "b"]
+        origin_df.set_index("datetime", inplace=True, drop=True)
+        df = origin_df.copy()
+        CSZFillna(fields_group=None).__call__(df)
+        assert ~((origin_df == df).iloc[1, 0])
+
+    def test_CSZScoreNorm(self):
+        st = """
+        2000-01-01,1,2
+        2000-01-02,3,4
+        2000-01-03,5,6
+        """
+        origin_df = pd.read_csv(io.StringIO(st), header=None)
+        origin_df.columns = ["datetime", "a", "b"]
+        origin_df.set_index("datetime", inplace=True, drop=True)
+        df = origin_df.copy()
+        CSZScoreNorm(fields_group=None).__call__(df)
+        assert (df == ((origin_df - origin_df.mean()).div(origin_df.std()))).all().all()
+
+
+def suite():
+    _suite = unittest.TestSuite()
+    _suite.addTest(TestProcessor("test_MinMaxNorm"))
+    _suite.addTest(TestProcessor("test_ZScoreNorm"))
+    _suite.addTest(TestProcessor("test_CSZFillna"))
+    _suite.addTest(TestProcessor("test_CSZScoreNorm"))
+    return _suite

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -12,41 +12,62 @@ class TestProcessor(TestAutoData):
     TEST_INST = "SH600519"
 
     def test_MinMaxNorm(self):
+        def normalize(df):
+            min_val = np.nanmin(df.values, axis=0)
+            max_val = np.nanmax(df.values, axis=0)
+            ignore = min_val == max_val
+            for _i, _con in enumerate(ignore):
+                if _con:
+                    max_val[_i] = 1
+                    min_val[_i] = 0
+            df.loc(axis=1)[df.columns] = (df.values - min_val) / (max_val - min_val)
+            return df
+
         origin_df = D.features([self.TEST_INST], ["$high", "$open", "$low", "$close"]).tail(10)
         origin_df["test"] = 0
         df = origin_df.copy()
         mmn = MinMaxNorm(fields_group=None, fit_start_time="2021-05-31", fit_end_time="2021-06-11")
         mmn.fit(df)
         mmn.__call__(df)
-        min_val = np.nanmin(origin_df.values, axis=0)
-        max_val = np.nanmax(origin_df.values, axis=0)
-        origin_df.loc(axis=1)[origin_df.columns] = (origin_df.values - min_val) / (max_val - min_val)
-        assert (df.iloc[:, :-1] == origin_df.iloc[:, :-1]).all().all()
+        origin_df = normalize(origin_df)
+        assert (df == origin_df).all().all()
 
     def test_ZScoreNorm(self):
+        def normalize(df):
+            mean_train = np.nanmean(df.values, axis=0)
+            std_train = np.nanstd(df.values, axis=0)
+            ignore = std_train == 0
+            for _i, _con in enumerate(ignore):
+                if _con:
+                    std_train[_i] = 1
+                    mean_train[_i] = 0
+            df.loc(axis=1)[df.columns] = (df.values - mean_train) / std_train
+            return df
+
         origin_df = D.features([self.TEST_INST], ["$high", "$open", "$low", "$close"]).tail(10)
         origin_df["test"] = 0
         df = origin_df.copy()
         zsn = ZScoreNorm(fields_group=None, fit_start_time="2021-05-31", fit_end_time="2021-06-11")
         zsn.fit(df)
         zsn.__call__(df)
-        mean_train = np.nanmean(origin_df.values, axis=0)
-        std_train = np.nanstd(origin_df.values, axis=0)
-        origin_df.loc(axis=1)[origin_df.columns] = (origin_df.values - mean_train) / std_train
-        assert (df.iloc[:, :-1] == origin_df.iloc[:, :-1]).all().all()
+        origin_df = normalize(origin_df)
+        assert (df == origin_df).all().all()
 
     def test_CSZFillna(self):
         origin_df = D.features(D.instruments(market="csi300"), fields=["$high", "$open", "$low", "$close"])
         origin_df = origin_df.groupby("datetime", group_keys=False).apply(lambda x: x[97:99])[228:238]
         df = origin_df.copy()
         CSZFillna(fields_group=None).__call__(df)
-        assert ~((origin_df == df)[1:2].all().all())
+        assert ~df[1:2].isna().all().all() and origin_df[1:2].isna().all().all()
 
     def test_CSZScoreNorm(self):
         origin_df = D.features(D.instruments(market="csi300"), fields=["$high", "$open", "$low", "$close"])
-        origin_df = origin_df.groupby("datetime", group_keys=False).apply(lambda x: x[10:12])[50:70]
+        origin_df = origin_df.groupby("datetime", group_keys=False).apply(lambda x: x[10:12])[50:60]
         df = origin_df.copy()
         CSZScoreNorm(fields_group=None).__call__(df)
+        # If we use the formula directly on the original data, we cannot get the correct result,
+        # because the original data is processed by `groupby`, so we use the method of slicing,
+        # taking the 2nd group of data from the original data, to calculate and compare.
         assert (df[2:4] == ((origin_df[2:4] - origin_df[2:4].mean()).div(origin_df[2:4].std()))).all().all()
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Because the version of numba is limited to 0.52.0, some old code(e.g. np.long) in numba can not adapt to the new version of numpy, resulting in CI failure, so update numba to the latest version to solve the CI problem.
