### PR TITLE
fix_labeler_bug

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,6 @@
 documentation:
 - 'docs/**/*'
-- '*/**/*.md'
-- '*.md'
+- '**/*.md'
 
 waiting for triage:
-- all: ['!docs/**/*', '!*/**/*.md', '!*.md']
+- any: ['**/*', '!docs/**/*', '!**/*.md']


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The official documentation does not give an example of using `- all` alone, so I analyzed that using `- all` alone in the matching rules is wrong, so I turned `- all` into `- any`, and inferred from the official documentation that the relationship between the matching rules in the `- any` list is `and`.
The matching rules in the `documentation` are related to each other as `or`.

Trigger waiting for triage label: If a file in the entire repository is modified, and the modified file is neither all files in the docs folder nor all .md files in the entire repository, the `waiting for triage` label will be added.

Trigger documentation label: If all files in the docs folder are modified, or if the entire repository .md file is modified, the documentation label will be added.

I have tested this [here](https://github.com/SunsetWolf/qlib/pull/6).
The official labeler documentation is [here](https://github.com/actions/labeler).
