### PR TITLE
Add util function to help automatically get horizon

### DIFF
--- a/qlib/utils/data.py
+++ b/qlib/utils/data.py
@@ -3,10 +3,12 @@
 """
 This module covers some utility functions that operate on data or basic object
 """
+import re
 from copy import deepcopy
 from typing import List, Union
-import pandas as pd
+
 import numpy as np
+import pandas as pd
 
 
 def robust_zscore(x: pd.Series, zscore=False):
@@ -103,3 +105,19 @@ def update_config(base_config: dict, ext_config: Union[dict, List[dict]]):
                     # one of then are not dict. Then replace
                     base_config[key] = ec[key]
     return base_config
+
+
+def guess_horizon(label):
+    """
+        Try to guess the horizon by parsing label
+    """
+    regex = r"Ref\(\s*\$[a-zA-Z]+,\s*-(\d+)\)"
+    horizon_list = [int(x) for x in re.findall(regex, label)]
+
+    if len(horizon_list) == 0:
+        return None
+    max_horizon = max(horizon_list)
+    # Unlikely the label doesn't use future information
+    if max_horizon < 2:
+        return None
+    return max_horizon

--- a/tests/misc/test_utils.py
+++ b/tests/misc/test_utils.py
@@ -9,6 +9,7 @@ from qlib.config import C
 from qlib.log import TimeInspector
 from qlib.constant import REG_CN, REG_US, REG_TW
 from qlib.utils.time import cal_sam_minute as cal_sam_minute_new, get_min_cal, CN_TIME, US_TIME, TW_TIME
+from qlib.utils.data import guess_horizon
 
 REG_MAP = {REG_CN: CN_TIME, REG_US: US_TIME, REG_TW: TW_TIME}
 
@@ -111,6 +112,23 @@ class TimeUtils(TestCase):
                 for args in args_l:
                     cal_sam_minute_new(*args, region=region)
 
+class DataUtils(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        init()
+
+    def test_guess_horizon(self):
+        label1 = "Ref($close, -2) / Ref($close, -1) - 1"
+        result1 = guess_horizon(label1)
+        assert(result1 == 2)
+
+        label1 = "Ref($close, -5) / Ref($close, -1) - 1"
+        result1 = guess_horizon(label1)
+        assert(result1 == 5)
+
+        label1 = "Ref($close, -1) / Ref($close, -1) - 1"
+        result1 = guess_horizon(label1)
+        assert(result1 is None)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add util function to help automatically get horizon

## Description
Add util function to help automatically get horizon

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->
In some code like TRA and DDG-DA, horizon is manually passed into the model. Which is not convenient to automate the workflow. Add a util function to help guess the horizon by label.

## How Has This Been Tested?
<!---  Put an `x` in all the boxes that apply: --->
- [x] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [x] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Fix bugs
- [x] Add new feature
- [ ] Update documentation
