### PR TITLE
Remove unused `DNNModelPytorch` params

### DIFF
--- a/examples/benchmarks/MLP/workflow_config_mlp_Alpha158.yaml
+++ b/examples/benchmarks/MLP/workflow_config_mlp_Alpha158.yaml
@@ -64,8 +64,6 @@ task:
         kwargs:
             loss: mse
             lr: 0.002
-            lr_decay: 0.96
-            lr_decay_steps: 100
             optimizer: adam
             max_steps: 8000
             batch_size: 8192

--- a/examples/benchmarks/MLP/workflow_config_mlp_Alpha158_csi500.yaml
+++ b/examples/benchmarks/MLP/workflow_config_mlp_Alpha158_csi500.yaml
@@ -64,8 +64,6 @@ task:
         kwargs:
             loss: mse
             lr: 0.002
-            lr_decay: 0.96
-            lr_decay_steps: 100
             optimizer: adam
             max_steps: 8000
             batch_size: 8192

--- a/examples/benchmarks/MLP/workflow_config_mlp_Alpha360.yaml
+++ b/examples/benchmarks/MLP/workflow_config_mlp_Alpha360.yaml
@@ -52,8 +52,6 @@ task:
         kwargs:
             loss: mse
             lr: 0.002
-            lr_decay: 0.96
-            lr_decay_steps: 100
             optimizer: adam
             max_steps: 8000
             batch_size: 4096

--- a/examples/benchmarks/MLP/workflow_config_mlp_Alpha360_csi500.yaml
+++ b/examples/benchmarks/MLP/workflow_config_mlp_Alpha360_csi500.yaml
@@ -52,8 +52,6 @@ task:
         kwargs:
             loss: mse
             lr: 0.002
-            lr_decay: 0.96
-            lr_decay_steps: 100
             optimizer: adam
             max_steps: 8000
             batch_size: 4096

--- a/qlib/contrib/model/pytorch_nn.py
+++ b/qlib/contrib/model/pytorch_nn.py
@@ -47,10 +47,6 @@ class DNNModelPytorch(Model):
         layer sizes
     lr : float
         learning rate
-    lr_decay : float
-        learning rate decay
-    lr_decay_steps : int
-        learning rate decay steps
     optimizer : str
         optimizer name
     GPU : int
@@ -64,8 +60,6 @@ class DNNModelPytorch(Model):
         batch_size=2000,
         early_stop_rounds=50,
         eval_steps=20,
-        lr_decay=0.96,
-        lr_decay_steps=100,
         optimizer="gd",
         loss="mse",
         GPU=0,
@@ -93,8 +87,6 @@ class DNNModelPytorch(Model):
         self.batch_size = batch_size
         self.early_stop_rounds = early_stop_rounds
         self.eval_steps = eval_steps
-        self.lr_decay = lr_decay
-        self.lr_decay_steps = lr_decay_steps
         self.optimizer = optimizer.lower()
         self.loss_type = loss
         if isinstance(GPU, str):
@@ -116,8 +108,6 @@ class DNNModelPytorch(Model):
             f"\nbatch_size : {batch_size}"
             f"\nearly_stop_rounds : {early_stop_rounds}"
             f"\neval_steps : {eval_steps}"
-            f"\nlr_decay : {lr_decay}"
-            f"\nlr_decay_steps : {lr_decay_steps}"
             f"\noptimizer : {optimizer}"
             f"\nloss_type : {loss}"
             f"\nseed : {seed}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove unused `lr_decay` and `lr_decay_steps` parameters from `DNNModelPytorch`. `DNNModelPytorch` already support a more flexible way to pass scheduler via callable function, so we don't need to enable `DNNModelPytorch` to leverage this parameters.

## Motivation and Context
Resolves #1056

## How Has This Been Tested?
<!---  Put an `x` in all the boxes that apply: --->
- [x] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
Pipeline test:
![image](https://user-images.githubusercontent.com/38360126/225845849-268b713d-1077-479e-942d-4395d90450ae.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
