### PR TITLE
docs: add docstrings for order generators, WeightStrategyBase, and Exchange

### DIFF
--- a/qlib/contrib/strategy/order_generator.py
+++ b/qlib/contrib/strategy/order_generator.py
@@ -12,6 +12,29 @@ import copy
 
 
 class OrderGenerator:
+    """Base class for order generators used by ``WeightStrategyBase``.
+
+    An order generator converts a target weight position (a mapping from
+    stock_id to portfolio weight) into a concrete list of ``Order`` objects
+    that can be executed by the ``Exchange``.
+
+    Two built-in implementations are provided:
+
+    * ``OrderGenWInteract`` – uses trade-date market information (prices,
+      tradability) when building orders. It automatically **re-normalises**
+      weights across *tradable* stocks so that the full allocatable capital
+      is utilised. Use this when the executor can interact with the exchange
+      at execution time.
+    * ``OrderGenWOInteract`` – generates orders **without** accessing
+      trade-date information. It relies on the prediction-date close price
+      (or the price recorded in the current position) to estimate order
+      amounts. This is the default used by ``WeightStrategyBase``.
+
+    Subclass this and override
+    ``generate_order_list_from_target_weight_position`` to implement custom
+    order generation logic.
+    """
+
     def generate_order_list_from_target_weight_position(
         self,
         current: Position,
@@ -23,32 +46,56 @@ class OrderGenerator:
         trade_start_time: pd.Timestamp,
         trade_end_time: pd.Timestamp,
     ) -> list:
-        """generate_order_list_from_target_weight_position
+        """Generate a list of orders from the target weight position.
 
-        :param current: The current position
+        :param current: The current portfolio position.
         :type current: Position
-        :param trade_exchange:
+        :param trade_exchange: The exchange instance providing market data,
+            tradability checks, and order-rounding utilities.
         :type trade_exchange: Exchange
-        :param target_weight_position: {stock_id : weight}
+        :param target_weight_position: Mapping ``{stock_id: weight}`` where
+            each weight is a float in ``(0, 1)`` representing the desired
+            portfolio proportion for that stock.
         :type target_weight_position: dict
-        :param risk_degree:
+        :param risk_degree: Fraction of total portfolio value that may be
+            allocated to risky assets (stocks). ``1.0`` means fully invested.
         :type risk_degree: float
-        :param pred_start_time:
+        :param pred_start_time: Start of the prediction time window.
         :type pred_start_time: pd.Timestamp
-        :param pred_end_time:
+        :param pred_end_time: End of the prediction time window.
         :type pred_end_time: pd.Timestamp
-        :param trade_start_time:
+        :param trade_start_time: Start of the actual trading time window.
         :type trade_start_time: pd.Timestamp
-        :param trade_end_time:
+        :param trade_end_time: End of the actual trading time window.
         :type trade_end_time: pd.Timestamp
 
         :rtype: list
+        :returns: A list of ``Order`` objects.
         """
         raise NotImplementedError()
 
 
 class OrderGenWInteract(OrderGenerator):
-    """Order Generator With Interact"""
+    """Order generator that uses trade-date market information.
+
+    This generator **interacts** with the exchange at execution time to
+    obtain accurate trade-date prices and tradability status. It
+    re-normalises the target weights so that the full tradable capital is
+    distributed only among stocks that are actually tradable on the trade
+    date.
+
+    Key behaviour:
+    * Calls ``Exchange.generate_amount_position_from_weight_position`` which
+      divides cash among tradable stocks proportionally to their weights,
+      effectively **ignoring suspended or limited stocks** and
+      redistributing their weight to the remaining tradable stocks.
+    * This ensures full capital utilisation when some stocks become
+      untradable between the prediction date and the trade date.
+
+    See Also
+    --------
+    OrderGenWOInteract : Alternative that does **not** use trade-date data.
+    """
 
     def generate_order_list_from_target_weight_position(
         self,
@@ -61,31 +108,32 @@ class OrderGenWInteract(OrderGenerator):
         trade_start_time: pd.Timestamp,
         trade_end_time: pd.Timestamp,
     ) -> list:
-        """generate_order_list_from_target_weight_position
+        """Generate orders using trade-date prices and tradability data.
 
-        No adjustment for for the nontradable share.
-        All the tadable value is assigned to the tadable stock according to the weight.
-        if interact == True, will use the price at trade date to generate order list
-        else, will only use the price before the trade date to generate order list
+        The tradable portfolio value is computed from the current position
+        valued at trade-date prices. Weights are then allocated only across
+        stocks that are tradable on the trade date, so the full allocatable
+        capital is utilised even when some target stocks are suspended.
 
-        :param current:
+        :param current: The current portfolio position.
         :type current: Position
-        :param trade_exchange:
+        :param trade_exchange: Exchange providing trade-date market data.
         :type trade_exchange: Exchange
-        :param target_weight_position:
+        :param target_weight_position: ``{stock_id: weight}`` mapping.
         :type target_weight_position: dict
-        :param risk_degree:
+        :param risk_degree: Fraction of portfolio allocated to stocks.
         :type risk_degree: float
-        :param pred_start_time:
+        :param pred_start_time: Start of the prediction window.
         :type pred_start_time: pd.Timestamp
-        :param pred_end_time:
+        :param pred_end_time: End of the prediction window.
         :type pred_end_time: pd.Timestamp
-        :param trade_start_time:
+        :param trade_start_time: Start of the trading window.
         :type trade_start_time: pd.Timestamp
-        :param trade_end_time:
+        :param trade_end_time: End of the trading window.
         :type trade_end_time: pd.Timestamp
 
         :rtype: list
+        :returns: A list of ``Order`` objects.
         """
         if target_weight_position is None:
             return []
