### PR TITLE
  fix: replace deprecated pandas fillna(method=) with ffill()/bfill()

### DIFF
--- a/qlib/backtest/profit_attribution.py
+++ b/qlib/backtest/profit_attribution.py
@@ -281,13 +281,13 @@ def brinson_pa(
 
     stock_group_field = stock_df[group_field].unstack().T
     # FIXME: some attributes of some suspend stock is NAN.
-    stock_group_field = stock_group_field.fillna(method="ffill")
+    stock_group_field = stock_group_field.ffill()
     stock_group_field = stock_group_field.loc[start_date:end_date]
 
     stock_group = get_stock_group(stock_group_field, bench_stock_weight, group_method, group_n)
 
     deal_price_df = stock_df["deal_price"].unstack().T
-    deal_price_df = deal_price_df.fillna(method="ffill")
+    deal_price_df = deal_price_df.ffill()
 
     # NOTE:
     # The return will be slightly different from the of the return in the report.

--- a/qlib/contrib/ops/high_freq.py
+++ b/qlib/contrib/ops/high_freq.py
@@ -135,7 +135,7 @@ class FFillNan(ElemOperator):
 
     def _load_internal(self, instrument, start_index, end_index, freq):
         series = self.feature.load(instrument, start_index, end_index, freq)
-        return series.fillna(method="ffill")
+        return series.ffill()
 
 
 class BFillNan(ElemOperator):
@@ -154,7 +154,7 @@ class BFillNan(ElemOperator):
 
     def _load_internal(self, instrument, start_index, end_index, freq):
         series = self.feature.load(instrument, start_index, end_index, freq)
-        return series.fillna(method="bfill")
+        return series.bfill()
 
 
 class Date(ElemOperator):

--- a/qlib/contrib/report/analysis_position/parse_position.py
+++ b/qlib/contrib/report/analysis_position/parse_position.py
@@ -33,7 +33,7 @@ def parse_position(position: dict = None) -> pd.DataFrame:
 
     position_weight_df = get_stock_weight_df(position)
     # If the day does not exist, use the last weight
-    position_weight_df.fillna(method="ffill", inplace=True)
+    position_weight_df.ffill(inplace=True)
 
     previous_data = {"date": None, "code_list": []}
 

--- a/qlib/data/dataset/storage.py
+++ b/qlib/data/dataset/storage.py
@@ -67,7 +67,6 @@ class NaiveDFStorage(BaseHandlerStorage):
         col_set: Union[str, List[str]] = DataHandler.CS_ALL,
         fetch_orig: bool = True,
     ) -> pd.DataFrame:
-
         # Following conflicts may occur
         # - Does [20200101", "20210101"] mean selecting this slice or these two days?
         # To solve this issue

--- a/qlib/model/riskmodel/shrink.py
+++ b/qlib/model/riskmodel/shrink.py
@@ -247,7 +247,9 @@ class ShrinkCovEstimator(RiskModel):
         v1 = y.T.dot(z) / t - cov_mkt[:, None] * S
         roff1 = np.sum(v1 * cov_mkt[:, None].T) / var_mkt - np.sum(np.diag(v1) * cov_mkt) / var_mkt
         v3 = z.T.dot(z) / t - var_mkt * S
-        roff3 = np.sum(v3 * np.outer(cov_mkt, cov_mkt)) / var_mkt**2 - np.sum(np.diag(v3) * cov_mkt**2) / var_mkt**2
+        roff3 = (
+            np.sum(v3 * np.outer(cov_mkt, cov_mkt)) / var_mkt**2 - np.sum(np.diag(v3) * cov_mkt**2) / var_mkt**2
+        )
         roff = 2 * roff1 - roff3
         rho = rdiag + roff
 

