### PR TITLE
feat(config): add explicit validation for required configuration fields

### DIFF
--- a/qlib/config.py
+++ b/qlib/config.py
@@ -131,11 +131,11 @@ class Config:
         if C.registered and skip_register:
             return
 
-        
+
         C.set_conf_from_C(config)
 
-
-        C.validate()
+        if not skip_register:
+            C.validate()
 
         if C.logging_config:
             set_log_with_config(C.logging_config)

--- a/qlib/config.py
+++ b/qlib/config.py
@@ -133,9 +133,7 @@ class Config:
 
 
         C.set_conf_from_C(config)
-
-        if not skip_register:
-            C.validate()
+        C.validate()
 
         if C.logging_config:
             set_log_with_config(C.logging_config)

--- a/qlib/config.py
+++ b/qlib/config.py
@@ -126,7 +126,7 @@ class Config:
 
     @staticmethod
     def register_from_C(config, skip_register=True):
-        from .utils import set_log_with_config
+        from .utils import set_log_with_config  # pylint: disable=C0415
 
         if C.registered and skip_register:
             return

--- a/qlib/config.py
+++ b/qlib/config.py
@@ -62,8 +62,26 @@ QSETTINGS = QSettings()
 
 class Config:
     def __init__(self, default_conf):
-        self.__dict__["_default_config"] = copy.deepcopy(default_conf)  # avoiding conflicts with __getattr__
+        self.__dict__["_default_config"] = copy.deepcopy(default_conf)
         self.reset()
+
+    def validate(self):
+        errors = []
+
+        if not self.get("provider_uri"):
+            errors.append(
+                "provider_uri must be set (e.g. ~/.qlib/qlib_data or a valid path)"
+            )
+
+        if not self.get("region"):
+            errors.append(
+                "region must be specified (e.g. 'cn', 'us')"
+            )
+
+        if errors:
+            raise ValueError(
+                "Invalid Qlib configuration:\n- " + "\n- ".join(errors)
+            )
 
     def __getitem__(self, key):
         return self.__dict__["_config"][key]
@@ -71,7 +89,6 @@ class Config:
     def __getattr__(self, attr):
         if attr in self.__dict__["_config"]:
             return self.__dict__["_config"][attr]
-
         raise AttributeError(f"No such `{attr}` in self._config")
 
     def get(self, key, default=None):
@@ -109,14 +126,20 @@ class Config:
 
     @staticmethod
     def register_from_C(config, skip_register=True):
-        from .utils import set_log_with_config  # pylint: disable=C0415
+        from .utils import set_log_with_config
 
         if C.registered and skip_register:
             return
 
+        
         C.set_conf_from_C(config)
+
+
+        C.validate()
+
         if C.logging_config:
             set_log_with_config(C.logging_config)
+
         C.register()
 
 

--- a/qlib/config.py
+++ b/qlib/config.py
@@ -65,21 +65,21 @@ class Config:
         self.__dict__["_default_config"] = copy.deepcopy(default_conf)
         self.reset()
 
+    # TODO: This validation logic is a temporary solution.
+    # The long-term goal is to migrate Qlib Config to a typed configuration
+    # system based on pydantic.BaseModel, with explicit schema and field validation.
     def validate(self):
         errors = []
 
         if not self.get("provider_uri"):
-            errors.append(
-                "provider_uri must be set (e.g. ~/.qlib/qlib_data or a valid path)"
-            )
+            errors.append("provider_uri must be set (e.g. ~/.qlib/qlib_data or a valid path)")
 
         if not self.get("region"):
-            errors.append(
-                "region must be specified (e.g. 'cn', 'us')"
-            )
+            errors.append("region must be specified (e.g. 'cn', 'us')")
 
         if errors:
             raise ValueError(
+                "Invalid Qlib configuration (note: the global config has already been updated):\n"
                 "Invalid Qlib configuration:\n- " + "\n- ".join(errors)
             )
 
@@ -130,7 +130,6 @@ class Config:
 
         if C.registered and skip_register:
             return
-
 
         C.set_conf_from_C(config)
         C.validate()

--- a/qlib/tests/test_config_validation.py
+++ b/qlib/tests/test_config_validation.py
@@ -1,0 +1,17 @@
+import pytest
+from qlib.config import C, Config
+
+
+def test_missing_provider_uri_raises():
+    
+    default_conf = {
+        "provider_uri": None,
+        "region": "us"
+    }
+
+    cfg = Config(default_conf)
+
+    with pytest.raises(ValueError) as exc:
+        cfg.validate()
+
+    assert "provider_uri must be set" in str(exc.value)

--- a/qlib/tests/test_config_validation.py
+++ b/qlib/tests/test_config_validation.py
@@ -1,12 +1,12 @@
 import pytest
-from qlib.config import C, Config
+
+from qlib.config import Config
 
 
 def test_missing_provider_uri_raises():
-    
     default_conf = {
         "provider_uri": None,
-        "region": "us"
+        "region": "us",
     }
 
     cfg = Config(default_conf)


### PR DESCRIPTION
### What changed
This PR adds explicit validation to the `Config` class to surface missing required configuration fields early, with clear error messages.

### Why
Currently, missing core fields such as `provider_uri` or `region` can lead to unclear runtime errors later in the execution flow. This change fails fast and makes misconfiguration easier to diagnose.

### What’s included
- A new `Config.validate()` method that checks required fields
- A focused unit test validating the behavior for missing `provider_uri`

### Notes
Some tests depend on optional development packages (e.g. tqdm), so local test collection may fail on a minimal setup. CI should be used to verify test results.
