### PR TITLE
Fix: QlibDataLoader drops the cols added by inst_processor

### DIFF
--- a/qlib/data/dataset/loader.py
+++ b/qlib/data/dataset/loader.py
@@ -211,7 +211,7 @@ class QlibDataLoader(DLWParser):
         df = D.features(
             instruments, exprs, start_time, end_time, freq=freq, inst_processors=self.inst_processor.get(gp_name, [])
         )
-        df.columns = names
+        df.rename(columns=dict(zip(exprs, names)), inplace=True)
         if self.swap_level:
             df = df.swaplevel().sort_index()  # NOTE: if swaplevel, return <datetime, instrument>
         return df


### PR DESCRIPTION
Fix: QlibDataLoader drops the cols added by inst_processor

## Description
When `inst_processor` creates new columns, the `QlibDataLoader` drops them.

## Motivation and Context

## How Has This Been Tested?
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
- [ X] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
