### PR TITLE
fix: correct WMA calculation to use nansum instead of nanmean

### DIFF
--- a/qlib/data/ops.py
+++ b/qlib/data/ops.py
@@ -1337,7 +1337,7 @@ class WMA(Rolling):
         def weighted_mean(x):
             w = np.arange(len(x)) + 1
             w = w / w.sum()
-            return np.nanmean(w * x)
+            return np.nansum(w * x)
 
         if self.N == 0:
             series = series.expanding(min_periods=1).apply(weighted_mean, raw=True)


### PR DESCRIPTION
## Summary

Closes #1993

The `weighted_mean` function in `WMA._load_internal` (qlib/data/ops.py) normalizes weights to sum to 1 via `w = w / w.sum()`, then incorrectly uses `np.nanmean(w * x)` which divides by the element count again. The correct function is `np.nansum(w * x)` since the weights already sum to 1.

This is consistent with how `EMA.exp_weighted_mean` is implemented (which already uses `np.nansum`).

### Before
```python
def weighted_mean(x):
    w = np.arange(len(x)) + 1
    w = w / w.sum()
    return np.nanmean(w * x)  # BUG: divides by count again
```

### After
```python
def weighted_mean(x):
    w = np.arange(len(x)) + 1
    w = w / w.sum()
    return np.nansum(w * x)  # correct: weights already sum to 1
```

## Test Plan

- [x] Change is consistent with EMA implementation pattern
- [x] Single-line fix, minimal risk