### PR TITLE
Remove test df from alstm code

### DIFF
--- a/qlib/contrib/model/pytorch_alstm.py
+++ b/qlib/contrib/model/pytorch_alstm.py
@@ -218,8 +218,8 @@ class ALSTM(Model):
         save_path=None,
     ):
 
-        df_train, df_valid, df_test = dataset.prepare(
-            ["train", "valid", "test"],
+        df_train, df_valid = dataset.prepare(
+            ["train", "valid"],
             col_set=["feature", "label"],
             data_key=DataHandlerLP.DK_L,
         )


### PR DESCRIPTION
Remove test df from alstm, it's not used.

## Description
Remove test df from alstm, it's not used.

## Motivation and Context
To prevent information leak, model should still be able to train even when test segment is not defined.

## How Has This Been Tested?
<!---  Put an `x` in all the boxes that apply: --->
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:
qrun completed with a config which has no test segment sepcified:
```
qlib_init:
    provider_uri: "~/.qlib/qlib_data/cn_data"
    region: cn
market: &market csi300
benchmark: &benchmark SH000300
data_handler_config: &data_handler_config
    start_time: 2005-05-01
    end_time: 2022-08-01
    fit_start_time: &fit_start_time 2005-05-01
    fit_end_time: &fit_end_time 2018-12-31
    instruments: *market
    infer_processors:
        - class: RobustZScoreNorm
          kwargs:
              fields_group: feature
              clip_outlier: true
        - class: Fillna
          kwargs:
              fields_group: feature
    learn_processors:
        - class: DropnaLabel
        - class: CSRankNorm
          kwargs:
              fields_group: label
task:
    model:
        class: ALSTM
        module_path: qlib.contrib.model.pytorch_alstm
        kwargs:
            d_feat: 6
            hidden_size: 64
            num_layers: 2
            dropout: 0.0
            n_epochs: 200
            lr: 1.0e-3
            early_stop: 20
            batch_size: 800
            metric: loss
            loss: mse
            GPU: 0
            rnn_type: GRU
    dataset:
        class: DatasetH
        module_path: qlib.data.dataset
        kwargs:
            handler:
                class: Alpha360
                module_path: qlib.contrib.data.handler
                kwargs: *data_handler_config
            segments:
                train: [*fit_start_time, *fit_end_time]
                valid: [2019-01-01, 2022-08-01]
```
![image](https://user-images.githubusercontent.com/3244845/233319653-cb2810dd-a65b-4483-ac96-4f503bc335b4.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
