### PR TITLE
Fix deprecated syntax in numpy

### DIFF
--- a/qlib/contrib/strategy/rule_strategy.py
+++ b/qlib/contrib/strategy/rule_strategy.py
@@ -635,7 +635,7 @@ class FileOrderStrategy(BaseStrategy):
             self.order_df = file
         else:
             with get_io_object(file) as f:
-                self.order_df = pd.read_csv(f, dtype={"datetime": np.str})
+                self.order_df = pd.read_csv(f, dtype={"datetime": str})
 
         self.order_df["datetime"] = self.order_df["datetime"].apply(pd.Timestamp)
         self.order_df = self.order_df.set_index(["datetime", "instrument"])

--- a/qlib/data/dataset/__init__.py
+++ b/qlib/data/dataset/__init__.py
@@ -417,7 +417,7 @@ class TSDataSampler:
             # NOTE: bool(np.nan) is True !!!!!!!!
             # make sure reindex comes first. Otherwise extra NaN may appear.
             flt_data = flt_data.swaplevel()
-            flt_data = flt_data.reindex(self.data_index).fillna(False).astype(np.bool)
+            flt_data = flt_data.reindex(self.data_index).fillna(False).astype(bool)
             self.flt_data = flt_data.values
             self.idx_map = self.flt_idx_map(self.flt_data, self.idx_map)
             self.data_index = self.data_index[np.where(self.flt_data)[0]]

--- a/tests/misc/test_index_data.py
+++ b/tests/misc/test_index_data.py
@@ -76,7 +76,7 @@ class IndexDataTest(unittest.TestCase):
         self.assertTrue(np.isnan(sd.loc["bar", "g"]))
 
         # support slicing
-        print(sd.loc[~sd.loc[:, "g"].isna().data.astype(np.bool)])
+        print(sd.loc[~sd.loc[:, "g"].isna().data.astype(bool)])
 
         print(self.assertTrue(idd.SingleData().index == idd.SingleData().index))
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
See #1506 .
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!---  Put an `x` in all the boxes that apply: --->
- [x] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
![image](https://user-images.githubusercontent.com/32626585/236409403-1d1bf9bf-072a-47ae-96e9-438d56d9a861.png)

2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
