### PR TITLE
Fix date parsing, timezone, and type errors in Yahoo collector

### DIFF
--- a/scripts/data_collector/base.py
+++ b/scripts/data_collector/base.py
@@ -305,7 +305,7 @@ class Normalize:
         df = self._normalize_obj.normalize(df)
         if df is not None and not df.empty:
             if self._end_date is not None:
-                _mask = pd.to_datetime(df[self._date_field_name]) <= pd.Timestamp(self._end_date)
+                _mask = pd.to_datetime(df[self._date_field_name], utc=True).dt.tz_convert(None) <= pd.Timestamp(self._end_date)
                 df = df[_mask]
             df.to_csv(self._target_dir.joinpath(file_path.name), index=False)
 


### PR DESCRIPTION
## Summary
- Fix `ValueError` on mixed date formats (`YYYY-MM-DD` vs `YYYY-MM-DD HH:MM:SS`) by using `pd.to_datetime(utc=True)` which handles mixed formats across all pandas versions
- Fix `AttributeError: 'Index' object has no attribute 'tz_localize'` by switching to `tz_convert(None)` after `utc=True` conversion
- Fix `TypeError: unsupported operand type(s) for /: 'str' and 'float'` by adding `pd.to_numeric(errors="coerce")` before arithmetic operations on columns that may contain string data from CSV reads

## Changes
- `scripts/data_collector/yahoo/collector.py`: Fix `normalize_yahoo` date handling (lines 395-396), add numeric coercion in `adjusted_price` and `_manual_adj_data`
- `scripts/data_collector/base.py`: Fix `Normalize._executor` date filtering (line 308)

## Test plan
- The `fillna(method="ffill")` deprecation warning mentioned in the issue is already fixed in the current codebase (`.ffill()` is used)
- Performance improvements and `--skip_download` are feature requests beyond the scope of this bug fix PR

Fixes #1981