### PR TITLE
Small fix for local storage

### DIFF
--- a/qlib/data/storage/file_storage.py
+++ b/qlib/data/storage/file_storage.py
@@ -80,6 +80,7 @@ class FileCalendarStorage(FileStorageMixin, CalendarStorage):
         self._provider_uri = None if provider_uri is None else C.DataPathManager.format_provider_uri(provider_uri)
         self.enable_read_cache = True  # TODO: make it configurable
         self.region = C["region"]
+        (Path(self.uri.parent) / self.file_name).mkdir(parents=True, exist_ok=True)
 
     @property
     def file_name(self) -> str:
@@ -200,6 +201,7 @@ class FileInstrumentStorage(FileStorageMixin, InstrumentStorage):
         super(FileInstrumentStorage, self).__init__(market, freq, **kwargs)
         self._provider_uri = None if provider_uri is None else C.DataPathManager.format_provider_uri(provider_uri)
         self.file_name = f"{market.lower()}.txt"
+        (Path(self.uri.parent) / self.file_name).mkdir(parents=True, exist_ok=True)
 
     def _read_instrument(self) -> Dict[InstKT, InstVT]:
         if not self.uri.exists():
@@ -289,6 +291,7 @@ class FileFeatureStorage(FileStorageMixin, FeatureStorage):
         super(FileFeatureStorage, self).__init__(instrument, field, freq, **kwargs)
         self._provider_uri = None if provider_uri is None else C.DataPathManager.format_provider_uri(provider_uri)
         self.file_name = f"{instrument.lower()}/{field.lower()}.{freq.lower()}.bin"
+        (Path(self.uri.parent) / self.file_name).mkdir(parents=True, exist_ok=True)
 
     def clear(self):
         with self.uri.open("wb") as _:

--- a/qlib/data/storage/file_storage.py
+++ b/qlib/data/storage/file_storage.py
@@ -80,7 +80,7 @@ class FileCalendarStorage(FileStorageMixin, CalendarStorage):
         self._provider_uri = None if provider_uri is None else C.DataPathManager.format_provider_uri(provider_uri)
         self.enable_read_cache = True  # TODO: make it configurable
         self.region = C["region"]
-        (Path(self.uri.parent) / self.file_name).mkdir(parents=True, exist_ok=True)
+        self.uri.parent.mkdir(parents=True, exist_ok=True)
 
     @property
     def file_name(self) -> str:
@@ -201,7 +201,7 @@ class FileInstrumentStorage(FileStorageMixin, InstrumentStorage):
         super(FileInstrumentStorage, self).__init__(market, freq, **kwargs)
         self._provider_uri = None if provider_uri is None else C.DataPathManager.format_provider_uri(provider_uri)
         self.file_name = f"{market.lower()}.txt"
-        (Path(self.uri.parent) / self.file_name).mkdir(parents=True, exist_ok=True)
+        self.uri.parent.mkdir(parents=True, exist_ok=True)
 
     def _read_instrument(self) -> Dict[InstKT, InstVT]:
         if not self.uri.exists():
@@ -291,7 +291,7 @@ class FileFeatureStorage(FileStorageMixin, FeatureStorage):
         super(FileFeatureStorage, self).__init__(instrument, field, freq, **kwargs)
         self._provider_uri = None if provider_uri is None else C.DataPathManager.format_provider_uri(provider_uri)
         self.file_name = f"{instrument.lower()}/{field.lower()}.{freq.lower()}.bin"
-        (Path(self.uri.parent) / self.file_name).mkdir(parents=True, exist_ok=True)
+        self.uri.parent.mkdir(parents=True, exist_ok=True)
 
     def clear(self):
         with self.uri.open("wb") as _:


### PR DESCRIPTION
Ensure localstorage folder is exist during init.

## Description
I found although localstorage interface support write or update method, they are not actually used. They do not check folder exist during init and calling write method when only provider uri is exist will cause error.

## Motivation and Context
no

## How Has This Been Tested?
<!---  Put an `x` in all the boxes that apply: --->
- [x] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
![image](https://github.com/microsoft/qlib/assets/8296331/ae156ed2-0c9e-4cab-b362-155001ed7bb3)
(it is tested with temp fix from https://github.com/microsoft/qlib/issues/1547)
3. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
