### PR TITLE
suppress the SettingWithCopyWarning of pandas

### DIFF
--- a/qlib/data/dataset/processor.py
+++ b/qlib/data/dataset/processor.py
@@ -14,8 +14,6 @@ from ...utils.paral import datetime_groupby_apply
 from qlib.data.inst_processor import InstProcessor
 from qlib.data import D
 
-pd.options.mode.chained_assignment = None  # default='warn'
-
 
 def get_group_columns(df: pd.DataFrame, group: Union[Text, None]):
     """
@@ -321,9 +319,13 @@ class CSZScoreNorm(Processor):
         # try not modify original dataframe
         if not isinstance(self.fields_group, list):
             self.fields_group = [self.fields_group]
-        for g in self.fields_group:
-            cols = get_group_columns(df, g)
-            df[cols] = df[cols].groupby("datetime", group_keys=False).apply(self.zscore_func)
+        # depress warning by references:
+        # https://stackoverflow.com/questions/20625582/how-to-deal-with-settingwithcopywarning-in-pandas
+        # https://pandas.pydata.org/pandas-docs/stable/user_guide/options.html#getting-and-setting-options
+        with pd.option_context("mode.chained_assignment", None):
+            for g in self.fields_group:
+                cols = get_group_columns(df, g)
+                df[cols] = df[cols].groupby("datetime", group_keys=False).apply(self.zscore_func)
         return df
 
 

--- a/qlib/data/dataset/processor.py
+++ b/qlib/data/dataset/processor.py
@@ -14,6 +14,8 @@ from ...utils.paral import datetime_groupby_apply
 from qlib.data.inst_processor import InstProcessor
 from qlib.data import D
 
+pd.options.mode.chained_assignment = None  # default='warn'
+
 
 def get_group_columns(df: pd.DataFrame, group: Union[Text, None]):
     """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
df value is set as expected, suppress the warning.[reference](https://stackoverflow.com/questions/20625582/how-to-deal-with-settingwithcopywarning-in-pandas)

## Description
<!--- Describe your changes in detail -->
![image](https://github.com/microsoft/qlib/assets/128388363/340a3ead-f095-4b63-87b9-6fd91f095056)

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!---  Put an `x` in all the boxes that apply: --->
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

before:
![image](https://github.com/microsoft/qlib/assets/128388363/9a03c97f-e238-48ab-8333-aa7b70a91c7b)

after:
![image](https://github.com/microsoft/qlib/assets/128388363/dfd13afc-143b-4139-bad6-6e37da5a7a52)


<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
