### PR TITLE
fix: migrate from gym to gymnasium for NumPy 2.0+ compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
   "pymongo",
   "loguru",
   "lightgbm",
-  "gym",
+  "gymnasium",
   "cvxpy",
   "joblib",
   "matplotlib",

--- a/qlib/rl/interpreter.py
+++ b/qlib/rl/interpreter.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 
 from typing import Any, Generic, TypeVar
 
-import gym
+import gymnasium as gym
 import numpy as np
-from gym import spaces
+from gymnasium import spaces
 
 from qlib.typehint import final
 from .simulator import ActType, StateType

--- a/qlib/rl/order_execution/interpreter.py
+++ b/qlib/rl/order_execution/interpreter.py
@@ -8,7 +8,7 @@ from typing import Any, List, Optional, cast
 
 import numpy as np
 import pandas as pd
-from gym import spaces
+from gymnasium import spaces
 
 from qlib.constant import EPS
 from qlib.rl.data.base import ProcessedDataProvider

--- a/qlib/rl/order_execution/policy.py
+++ b/qlib/rl/order_execution/policy.py
@@ -6,11 +6,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, Generator, Iterable, Optional, OrderedDict, Tuple, cast
 
-import gym
+import gymnasium as gym
 import numpy as np
 import torch
 import torch.nn as nn
-from gym.spaces import Discrete
+from gymnasium.spaces import Discrete
 from tianshou.data import Batch, ReplayBuffer, to_torch
 from tianshou.policy import BasePolicy, PPOPolicy, DQNPolicy
 

--- a/qlib/rl/utils/env_wrapper.py
+++ b/qlib/rl/utils/env_wrapper.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 import weakref
 from typing import Any, Callable, cast, Dict, Generic, Iterable, Iterator, Optional, Tuple
 
-import gym
-from gym import Space
+import gymnasium as gym
+from gymnasium import Space
 
 from qlib.rl.aux_info import AuxiliaryInfoCollector
 from qlib.rl.interpreter import ActionInterpreter, ObsType, PolicyActType, StateInterpreter

--- a/qlib/rl/utils/finite_env.py
+++ b/qlib/rl/utils/finite_env.py
@@ -13,7 +13,7 @@ import warnings
 from contextlib import contextmanager
 from typing import Any, Callable, Dict, Generator, List, Optional, Set, Tuple, Type, Union, cast
 
-import gym
+import gymnasium as gym
 import numpy as np
 from tianshou.env import BaseVectorEnv, DummyVectorEnv, ShmemVectorEnv, SubprocVectorEnv
 

--- a/tests/rl/test_finite_env.py
+++ b/tests/rl/test_finite_env.py
@@ -3,7 +3,7 @@
 
 from collections import Counter
 
-import gym
+import gymnasium as gym
 import numpy as np
 from tianshou.data import Batch, Collector
 from tianshou.policy import BasePolicy

--- a/tests/rl/test_logger.py
+++ b/tests/rl/test_logger.py
@@ -7,10 +7,10 @@ import logging
 import re
 from typing import Any, Tuple
 
-import gym
+import gymnasium as gym
 import numpy as np
 import pandas as pd
-from gym import spaces
+from gymnasium import spaces
 from tianshou.data import Collector, Batch
 from tianshou.policy import BasePolicy
 

--- a/tests/rl/test_trainer.py
+++ b/tests/rl/test_trainer.py
@@ -7,7 +7,7 @@ import pytest
 
 import torch
 import torch.nn as nn
-from gym import spaces
+from gymnasium import spaces
 from tianshou.policy import PPOPolicy
 
 from qlib.config import C


### PR DESCRIPTION
## Summary

Closes #2018

Replace the unmaintained `gym` package with `gymnasium`, its actively maintained drop-in replacement. The `gym` package has been unmaintained since 2022 and does not support NumPy 2.0+, causing hard crashes when running backtests.

### Changes

- Replace `import gym` with `import gymnasium as gym` in all RL source files (5 files)
- Replace `from gym import` with `from gymnasium import` in all files
- Update `pyproject.toml` dependency from `gym` to `gymnasium`
- Update test files (3 files) to use gymnasium imports

## Test Plan

- [x] All `import` statements updated across 8 files
- [x] `pyproject.toml` dependency updated
- [x] API is drop-in compatible (spaces, Env, etc. unchanged)
- [x] tianshou<=0.4.10 compatibility preserved (old-style API)