### PR TITLE
fix: convert custom Index to list in SingleData.to_series()

### DIFF
--- a/qlib/utils/index_data.py
+++ b/qlib/utils/index_data.py
@@ -612,7 +612,7 @@ class SingleData(IndexData):
         return dict(zip(self.index, self.data.tolist()))
 
     def to_series(self):
-        return pd.Series(self.data, index=self.index)
+        return pd.Series(self.data, index=self.index.tolist())
 
     def __repr__(self) -> str:
         return str(pd.Series(self.data, index=self.index.tolist()))


### PR DESCRIPTION
## Summary
- `SingleData.to_series()` passed a `qlib.utils.index_data.Index` object directly to `pd.Series()`, which raises `TypeError` since pandas does not recognize it as a valid index type
- Fixed by calling `.tolist()` to convert to a plain list, consistent with how `__repr__()` already handles it on the next line
- One-line fix in `qlib/utils/index_data.py`

## Root Cause
The `Index` class in `qlib/utils/index_data.py` is a custom high-performance index wrapper. While it supports iteration and `.tolist()`, pandas `pd.Series()` constructor does not accept it as a valid `index` parameter. The `__repr__` method (line 618) already uses `.tolist()` correctly, but `to_series()` (line 614) did not.

## Test plan
- [x] Verified `SingleData.to_series()` returns a valid `pd.Series` with correct index
- [x] Verified `__repr__` continues to work
- [ ] Existing tests pass without modification

Fixes #2020