### PR TITLE
fix: Support new format of freq in pandas

### DIFF
--- a/qlib/contrib/report/analysis_model/analysis_model_performance.py
+++ b/qlib/contrib/report/analysis_model/analysis_model_performance.py
@@ -157,7 +157,7 @@ def _pred_ic(
     _month_list = pd.date_range(
         start=pd.Timestamp(f"{_index.min()[:4]}0101"),
         end=pd.Timestamp(f"{_index.max()[:4]}1231"),
-        freq="1M",
+        freq = '1ME' if tuple(map(int, pd.__version__.split('.'))) >= (2, 2, 0) else '1M',
     )
     _years = []
     _month = []

--- a/up.sh
+++ b/up.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+git pull upstream main
+git fetch upstream --tags --prune


### PR DESCRIPTION
## Description

Pandas deprecated 'M' in favor of 'ME' to make the frequency meaning more explicit and unambiguous.

## Motivation and Context

Use 'M' or 'ME' according to the version of pandas

## Types of changes

- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
