### PR TITLE
Add multi pass portfolio analysis record

### DIFF
--- a/examples/benchmarks/Linear/workflow_config_linear_Alpha158_multi_pass_bt.yaml
+++ b/examples/benchmarks/Linear/workflow_config_linear_Alpha158_multi_pass_bt.yaml
@@ -1,0 +1,78 @@
+qlib_init:
+    provider_uri: "~/.qlib/qlib_data/cn_data"
+    region: cn
+market: &market csi300
+benchmark: &benchmark SH000300
+data_handler_config: &data_handler_config
+    start_time: 2008-01-01
+    end_time: 2020-08-01
+    fit_start_time: 2008-01-01
+    fit_end_time: 2014-12-31
+    instruments: *market
+    infer_processors:
+        - class: RobustZScoreNorm
+          kwargs:
+              fields_group: feature
+              clip_outlier: true
+        - class: Fillna
+          kwargs:
+              fields_group: feature
+    learn_processors:
+        - class: DropnaLabel
+        - class: CSRankNorm
+          kwargs:
+              fields_group: label
+port_analysis_config: &port_analysis_config
+    strategy:
+        class: TopkDropoutStrategy
+        module_path: qlib.contrib.strategy
+        kwargs:
+            signal:
+                - <MODEL> 
+                - <DATASET>
+            topk: 50
+            n_drop: 5
+    backtest:
+        start_time: 2017-01-01
+        end_time: 2020-08-01
+        account: 100000000
+        benchmark: *benchmark
+        exchange_kwargs:
+            limit_threshold: 0.095
+            deal_price: close
+            open_cost: 0.0005
+            close_cost: 0.0015
+            min_cost: 5
+task:
+    model:
+        class: LinearModel
+        module_path: qlib.contrib.model.linear
+        kwargs:
+            estimator: ols
+    dataset:
+        class: DatasetH
+        module_path: qlib.data.dataset
+        kwargs:
+            handler:
+                class: Alpha158
+                module_path: qlib.contrib.data.handler
+                kwargs: *data_handler_config
+            segments:
+                train: [2008-01-01, 2014-12-31]
+                valid: [2015-01-01, 2016-12-31]
+                test: [2017-01-01, 2020-08-01]
+    record: 
+        - class: SignalRecord
+          module_path: qlib.workflow.record_temp
+          kwargs: 
+            model: <MODEL>
+            dataset: <DATASET>
+        - class: SigAnaRecord
+          module_path: qlib.workflow.record_temp
+          kwargs: 
+            ana_long_short: True
+            ann_scaler: 252
+        - class: MultiPassPortAnaRecord
+          module_path: qlib.workflow.record_temp
+          kwargs: 
+            config: *port_analysis_config

--- a/qlib/workflow/record_temp.py
+++ b/qlib/workflow/record_temp.py
@@ -7,7 +7,7 @@ import pandas as pd
 import numpy as np
 from tqdm import trange
 from pprint import pprint
-from typing import Union, List, Optional
+from typing import Union, List, Optional, Dict
 
 from qlib.utils.exceptions import LoadObjectError
 from ..contrib.evaluate import risk_analysis, indicator_analysis
@@ -237,7 +237,7 @@ class ACRecordTemp(RecordTemp):
             self.save(**artifact_dict)
         return artifact_dict
 
-    def _generate(self, *args, **kwargs) -> dict[str, object]:
+    def _generate(self, *args, **kwargs) -> Dict[str, object]:
         """
         Run the concrete generating task, return the dictionary of the generated results.
         The caller method will save the results to the recorder.

--- a/qlib/workflow/record_temp.py
+++ b/qlib/workflow/record_temp.py
@@ -19,6 +19,7 @@ from ..log import get_module_logger
 from ..utils import fill_placeholder, flatten_dict, class_casting, get_date_by_shift
 from ..utils.time import Freq
 from ..utils.data import deepcopy_basic_type
+from ..utils.exceptions import QlibException
 from ..contrib.eva.alpha import calc_ic, calc_long_short_return, calc_long_short_prec
 
 
@@ -604,9 +605,9 @@ class MultiPassPortAnaRecord(PortAnaRecord):
         # Save original strategy so that pred df can be replaced in next generate
         self.original_strategy = deepcopy_basic_type(self.strategy_config)
         if not isinstance(self.original_strategy, dict):
-            raise Exception("MultiPassPortAnaRecord require the passed in strategy to be a dict")
+            raise QlibException("MultiPassPortAnaRecord require the passed in strategy to be a dict")
         if "signal" not in self.original_strategy.get("kwargs", {}):
-            raise Exception("MultiPassPortAnaRecord require the passed in strategy to have signal as a parameter")
+            raise QlibException("MultiPassPortAnaRecord require the passed in strategy to have signal as a parameter")
 
     def random_init(self):
         pred_df = self.load("pred.pkl")

--- a/qlib/workflow/record_temp.py
+++ b/qlib/workflow/record_temp.py
@@ -571,7 +571,7 @@ class MultiPassPortAnaRecord(PortAnaRecord):
     - port_analysis.pkl : The last risk analysis of your portfolio, returned by `qlib/contrib/evaluate.py:risk_analysis`
     - multi_pass_port_analysis.pkl: The aggregated risk analysis data from port_analysis.pkl
     """
