### PR TITLE
Fix the empty price_s case.

### DIFF
--- a/qlib/backtest/report.py
+++ b/qlib/backtest/report.py
@@ -409,7 +409,7 @@ class Indicator:
             raise NotImplementedError(f"This type of input is not supported")
 
         # if there is no stock data during the time period
-        if price_s is None:
+        if price_s.empty:
             return None, None
 
         if isinstance(price_s, (int, float, np.number)):


### PR DESCRIPTION
The price_s is not None. Use price_s.empty instead.
## Description
<!--- Describe your changes in detail -->
The price_s is not None. Use price_s.empty instead.

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->
Fix bug.

## How Has This Been Tested?
<!---  Put an `x` in all the boxes that apply: --->
- [x] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
