### PR TITLE
Add "mse" metric option to ALSTM.metric_fn

### DIFF
--- a/qlib/contrib/model/pytorch_alstm_ts.py
+++ b/qlib/contrib/model/pytorch_alstm_ts.py
@@ -160,6 +160,10 @@ class ALSTM(Model):
 
         if self.metric in ("", "loss"):
             return -self.loss_fn(pred[mask], label[mask])
+        elif self.metric == "mse":
+            mask = ~torch.isnan(label)
+            weight = torch.ones_like(label)
+            return -self.mse(pred[mask], label[mask], weight[mask])
 
         raise ValueError("unknown metric `%s`" % self.metric)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Enhance the metric_fn method of the ALSTM class to include the "mse" metric option.

## Description
<!--- Describe your changes in detail -->
Add "mse" metric option to ALSTM.metric_fn

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
https://github.com/microsoft/qlib/issues/1780#issue-2257857368
<!--- Why is this change required? What problem does it solve? -->
User can choose "mse" metric to evaluate the model 

## How Has This Been Tested?
<!---  Put an `x` in all the boxes that apply: --->
- [x] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [x] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test: 
![image](https://github.com/microsoft/qlib/assets/37997482/49110b2b-7b08-419e-b14e-b39de9709d27)

2. Your own tests:
Use the file qlib/examples/benchmarks/ALSTM/workflow_config_alstm_Alpha158.yaml for testing. Set `task -> model -> kwargs -> metric` to `mse` and set n_jobs to 5 due to the memory limit of my computer.
![image](https://github.com/microsoft/qlib/assets/37997482/7d45e259-a003-4191-b0d0-f3d15e943637)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Fix bugs
- [x] Add new feature
- [ ] Update documentation
