### PR TITLE
docs: Improve OnlineTool docstring for clarity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ tags
 ./pretrain
 .idea/
 .aider*
+.venv/
+.venv/

--- a/qlib/workflow/online/utils.py
+++ b/qlib/workflow/online/utils.py
@@ -2,9 +2,7 @@
 # Licensed under the MIT License.
 
 """
-OnlineTool is a module to set and unset a series of `online` models.
-The `online` models are some decisive models in some time points, which can be changed with the change of time.
-This allows us to use efficient submodels as the market-style changing.
+OnlineTool is a module for setting and unsetting a series of online models. These are key models selected at specific time points, which can evolve over time. This enables the use of efficient submodels in response to changing market conditions.
 """
 
 from typing import List, Union


### PR DESCRIPTION
## Changes
Updated the module docstring in `qlib/workflow/online/utils.py` to improve readability and grammar. This text renders as the intro paragraph in the "Online Tool" docs section (via automodule in `docs/component/online.rst`).

**Original** (awkward phrasing):
> OnlineTool is a module to set and unset a series of online models. The online models are some decisive models in some time points, which can be changed with the change of time. This allows us to use efficient submodels as the market-style changing.

**Updated**:
> OnlineTool is a module for setting and unsetting a series of online models. These are key models selected at specific time points, which can evolve over time. This enables the use of efficient submodels in response to changing market conditions.

## Why?
Enhances clarity and flow without altering technical meaning. No functional code changes.

## Testing
Local Sphinx build confirmed the update renders correctly in `component/online.html`. No breaking changes.

## Related
Improves https://qlib.readthedocs.io/en/latest/component/online.html