### PR TITLE
Fix handling of maxtasksperchild in ParallelExt for better compatibil…

### DIFF
--- a/qlib/utils/paral.py
+++ b/qlib/utils/paral.py
@@ -21,13 +21,14 @@ class ParallelExt(Parallel):
     def __init__(self, *args, **kwargs):
         maxtasksperchild = kwargs.pop("maxtasksperchild", None)
         super(ParallelExt, self).__init__(*args, **kwargs)
-        if isinstance(self._backend, MultiprocessingBackend):
+        if isinstance(self._backend, MultiprocessingBackend) and maxtasksperchild is not None:
             # 2025-05-04 joblib released version 1.5.0, in which _backend_args was removed and replaced by _backend_kwargs.
             # Ref: https://github.com/joblib/joblib/pull/1525/files#diff-e4dff8042ce45b443faf49605b75a58df35b8c195978d4a57f4afa695b406bdc
-            if joblib.__version__ < "1.5.0":
-                self._backend_args["maxtasksperchild"] = maxtasksperchild  # pylint: disable=E1101
-            else:
+            # Check for attribute existence instead of version comparison to be more robust
+            if hasattr(self, '_backend_kwargs'):
                 self._backend_kwargs["maxtasksperchild"] = maxtasksperchild  # pylint: disable=E1101
+            elif hasattr(self, '_backend_args'):
+                self._backend_args["maxtasksperchild"] = maxtasksperchild  # pylint: disable=E1101
 
 
 def datetime_groupby_apply(


### PR DESCRIPTION
# Fix: Improve `ParallelExt` Compatibility with `joblib` Backend

## Description

This PR fixes the handling of `maxtasksperchild` in `ParallelExt`, ensuring better compatibility when using the `joblib` backend. The update ensures that task management behaves consistently under different multiprocessing settings.

## Motivation and Context

Previously, `maxtasksperchild` was either not respected or caused unexpected behavior under the `joblib` backend. This change ensures that task recycling and memory/resource constraints are correctly handled when running long or parallel workflows.

Related discussion: *(add link if any GitHub issue or discussion exists)*

## How Has This Been Tested?

* [ ] Ran: `pytest qlib/tests/test_all_pipeline.py`
* [ ] Verified on custom joblib-based scripts for parallel workflows

Please confirm the above after testing.

## Screenshots of Test Results (if appropriate)

*(You can attach console output or screenshots here if needed)*

## Types of Changes

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update