### PR TITLE
docs: update Docker run command in README.md to specify the correct image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ We recommend users to prepare their own data if they have a high-quality dataset
     ```
 2. Start a new Docker container
     ```bash
-    docker run -it --name <container name> -v <Mounted local directory>:/app qlib_image_stable
+    docker run -it --name <container name> -v <Mounted local directory>:/app pyqlib/qlib_image_stable:stable
     ```
 3. At this point you are in the docker environment and can run the qlib scripts. An example:
     ```bash


### PR DESCRIPTION
## Description
update Docker run command in README.md to specify the correct image name

## Motivation and Context
The README.md file contains an inconsistency in the Docker section. While the docker pull command correctly specifies the full image name pyqlib/qlib_image_stable:stable, the docker run command only uses qlib_image_stable which is incomplete and will cause Docker to fail to find the image. This needs to be corrected to use the full image name pyqlib/qlib_image_stable:stable for consistency and proper functionality.

## How Has This Been Tested?
N/A (documentation change only)

## Screenshots of Test Results (if appropriate):
1. Pipeline test: N/A (documentation change only)
2. Your own tests: N/A (documentation change only)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Fix bugs
- [ ] Add new feature
- [x] Update documentation
