### PR TITLE
[fix] keep group_keys=False in Average Ensemble

### DIFF
--- a/qlib/model/ens/ensemble.py
+++ b/qlib/model/ens/ensemble.py
@@ -126,7 +126,7 @@ class AverageEnsemble(Ensemble):
         # NOTE: this may change the style underlying data!!!!
         # from pd.DataFrame to pd.Series
         results = pd.concat(values, axis=1)
-        results = results.groupby("datetime").apply(lambda df: (df - df.mean()) / df.std())
+        results = results.groupby("datetime", group_keys=False).apply(lambda df: (df - df.mean()) / df.std())
         results = results.mean(axis=1)
         results = results.sort_index()
         return results


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Explicitly passing the group_keys param in AverageEnsemble

- Before
```
results = results.groupby("datetime").apply(lambda df: (df - df.mean()) / df.std())
```
- After
```
results = results.groupby("datetime", group_keys=False).apply(lambda df: (df - df.mean()) / df.std())
```
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
The related issues is https://github.com/microsoft/qlib/issues/1893. And this PR is similar to https://github.com/microsoft/qlib/pull/1898
<!--- Why is this change required? What problem does it solve? -->
When we use the OnlineManager with AverageEnsemble, the `The name datetime occurs multiple times` raises. I believe this caused by the new feature in Pandas 2.0.0, where [release notice](https://pandas.pydata.org/docs/reference/api/pandas.Series.groupby.html) says "group_keys now defaults to True." 
![image](https://github.com/user-attachments/assets/fa2a29da-cafe-44c6-8b3b-3cc76619cd82)

## How Has This Been Tested?
<!---  Put an `x` in all the boxes that apply: --->
- [] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [x] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:
- before
![image](https://github.com/user-attachments/assets/e2c242aa-cc93-43a7-91ec-aac159ff7118)
- after
![image](https://github.com/user-attachments/assets/112fa1a0-beb6-4e6f-bd2c-48dee6ac08ed)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