--- a/qlib/utils/mod.py
+++ b/qlib/utils/mod.py
@@ -161,7 +161,6 @@ def init_instance_by_config(
             # path like 'file:///<path to pickle file>/obj.pkl'
             pr = urlparse(config)
             if pr.scheme == "file":
-
                 # To enable relative path like file://data/a/b/c.pkl.  pr.netloc will be data
                 path = pr.path
                 if pr.netloc != "":

--- a/qlib/utils/resam.py
+++ b/qlib/utils/resam.py
@@ -222,7 +222,7 @@ def get_valid_value(series, last=True):
     Nan | float
         the first/last valid value
     """
-    return series.fillna(method="ffill").iloc[-1] if last else series.fillna(method="bfill").iloc[0]
+    return series.ffill().iloc[-1] if last else series.bfill().iloc[0]
 
 
 def _ts_data_valid(ts_feature, last=False):

--- a/scripts/data_collector/baostock_5min/collector.py
+++ b/scripts/data_collector/baostock_5min/collector.py
@@ -172,7 +172,7 @@ class BaostockNormalizeHS3005min(BaseNormalize):
     @staticmethod
     def calc_change(df: pd.DataFrame, last_close: float) -> pd.Series:
         df = df.copy()
-        _tmp_series = df["close"].fillna(method="ffill")
+        _tmp_series = df["close"].ffill()
         _tmp_shift_series = _tmp_series.shift(1)
         if last_close is not None:
             _tmp_shift_series.iloc[0] = float(last_close)

--- a/scripts/data_collector/yahoo/collector.py
+++ b/scripts/data_collector/yahoo/collector.py
@@ -371,7 +371,7 @@ class YahooNormalize(BaseNormalize):
     @staticmethod
     def calc_change(df: pd.DataFrame, last_close: float) -> pd.Series:
         df = df.copy()
-        _tmp_series = df["close"].fillna(method="ffill")
+        _tmp_series = df["close"].ffill()
         _tmp_shift_series = _tmp_series.shift(1)
         if last_close is not None:
             _tmp_shift_series.iloc[0] = float(last_close)
@@ -459,7 +459,7 @@ class YahooNormalize1d(YahooNormalize, ABC):
         df.set_index(self._date_field_name, inplace=True)
         if "adjclose" in df:
             df["factor"] = df["adjclose"] / df["close"]
-            df["factor"] = df["factor"].fillna(method="ffill")
+            df["factor"] = df["factor"].ffill()
         else:
             df["factor"] = 1
         for _col in self.COLUMNS:

--- a/scripts/dump_bin.py
+++ b/scripts/dump_bin.py
@@ -180,7 +180,9 @@ class DumpDataBase:
         return (
             self._include_fields
             if self._include_fields
-            else set(df_columns) - set(self._exclude_fields) if self._exclude_fields else df_columns
+            else set(df_columns) - set(self._exclude_fields)
+            if self._exclude_fields
+            else df_columns
         )
 
     @staticmethod


### PR DESCRIPTION
## Description
  Replace deprecated `fillna(method="ffill"/"bfill")` calls with modern pandas `ffill()` and `bfill()` methods to fix FutureWarnings in pandas 2.x.

  This addresses the pandas deprecation warnings portion of issue #1981. Other issues (date parsing, type conversion, timezone handling) will be addressed in separate commits.

  ## Motivation and Context
  - **Related Issue:** Partially addresses GitHub issue #1981
  - **Problem:** Deprecated pandas methods causing FutureWarnings that will become errors in future pandas versions
  - **Solution:** Update to modern pandas API equivalents across 6 files and 8 instances

  ## How Has This Been Tested?
  - [x] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
  - [x] Verified no deprecation warnings with updated methods
  - [x] Black formatting applied for code compliance

  ## Screenshots of Test Results (if appropriate):
  1. Pipeline test: ✅ All 3 tests passed
  2. Deprecation test: ✅ No FutureWarnings with new methods

  ## Types of changes
  - [x] Fix bugs

  ## Files Changed:
  - `qlib/backtest/profit_attribution.py` - 2 fixes
  - `qlib/contrib/ops/high_freq.py` - 2 fixes
  - `qlib/contrib/report/analysis_position/parse_position.py` - 1 fix
  - `qlib/utils/resam.py` - 1 fix
  - `scripts/data_collector/baostock_5min/collector.py` - 1 fix
  - `scripts/data_collector/yahoo/collector.py` - 2 fixes
  - Plus black formatting compliance fixes