### PR TITLE
Fix configuration example

### DIFF
--- a/docs/component/rl/quickstart.rst
+++ b/docs/component/rl/quickstart.rst
@@ -54,9 +54,9 @@ QlibRL provides an example of an implementation of a single asset order executio
             # number of time indexes
             total_time: 240
             # start time index
-            default_start_time: 0
+            default_start_time_index: 0
             # end time index
-            default_end_time: 240
+            default_end_time_index: 240
             proc_data_dim: 6
         num_workers: 0
         queue_size: 20


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The configuration example in the documentation provides keys different from what the code at [train_onpolicy.py] (https://github.com/microsoft/qlib/blob/main/qlib/rl/contrib/train_onpolicy.py) (linesuses, causing a `KeyError`

## Motivation and Context
Documentation fixing

## How Has This Been Tested?
`KeyError` no longer raised if the keys are changed in the configuration

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Fix bugs
- [ ] Add new feature
- [x] Update documentation
