### PR TITLE
Update installation.rst - fixed typo on line 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ This table demonstrates the supported Python version of `Qlib`:
 Users can easily install ``Qlib`` by pip according to the following command.
 
 ```bash
-  pip install pyqlib
+  pip install qlib
 ```
 
 **Note**: pip will install the latest stable qlib. However, the main branch of qlib is in active development. If you want to test the latest scripts or functions in the main branch. Please install qlib with the methods below.
@@ -159,8 +159,8 @@ Also, users can install the latest dev version ``Qlib`` by the source code accor
 * Before installing ``Qlib`` from source, users need to install some dependencies:
 
   ```bash
-  pip install numpy
-  pip install --upgrade  cython
+  conda install numpy pandas matplotlib pyyaml hdf5 requests
+  conda install -c conda-forge liblapack lightgbm
   ```
 
 * Clone the repository and install ``Qlib`` as follows.

--- a/docs/start/installation.rst
+++ b/docs/start/installation.rst
@@ -17,7 +17,7 @@ Users can easily install ``Qlib`` by pip according to the following command:
 
 .. code-block:: bash
 
-   pip install pyqlib
+   pip install qlib
 
 
 Also, Users can install ``Qlib`` by the source code according to the following steps:


### PR DESCRIPTION
So when you are installing it as of 1/27/2024, you actually need to run pip install qlib instead of pip install pyqlib to install the package.

<img width="716" alt="image" src="https://github.com/microsoft/qlib/assets/32472626/36ea1b7f-fbfb-47ca-bdb7-8ab0a54a47b8">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Fix bugs
- [ ] Add new feature
- [X] Update documentation
