### PR TITLE
Fix missing freq param in cache update writer locks

### DIFF
--- a/qlib/data/cache.py
+++ b/qlib/data/cache.py
@@ -591,7 +591,7 @@ class DiskExpressionCache(ExpressionCache):
             self.clear_cache(cp_cache_uri)
             return 2
 
-        with CacheUtils.writer_lock(self.r, f"{str(C.dpm.get_data_uri())}:expression-{cache_uri}"):
+        with CacheUtils.writer_lock(self.r, f"{str(C.dpm.get_data_uri(freq))}:expression-{cache_uri}"):
             with meta_path.open("rb") as f:
                 d = restricted_pickle_load(f)
             instrument = d["info"]["instrument"]
@@ -958,7 +958,7 @@ class DiskDatasetCache(DatasetCache):
             return 2
 
         im = DiskDatasetCache.IndexManager(cp_cache_uri)
-        with CacheUtils.writer_lock(self.r, f"{str(C.dpm.get_data_uri())}:dataset-{cache_uri}"):
+        with CacheUtils.writer_lock(self.r, f"{str(C.dpm.get_data_uri(freq))}:dataset-{cache_uri}"):
             with meta_path.open("rb") as f:
                 d = restricted_pickle_load(f)
             instruments = d["info"]["instruments"]


### PR DESCRIPTION
## Summary
- Pass `freq` to `C.dpm.get_data_uri()` in `DiskExpressionCache.update()` (line 594) and `DiskDatasetCache.update()` (line 961)
- Without `freq`, `get_data_uri()` falls back to `DEFAULT_FREQ`, which raises `KeyError` when only non-default frequencies are configured

## Root Cause
Both `update()` methods receive a `freq` parameter but the writer lock calls `C.dpm.get_data_uri()` without forwarding it. This is inconsistent with all other call sites in the same file which correctly pass `freq`.

## Test plan
- Verified all other `get_data_uri` call sites in `cache.py` pass `freq` (lines 324, 549, 727, 737, 778, 783, 1155)
- The two fixed lines are the only ones that were missing the parameter

Fixes #2012