-    depend_cls = None
+    depend_cls = SignalRecord
 
     def __init__(
         self,
@@ -615,6 +615,7 @@ class MultiPassPortAnaRecord(PortAnaRecord):
             if self.shuffle_init_score:
                 self.random_init()
                 
+            # Not check for cache file list
             super()._generate(**kwargs)
             
             for _analysis_freq in self.risk_analysis_freq:
@@ -638,7 +639,7 @@ class MultiPassPortAnaRecord(PortAnaRecord):
             
             # Only look at "annualized_return" and "information_ratio"
             multi_pass_port_analysis_df = multi_pass_port_analysis_df.loc[(slice(None),["annualized_return", "information_ratio"]),:]
-            print(multi_pass_port_analysis_df)
+            pprint(multi_pass_port_analysis_df)
             
             # Save new df
             self.save(**{f"multi_pass_port_analysis_{_analysis_freq}.pkl": multi_pass_port_analysis_df})
@@ -650,3 +651,12 @@ class MultiPassPortAnaRecord(PortAnaRecord):
                 "mean_std": multi_pass_port_analysis_df["mean_std"].unstack().T.to_dict(),
             })
             self.recorder.log_metrics(**metrics)
+
+    def list(self):
+        list_path = []
+        for _analysis_freq in self.risk_analysis_freq:
+            if _analysis_freq in self.all_freq:
+                list_path.append(f"multi_pass_port_analysis_{_analysis_freq}.pkl")
+            else:
+                warnings.warn(f"risk_analysis freq {_analysis_freq} is not found")
+        return list_path

--- a/qlib/workflow/record_temp.py
+++ b/qlib/workflow/record_temp.py
@@ -603,8 +603,10 @@ class MultiPassPortAnaRecord(PortAnaRecord):
 
         # Save original strategy so that pred df can be replaced in next generate
         self.original_strategy = deepcopy_basic_type(self.strategy_config)
-        if (not isinstance(self.original_strategy, dict)) or ("signal" not in self.original_strategy.get("kwargs", {}))):
-            raise Exception("MultiPassPortAnaRecord require the passed in strategy to be a dict and contains ['kwargs']['signal'] field")
+        if not isinstance(self.original_strategy, dict):
+            raise Exception("MultiPassPortAnaRecord require the passed in strategy to be a dict")
+        if "signal" not in self.original_strategy.get("kwargs", {}):
+            raise Exception("MultiPassPortAnaRecord require the passed in strategy to have signal as a parameter")
 
     def random_init(self):
         pred_df = self.load("pred.pkl")


### PR DESCRIPTION
## Description
Add a new record to initialize position randomly and run backtest multiple times.

## Motivation and Context
Signal based strategy's performance can be variant due to initial position setup. To better evalute the performance of each model, this recorder will:
1. Randomly shuffle the prediction signal of first backtest date, so that initial position will be random.
2. Run the backtest multiple times.
3. Aggregate the portfolio performance and publish the metrics.

## How Has This Been Tested?
<!---  Put an `x` in all the boxes that apply: --->
- [x] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [x] If you are adding a new feature, test on your own test scripts.

Added an example benchmark config yaml, run with the example yaml. 
```
$ qrun workflow_config_backward_alstm_Alpha158WithBenchDiff_full.yaml
```

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
![image](https://github.com/microsoft/qlib/assets/3244845/a3edb16a-7c3a-4751-b23c-8190ea868695)

4. Your own tests:
![image](https://github.com/microsoft/qlib/assets/3244845/6f22caa1-ef3a-4cf5-8bbd-0e5692d3abca)

I also ran test on existing workflow file and confirmed the format of out is the same.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Fix bugs
- [x] Add new feature
- [ ] Update documentation
