### PR TITLE
refactor: add ModeType enum for client/server mode selection

### DIFF
--- a/qlib/__init__.py
+++ b/qlib/__init__.py
@@ -27,8 +27,8 @@ def init(default_conf="client", **kwargs):
 
     Parameters
     ----------
-    default_conf: str
-        the default value is client. Accepted values: client/server.
+    default_conf: str or ModeType
+        the default value is client. Accepted values: ModeType.CLIENT/ModeType.SERVER (or "client"/"server").
     **kwargs :
         clear_mem_cache: str
             the default value is True;

--- a/qlib/config.py
+++ b/qlib/config.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import Callable, Optional, Union
 from typing import TYPE_CHECKING
 
-from qlib.constant import REG_CN, REG_US, REG_TW
+from qlib.constant import REG_CN, REG_US, REG_TW, ModeType
 
 if TYPE_CHECKING:
     from qlib.utils.time import Freq
@@ -247,7 +247,7 @@ _default_config = {
 }
 
 MODE_CONF = {
-    "server": {
+    ModeType.SERVER: {
         # config it in qlib.init()
         "provider_uri": "",
         # redis
@@ -260,7 +260,7 @@ MODE_CONF = {
         "local_cache_path": Path("~/.cache/qlib_simple_cache").expanduser().resolve(),
         "mount_path": None,
     },
-    "client": {
+    ModeType.CLIENT: {
         # config it in user's own code
         "provider_uri": QSETTINGS.provider_uri,
         # cache
@@ -385,7 +385,7 @@ class QlibConfig(Config):
 
     def set_mode(self, mode):
         # raise KeyError
-        self.update(MODE_CONF[mode])
+        self.update(MODE_CONF[ModeType(mode)])
         # TODO: update region based on kwargs
 
     def set_region(self, region):
@@ -420,7 +420,7 @@ class QlibConfig(Config):
         self["provider_uri"] = _provider_uri
         self["mount_path"] = _mount_path
 
-    def set(self, default_conf: str = "client", **kwargs):
+    def set(self, default_conf: Union[str, ModeType] = ModeType.CLIENT, **kwargs):
         """
         configure qlib based on the input parameters
 
@@ -435,8 +435,8 @@ class QlibConfig(Config):
 
         Parameters
         ----------
-        default_conf : str
-            the default config template chosen by user: "server", "client"
+        default_conf : str or ModeType
+            the default config template chosen by user: ModeType.SERVER, ModeType.CLIENT (or "server", "client")
         """
         from .utils import set_log_with_config, get_module_logger, can_use_cache  # pylint: disable=C0415
 

--- a/qlib/constant.py
+++ b/qlib/constant.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 # REGION CONST
+from enum import Enum
 from typing import TypeVar
 
 import numpy as np
@@ -20,3 +21,10 @@ ONE_DAY = pd.Timedelta("1day")
 ONE_MIN = pd.Timedelta("1min")
 EPS_T = pd.Timedelta("1s")  # use 1 second to exclude the right interval point
 float_or_ndarray = TypeVar("float_or_ndarray", float, np.ndarray)
+
+
+class ModeType(str, Enum):
+    """Mode type for qlib initialization: client or server."""
+
+    CLIENT = "client"
+    SERVER = "server"


### PR DESCRIPTION
## Summary
- Introduces a `ModeType(str, Enum)` in `qlib/constant.py` with `CLIENT` and `SERVER` values
- Updates `MODE_CONF` dictionary keys to use `ModeType` enum instead of raw strings
- Updates `set_mode()` to convert string arguments to `ModeType` via `ModeType(mode)`
- Updates `set()` method signature to accept `Union[str, ModeType]`
- Full backward compatibility: `ModeType.CLIENT == "client"` is `True` since `ModeType` inherits from `str`

## Test plan
- [x] Verified `ModeType.CLIENT == "client"` and `ModeType.SERVER == "server"` evaluate to `True`
- [x] Verified `MODE_CONF[ModeType("client")]` works (string-to-enum conversion)
- [x] Verified `MODE_CONF[ModeType.CLIENT]` works (direct enum access)
- [ ] Existing tests pass without modification (no consumer code changes needed)

Closes #813