@@ -140,7 +188,29 @@ class OrderGenWInteract(OrderGenerator):
 
 
 class OrderGenWOInteract(OrderGenerator):
-    """Order Generator Without Interact"""
+    """Order generator that does **not** use trade-date market information.
+
+    This is the **default** order generator for ``WeightStrategyBase``.
+
+    Because trade-date prices are unavailable at decision time, this
+    generator estimates order amounts using:
+
+    1. The **prediction-date close price** (``$close`` at ``pred_date``) for
+       stocks that are tradable on both the prediction date and the trade
+       date.
+    2. The **price recorded in the current position** for stocks that are
+       currently held but not tradable on the prediction date.
+
+    Unlike ``OrderGenWInteract``, this generator does **not** re-normalise
+    weights across tradable stocks. Stocks that are untradable on the trade
+    date are simply skipped, which may result in less than full capital
+    utilisation.
+
+    See Also
+    --------
+    OrderGenWInteract : Alternative that re-normalises weights using
+        trade-date data for full capital utilisation.
+    """
 
     def generate_order_list_from_target_weight_position(
         self,
@@ -153,33 +223,32 @@ class OrderGenWOInteract(OrderGenerator):
         trade_start_time: pd.Timestamp,
         trade_end_time: pd.Timestamp,
     ) -> list:
-        """generate_order_list_from_target_weight_position
+        """Generate orders without accessing trade-date information.
 
-        generate order list directly not using the information (e.g. whether can be traded, the accurate trade price)
-         at trade date.
-        In target weight position, generating order list need to know the price of objective stock in trade date,
-        but we cannot get that
-        value when do not interact with exchange, so we check the %close price at pred_date or price recorded
-        in current position.
+        Order amounts are estimated from prediction-date close prices or
+        prices recorded in the current position. Stocks that are untradable
+        on either the prediction date or the trade date are skipped (not
+        re-allocated to other stocks).
 
-        :param current:
+        :param current: The current portfolio position.
         :type current: Position
-        :param trade_exchange:
+        :param trade_exchange: Exchange providing market data.
         :type trade_exchange: Exchange
-        :param target_weight_position:
+        :param target_weight_position: ``{stock_id: weight}`` mapping.
         :type target_weight_position: dict
-        :param risk_degree:
+        :param risk_degree: Fraction of portfolio allocated to stocks.
         :type risk_degree: float
-        :param pred_start_time:
+        :param pred_start_time: Start of the prediction window.
         :type pred_start_time: pd.Timestamp
-        :param pred_end_time:
+        :param pred_end_time: End of the prediction window.
         :type pred_end_time: pd.Timestamp
-        :param trade_start_time:
+        :param trade_start_time: Start of the trading window.
         :type trade_start_time: pd.Timestamp
-        :param trade_end_time:
+        :param trade_end_time: End of the trading window.
         :type trade_end_time: pd.Timestamp
 
-        :rtype: list of generated orders
+        :rtype: list
+        :returns: A list of ``Order`` objects.
         """
         if target_weight_position is None:
             return []


### PR DESCRIPTION
## Summary
- Adds comprehensive class and method docstrings to `OrderGenerator`, `OrderGenWInteract`, and `OrderGenWOInteract` explaining weight normalisation differences and capital utilisation behaviour
- Documents `WeightStrategyBase` class with guidance on order generator selection and the `$factor` field requirement for round-lot trading
- Clarifies `Exchange.limit_threshold` parameter: the three modes (`None`, `float`, `Tuple[str, str]`) with examples and per-region defaults
- Documents `Exchange.get_factor` explaining the adjustment factor's role in `round_amount_by_trade_unit`

## Test plan
- [x] Verified all imports still work
- [x] Documentation-only changes — no behavioural modifications
- [ ] Existing tests pass without modification

Closes #2026