### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/test_qlib_from_source.yml
+++ b/.github/workflows/test_qlib_from_source.yml
@@ -103,7 +103,7 @@ jobs:
 
     - name: Unit tests with Pytest (MacOS)
       if: ${{ matrix.os == 'macos-14' || matrix.os == 'macos-15' }}
-      uses: nick-fields/retry@v2
+      uses: nick-fields/retry@v3
       with:
         timeout_minutes: 60
         max_attempts: 3
@@ -119,7 +119,7 @@ jobs:
 
     - name: Unit tests with Pytest (Ubuntu and Windows)
       if: ${{ matrix.os != 'macos-13' && matrix.os != 'macos-14' && matrix.os != 'macos-15' }}
-      uses: nick-fields/retry@v2
+      uses: nick-fields/retry@v3
       with:
         timeout_minutes: 60
         max_attempts: 3

--- a/.github/workflows/test_qlib_from_source_slow.yml
+++ b/.github/workflows/test_qlib_from_source_slow.yml
@@ -47,7 +47,7 @@ jobs:
         python -m pip install --no-binary=:all: lightgbm
 
     - name: Unit tests with Pytest
-      uses: nick-fields/retry@v2
+      uses: nick-fields/retry@v3
       with:
         timeout_minutes: 240
         max_attempts: 3


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `nick-fields/retry` | [`v2`](https://github.com/nick-fields/retry/releases/tag/v2) | [`v3`](https://github.com/nick-fields/retry/releases/tag/v3) | [Release](https://github.com/nick-fields/retry/releases/tag/v3) | test_qlib_from_source.yml, test_qlib_from_source_slow.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
