### PR TITLE
fix: prevent AttributeError in joblib worker config sync

### DIFF
--- a/qlib/config.py
+++ b/qlib/config.py
@@ -111,7 +111,7 @@ class Config:
     def register_from_C(config, skip_register=True):
         from .utils import set_log_with_config  # pylint: disable=C0415
 
-        if C.registered and skip_register:
+        if getattr(C, "registered", False) and skip_register:
             return
 
         C.set_conf_from_C(config)


### PR DESCRIPTION
## Summary

Closes #2038

When backtests spawn joblib worker processes, `register_from_C` can crash with:
```
AttributeError: No such registered in self._config
```

This happens because the worker's fresh `Config` instance may not have the `_registered` key available when `C.registered` is accessed.

### Fix

Replace the direct attribute access with a safe `getattr` call:

```python
# Before
if C.registered and skip_register:

# After
if getattr(C, "registered", False) and skip_register:
```

This defaults to `False` when the attribute is missing, allowing the worker to proceed with config synchronization from the main process.

## Test Plan

- [x] Single-line defensive fix
- [x] Behavior unchanged when `registered` attribute exists
- [x] Gracefully handles missing attribute by defaulting to `False`