### PR TITLE
Update utils.py

### DIFF
--- a/qlib/backtest/utils.py
+++ b/qlib/backtest/utils.py
@@ -82,7 +82,15 @@ class TradeCalendarManager:
         - If self.trade_step >= self.self.trade_len, it means the trading is finished
         - If self.trade_step < self.self.trade_len, it means the number of trading step finished is self.trade_step
         """
-        return self.trade_step >= self.trade_len
+        """
+        In /contrib/strategy/signal_strategy.py,
+        it comments 
+        "get the number of trading step finished, trade_step can be [0, 1, 2, ..., trade_len - 1]"
+        If set finished == self.trade_step >= self.trade_len it will raise IndexError: index X is out of bounds for axis 0 with size X.
+        I think change self.trade_len = _end_index - _start_index + 1 to self.trade_len = _end_index - _start_index maybe better, but it may
+        result other errors.
+        """
+        return self.trade_step >= self.trade_len - 1
 
     def step(self) -> None:
         if self.finished():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In /contrib/strategy/signal_strategy.py,
        it comments 
        "get the number of trading step finished, trade_step can be [0, 1, 2, ..., trade_len - 1]"
        If set finished == self.trade_step >= self.trade_len it will raise IndexError: index X is out of bounds for axis 0 with size X.
        I think change self.trade_len = _end_index - _start_index + 1 to self.trade_len = _end_index - _start_index maybe better, but it may result in other errors.

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!---  Put an `x` in all the boxes that apply: --->
- [x] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
