### PR TITLE
normpath for Windows

### DIFF
--- a/qlib/utils/__init__.py
+++ b/qlib/utils/__init__.py
@@ -428,7 +428,7 @@ def init_instance_by_config(
             pr = urlparse(config)
             if pr.scheme == "file":
                 pr_path = os.path.join(pr.netloc, pr.path) if bool(pr.path) else pr.netloc
-                with open(pr_path, "rb") as f:
+                with open(os.path.normpath(pr_path), "rb") as f:
                     return pickle.load(f)
         else:
             with config.open("rb") as f:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
path on Windows contains double '/' which may cause open file failed.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!---  Put an `x` in all the boxes that apply: --->
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
