### PR TITLE
Fix ExpressionDFilter treating missing data as passing filter

### DIFF
--- a/qlib/data/filter.py
+++ b/qlib/data/filter.py
@@ -142,7 +142,7 @@ class SeriesDFilter(BaseDFilter):
             the series of bool value indicating whether the date satisfies the filter condition and exists in target timestamp.
         """
         fstart, fend = list(filter_series.keys())[0], list(filter_series.keys())[-1]
-        filter_series = filter_series.astype("bool")  # Make sure the filter_series is boolean
+        filter_series = filter_series.fillna(False).astype("bool")  # NaN means missing data, treat as not passing
         timestamp_series[fstart:fend] = timestamp_series[fstart:fend] & filter_series
         return timestamp_series
 


### PR DESCRIPTION
## Summary
- Fix NaN values in filter expressions being incorrectly treated as `True` (passing the filter)
- Add `fillna(False)` before `astype("bool")` in `SeriesDFilter._filterSeries`

## Root Cause
In `qlib/data/filter.py` line 145, `filter_series.astype("bool")` converts NaN to `True` due to pandas' casting behavior. This means instruments with missing feature data (e.g., during trading halts) incorrectly pass expression filters like `$close > 2000`.

## Fix
```python
# Before (NaN → True)
filter_series = filter_series.astype("bool")

# After (NaN → False)
filter_series = filter_series.fillna(False).astype("bool")
```

## Test plan
- `ExpressionDFilter(rule_expression='$close>2000')` should exclude instruments on dates where `$close` is missing
- Existing `_toTimestamp` NaN handling (lines 171-172) is now consistent with this fix

Fixes #2084