### PR TITLE
Fix the bug of reading string NA as NaN in the function exists_qlib_data.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ tags
 
 ./pretrain
 .idea/
+
+# personal
+personal/
+myenv/

--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,3 @@ tags
 
 ./pretrain
 .idea/
-
-# personal
-personal/
-myenv/

--- a/qlib/utils/__init__.py
+++ b/qlib/utils/__init__.py
@@ -25,7 +25,12 @@ import pandas as pd
 from pathlib import Path
 from typing import List, Union, Optional, Callable
 from packaging import version
-from .file import get_or_create_path, save_multiple_parts_file, unpack_archive_with_buffer, get_tmp_file_with_buffer
+from .file import (
+    get_or_create_path,
+    save_multiple_parts_file,
+    unpack_archive_with_buffer,
+    get_tmp_file_with_buffer,
+)
 from ..config import C
 from ..log import get_module_logger, set_log_with_config
 
@@ -37,7 +42,12 @@ is_deprecated_lexsorted_pandas = version.parse(pd.__version__) > version.parse("
 #################### Server ####################
 def get_redis_connection():
     """get redis connection instance."""
-    return redis.StrictRedis(host=C.redis_host, port=C.redis_port, db=C.redis_task_db, password=C.redis_password)
+    return redis.StrictRedis(
+        host=C.redis_host,
+        port=C.redis_port,
+        db=C.redis_task_db,
+        password=C.redis_password,
+    )
 
 
 #################### Data ####################
@@ -96,7 +106,14 @@ def get_period_offset(first_year, period, quarterly):
     return offset
 
 
-def read_period_data(index_path, data_path, period, cur_date_int: int, quarterly, last_period_index: int = None):
+def read_period_data(
+    index_path,
+    data_path,
+    period,
+    cur_date_int: int,
+    quarterly,
+    last_period_index: int = None,
+):
     """
     At `cur_date`(e.g. 20190102), read the information at `period`(e.g. 201803).
     Only the updating info before cur_date or at cur_date will be used.
@@ -133,7 +150,9 @@ def read_period_data(index_path, data_path, period, cur_date_int: int, quarterly
     # find the first index of linked revisions
     if last_period_index is None:
         with open(index_path, "rb") as fi:
-            (first_year,) = struct.unpack(PERIOD_DTYPE, fi.read(struct.calcsize(PERIOD_DTYPE)))
+            (first_year,) = struct.unpack(
+                PERIOD_DTYPE, fi.read(struct.calcsize(PERIOD_DTYPE))
+            )
             all_periods = np.fromfile(fi, dtype=INDEX_DTYPE)
         offset = get_period_offset(first_year, period, quarterly)
         _next = all_periods[offset]
@@ -147,7 +166,9 @@ def read_period_data(index_path, data_path, period, cur_date_int: int, quarterly
     with open(data_path, "rb") as fd:
         while _next != NAN_INDEX:
             fd.seek(_next)
-            date, period, value, new_next = struct.unpack(DATA_DTYPE, fd.read(struct.calcsize(DATA_DTYPE)))
+            date, period, value, new_next = struct.unpack(
+                DATA_DTYPE, fd.read(struct.calcsize(DATA_DTYPE))
+            )
             if date > cur_date_int:
                 break
             prev_next = _next
@@ -273,7 +294,10 @@ def parse_field(field):
     # \uff09 -> )
     chinese_punctuation_regex = r"\u3001\uff1a\uff08\uff09"
     for pattern, new in [
-        (rf"\$\$([\w{chinese_punctuation_regex}]+)", r'PFeature("\1")'),  # $$ must be before $
+        (
+            rf"\$\$([\w{chinese_punctuation_regex}]+)",
+            r'PFeature("\1")',
+        ),  # $$ must be before $
         (rf"\$([\w{chinese_punctuation_regex}]+)", r'Feature("\1")'),
         (r"(\w+\s*)\(", r"Operators.\1("),
     ]:  # Features  # Operators
@@ -359,7 +383,9 @@ def is_tradable_date(cur_date):
     """
     from ..data import D  # pylint: disable=C0415
 
-    return str(cur_date.date()) == str(D.calendar(start_time=cur_date, future=True)[0].date())
+    return str(cur_date.date()) == str(
+        D.calendar(start_time=cur_date, future=True)[0].date()
+    )
 
 
 def get_date_range(trading_date, left_shift=0, right_shift=0, future=False):
@@ -383,7 +409,14 @@ def get_date_range(trading_date, left_shift=0, right_shift=0, future=False):
     return calendar
 
 
-def get_date_by_shift(trading_date, shift, future=False, clip_shift=True, freq="day", align: Optional[str] = None):
+def get_date_by_shift(
+    trading_date,
+    shift,
+    future=False,
+    clip_shift=True,
+    freq="day",
+    align: Optional[str] = None,
+):
     """get trading date with shift bias will cur_date
         e.g. : shift == 1,  return next trading date
                shift == -1, return previous trading date
@@ -416,7 +449,9 @@ def get_date_by_shift(trading_date, shift, future=False, clip_shift=True, freq="
         if clip_shift:
             shift_index = np.clip(shift_index, 0, len(cal) - 1)
         else:
-            raise IndexError(f"The shift_index({shift_index}) of the trading day ({trading_date}) is out of range")
+            raise IndexError(
+                f"The shift_index({shift_index}) of the trading day ({trading_date}) is out of range"
+            )
     return cal[shift_index]
 
 
@@ -453,7 +488,11 @@ def transform_end_date(end_date=None, freq="day"):
     from ..data import D  # pylint: disable=C0415
 
     last_date = D.calendar(freq=freq)[-1]
-    if end_date is None or (str(end_date) == "-1") or (pd.Timestamp(last_date) < pd.Timestamp(end_date)):
+    if (
+        end_date is None
+        or (str(end_date) == "-1")
+        or (pd.Timestamp(last_date) < pd.Timestamp(end_date))
+    ):
         log.warning(
             "\nInfo: the end_date in the configuration file is {}, "
             "so the default last date {} is used.".format(end_date, last_date)
@@ -567,13 +606,42 @@ def exists_qlib_data(qlib_dir):
             return False
 
     # check instruments
-    code_names = set(map(lambda x: fname_to_code(
-        x.name.lower()), features_dir.iterdir()))
+    code_names = set(
+        map(lambda x: fname_to_code(x.name.lower()), features_dir.iterdir())
+    )
     _instrument = instruments_dir.joinpath("all.txt")
-    miss_code = set(pd.read_csv(_instrument, sep="\t", header=None, keep_default_na=False,
-                                na_values={0: [" ", "#N/A", "#N/A N/A", "#NA", "-1.#IND", "-1.#QNAN", "-NaN", "-nan", "1.#IND", "1.#QNAN", "<NA>", "N/A", "NaN", "None", "n/a", "nan", "null "],
-                                           1: [" ", "#N/A", "#N/A N/A", "#NA", "-1.#IND", "-1.#QNAN", "-NaN", "-nan", "1.#IND", "1.#QNAN", "<NA>", "N/A", "NA", "NULL", "NaN", "None", "n/a", "nan", "null "],
-                                           2: [" ", "#N/A", "#N/A N/A", "#NA", "-1.#IND", "-1.#QNAN", "-NaN", "-nan", "1.#IND", "1.#QNAN", "<NA>", "N/A", "NA", "NULL", "NaN", "None", "n/a", "nan", "null "]}).loc[:, 0].apply(str.lower)) - set(code_names)
+    # Removed two possible ticker names "NA" and "NULL" from the default na_values list for column 0
+    miss_code = set(
+        pd.read_csv(
+            _instrument,
+            sep="\t",
+            header=None,
+            keep_default_na=False,
+            na_values={
+                0: [
+                    " ",
+                    "#N/A",
+                    "#N/A N/A",
+                    "#NA",
+                    "-1.#IND",
+                    "-1.#QNAN",
+                    "-NaN",
+                    "-nan",
+                    "1.#IND",
+                    "1.#QNAN",
+                    "<NA>",
+                    "N/A",
+                    "NaN",
+                    "None",
+                    "n/a",
+                    "nan",
+                    "null ",
+                ]
+            },
+        )
+        .loc[:, 0]
+        .apply(str.lower)
+    ) - set(code_names)
     if miss_code and any(map(lambda x: "sht" not in x, miss_code)):
         return False
 
@@ -809,7 +877,9 @@ class Wrapper:
         self._provider = provider
 
     def __repr__(self):
-        return "{name}(provider={provider})".format(name=self.__class__.__name__, provider=self._provider)
+        return "{name}(provider={provider})".format(
+            name=self.__class__.__name__, provider=self._provider
+        )
 
     def __getattr__(self, key):
         if self.__dict__.get("_provider", None) is None:

--- a/qlib/utils/__init__.py
+++ b/qlib/utils/__init__.py
@@ -567,9 +567,13 @@ def exists_qlib_data(qlib_dir):
             return False
 
     # check instruments
-    code_names = set(map(lambda x: fname_to_code(x.name.lower()), features_dir.iterdir()))
+    code_names = set(map(lambda x: fname_to_code(
+        x.name.lower()), features_dir.iterdir()))
     _instrument = instruments_dir.joinpath("all.txt")
-    miss_code = set(pd.read_csv(_instrument, sep="\t", header=None).loc[:, 0].apply(str.lower)) - set(code_names)
+    miss_code = set(pd.read_csv(_instrument, sep="\t", header=None, keep_default_na=False,
+                                na_values={0: [" ", "#N/A", "#N/A N/A", "#NA", "-1.#IND", "-1.#QNAN", "-NaN", "-nan", "1.#IND", "1.#QNAN", "<NA>", "N/A", "NaN", "None", "n/a", "nan", "null "],
+                                           1: [" ", "#N/A", "#N/A N/A", "#NA", "-1.#IND", "-1.#QNAN", "-NaN", "-nan", "1.#IND", "1.#QNAN", "<NA>", "N/A", "NA", "NULL", "NaN", "None", "n/a", "nan", "null "],
+                                           2: [" ", "#N/A", "#N/A N/A", "#NA", "-1.#IND", "-1.#QNAN", "-NaN", "-nan", "1.#IND", "1.#QNAN", "<NA>", "N/A", "NA", "NULL", "NaN", "None", "n/a", "nan", "null "]}).loc[:, 0].apply(str.lower)) - set(code_names)
     if miss_code and any(map(lambda x: "sht" not in x, miss_code)):
         return False
 

--- a/qlib/utils/__init__.py
+++ b/qlib/utils/__init__.py
@@ -150,9 +150,7 @@ def read_period_data(
     # find the first index of linked revisions
     if last_period_index is None:
         with open(index_path, "rb") as fi:
-            (first_year,) = struct.unpack(
-                PERIOD_DTYPE, fi.read(struct.calcsize(PERIOD_DTYPE))
-            )
+            (first_year,) = struct.unpack(PERIOD_DTYPE, fi.read(struct.calcsize(PERIOD_DTYPE)))
             all_periods = np.fromfile(fi, dtype=INDEX_DTYPE)
         offset = get_period_offset(first_year, period, quarterly)
         _next = all_periods[offset]
@@ -166,9 +164,7 @@ def read_period_data(
     with open(data_path, "rb") as fd:
         while _next != NAN_INDEX:
             fd.seek(_next)
-            date, period, value, new_next = struct.unpack(
-                DATA_DTYPE, fd.read(struct.calcsize(DATA_DTYPE))
-            )
+            date, period, value, new_next = struct.unpack(DATA_DTYPE, fd.read(struct.calcsize(DATA_DTYPE)))
             if date > cur_date_int:
                 break
             prev_next = _next
@@ -383,9 +379,7 @@ def is_tradable_date(cur_date):
     """
     from ..data import D  # pylint: disable=C0415
 
-    return str(cur_date.date()) == str(
-        D.calendar(start_time=cur_date, future=True)[0].date()
-    )
+    return str(cur_date.date()) == str(D.calendar(start_time=cur_date, future=True)[0].date())
 
 
 def get_date_range(trading_date, left_shift=0, right_shift=0, future=False):
@@ -449,9 +443,7 @@ def get_date_by_shift(
         if clip_shift:
             shift_index = np.clip(shift_index, 0, len(cal) - 1)
         else:
-            raise IndexError(
-                f"The shift_index({shift_index}) of the trading day ({trading_date}) is out of range"
-            )
+            raise IndexError(f"The shift_index({shift_index}) of the trading day ({trading_date}) is out of range")
     return cal[shift_index]
 
 
@@ -488,11 +480,7 @@ def transform_end_date(end_date=None, freq="day"):
     from ..data import D  # pylint: disable=C0415
 
     last_date = D.calendar(freq=freq)[-1]
-    if (
-        end_date is None
-        or (str(end_date) == "-1")
-        or (pd.Timestamp(last_date) < pd.Timestamp(end_date))
-    ):
+    if end_date is None or (str(end_date) == "-1") or (pd.Timestamp(last_date) < pd.Timestamp(end_date)):
         log.warning(
             "\nInfo: the end_date in the configuration file is {}, "
             "so the default last date {} is used.".format(end_date, last_date)
@@ -606,9 +594,7 @@ def exists_qlib_data(qlib_dir):
             return False
 
     # check instruments
-    code_names = set(
-        map(lambda x: fname_to_code(x.name.lower()), features_dir.iterdir())
-    )
+    code_names = set(map(lambda x: fname_to_code(x.name.lower()), features_dir.iterdir()))
     _instrument = instruments_dir.joinpath("all.txt")
     # Removed two possible ticker names "NA" and "NULL" from the default na_values list for column 0
     miss_code = set(
@@ -877,9 +863,7 @@ class Wrapper:
         self._provider = provider
 
     def __repr__(self):
-        return "{name}(provider={provider})".format(
-            name=self.__class__.__name__, provider=self._provider
-        )
+        return "{name}(provider={provider})".format(name=self.__class__.__name__, provider=self._provider)
 
     def __getattr__(self, key):
         if self.__dict__.get("_provider", None) is None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix the bug of reading string NA as NaN of exists_qlib_data in /qlib/utils/\_\_init\_\_.py.

## Description
<!--- Describe your changes in detail -->
Nano Labs Ltd is a new Nasdaq-listing company with the ticker name NA from August 1, 2022. The default na_value list of pd.read_csv includes "NA". Changed the default reading behavior of pd.read_csv in `exists_qlib_data` by adding `keep_default_na=False`. Removed two values ("NA" and "NULL") from the default NA list while reading the first column of "all.txt", which normally are all strings. 

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->
To fix the bug in #1720.

## How Has This Been Tested?
<!---  Put an `x` in all the boxes that apply: --->
- [X] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [X] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
![image](https://github.com/microsoft/qlib/assets/28951750/da850c40-db7d-4ea9-82af-e2bddcb39dfe)

2. Your own tests:
![image (1)](https://github.com/microsoft/qlib/assets/28951750/73036858-66ea-4474-b54f-1c1b8b4d0605)
Place the attached file [all.txt](https://github.com/microsoft/qlib/files/13997190/all.txt) under \qlib_data\us_data_made\instruments and test with the following code 
```
import qlib
import pandas as pd
import sys, site
from pathlib import Path
from qlib.utils import exists_qlib_data
from qlib.constant import REG_US

scripts_dir = Path.cwd().parent.joinpath("scripts")
provider_uri = "./qlib_data/us_data_made"  # target_dir
if not exists_qlib_data(provider_uri):
    print(f"Qlib data is not found in {provider_uri}")
    sys.path.append(str(scripts_dir))
    from get_data import GetData

    GetData().qlib_data(target_dir=provider_uri, region=REG_US)
qlib.init(provider_uri=provider_uri, region=REG_US)
```



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
