### PR TITLE
refactor: separate constants from config.py into constant.py

### DIFF
--- a/qlib/config.py
+++ b/qlib/config.py
@@ -17,12 +17,21 @@ import re
 import copy
 import logging
 import platform
-import multiprocessing
 from pathlib import Path
 from typing import Callable, Optional, Union
 from typing import TYPE_CHECKING
 
-from qlib.constant import REG_CN, REG_US, REG_TW
+from qlib.constant import (
+    REG_CN,
+    REG_US,
+    REG_TW,
+    PROTOCOL_VERSION,
+    NUM_USABLE_CPU,
+    DISK_DATASET_CACHE,
+    SIMPLE_DATASET_CACHE,
+    DISK_EXPRESSION_CACHE,
+    DEPENDENCY_REDIS_CACHE,
+)
 
 if TYPE_CHECKING:
     from qlib.utils.time import Freq
@@ -119,17 +128,6 @@ class Config:
             set_log_with_config(C.logging_config)
         C.register()
 
-
-# pickle.dump protocol version: https://docs.python.org/3/library/pickle.html#data-stream-format
-PROTOCOL_VERSION = 4
-
-NUM_USABLE_CPU = max(multiprocessing.cpu_count() - 2, 1)
-
-DISK_DATASET_CACHE = "DiskDatasetCache"
-SIMPLE_DATASET_CACHE = "SimpleDatasetCache"
-DISK_EXPRESSION_CACHE = "DiskExpressionCache"
-
-DEPENDENCY_REDIS_CACHE = (DISK_DATASET_CACHE, DISK_EXPRESSION_CACHE)
 
 _default_config = {
     # data provider config

--- a/qlib/constant.py
+++ b/qlib/constant.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 # REGION CONST
+import multiprocessing
 from typing import TypeVar
 
 import numpy as np
@@ -20,3 +21,14 @@ ONE_DAY = pd.Timedelta("1day")
 ONE_MIN = pd.Timedelta("1min")
 EPS_T = pd.Timedelta("1s")  # use 1 second to exclude the right interval point
 float_or_ndarray = TypeVar("float_or_ndarray", float, np.ndarray)
+
+# pickle.dump protocol version: https://docs.python.org/3/library/pickle.html#data-stream-format
+PROTOCOL_VERSION = 4
+
+NUM_USABLE_CPU = max(multiprocessing.cpu_count() - 2, 1)
+
+DISK_DATASET_CACHE = "DiskDatasetCache"
+SIMPLE_DATASET_CACHE = "SimpleDatasetCache"
+DISK_EXPRESSION_CACHE = "DiskExpressionCache"
+
+DEPENDENCY_REDIS_CACHE = (DISK_DATASET_CACHE, DISK_EXPRESSION_CACHE)


### PR DESCRIPTION
## Summary
- Moves `PROTOCOL_VERSION`, `NUM_USABLE_CPU`, `DISK_DATASET_CACHE`, `SIMPLE_DATASET_CACHE`, `DISK_EXPRESSION_CACHE`, and `DEPENDENCY_REDIS_CACHE` from `qlib/config.py` to `qlib/constant.py`
- Constants are re-imported in `config.py` to maintain full backward compatibility
- Removes unused `multiprocessing` import from `config.py` (was only used for `cpu_count()` which moved with `NUM_USABLE_CPU`)

## Test plan
- [x] Verified all constants are accessible from both `qlib.constant` and `qlib.config`
- [x] Verified `C` (global config) still works correctly with moved constants
- [ ] Existing tests pass without modification

Closes #807