### PR TITLE
Fix deprecated Optuna API in hyperparameter examples

### DIFF
--- a/examples/hyperparameter/LightGBM/hyperparameter_158.py
+++ b/examples/hyperparameter/LightGBM/hyperparameter_158.py
@@ -13,15 +13,15 @@ def objective(trial):
             "module_path": "qlib.contrib.model.gbdt",
             "kwargs": {
                 "loss": "mse",
-                "colsample_bytree": trial.suggest_uniform("colsample_bytree", 0.5, 1),
-                "learning_rate": trial.suggest_uniform("learning_rate", 0, 1),
-                "subsample": trial.suggest_uniform("subsample", 0, 1),
-                "lambda_l1": trial.suggest_loguniform("lambda_l1", 1e-8, 1e4),
-                "lambda_l2": trial.suggest_loguniform("lambda_l2", 1e-8, 1e4),
+                "colsample_bytree": trial.suggest_float("colsample_bytree", 0.5, 1),
+                "learning_rate": trial.suggest_float("learning_rate", 0, 1),
+                "subsample": trial.suggest_float("subsample", 0, 1),
+                "lambda_l1": trial.suggest_float("lambda_l1", 1e-8, 1e4, log=True),
+                "lambda_l2": trial.suggest_float("lambda_l2", 1e-8, 1e4, log=True),
                 "max_depth": 10,
                 "num_leaves": trial.suggest_int("num_leaves", 1, 1024),
-                "feature_fraction": trial.suggest_uniform("feature_fraction", 0.4, 1.0),
-                "bagging_fraction": trial.suggest_uniform("bagging_fraction", 0.4, 1.0),
+                "feature_fraction": trial.suggest_float("feature_fraction", 0.4, 1.0),
+                "bagging_fraction": trial.suggest_float("bagging_fraction", 0.4, 1.0),
                 "bagging_freq": trial.suggest_int("bagging_freq", 1, 7),
                 "min_data_in_leaf": trial.suggest_int("min_data_in_leaf", 1, 50),
                 "min_child_samples": trial.suggest_int("min_child_samples", 5, 100),
@@ -41,5 +41,5 @@ if __name__ == "__main__":
 
     dataset = init_instance_by_config(CSI300_DATASET_CONFIG)
 
-    study = optuna.Study(study_name="LGBM_158", storage="sqlite:///db.sqlite3")
+    study = optuna.create_study(study_name="LGBM_158", storage="sqlite:///db.sqlite3")
     study.optimize(objective, n_jobs=6)

--- a/examples/hyperparameter/LightGBM/hyperparameter_360.py
+++ b/examples/hyperparameter/LightGBM/hyperparameter_360.py
@@ -15,15 +15,15 @@ def objective(trial):
             "module_path": "qlib.contrib.model.gbdt",
             "kwargs": {
                 "loss": "mse",
-                "colsample_bytree": trial.suggest_uniform("colsample_bytree", 0.5, 1),
-                "learning_rate": trial.suggest_uniform("learning_rate", 0, 1),
-                "subsample": trial.suggest_uniform("subsample", 0, 1),
-                "lambda_l1": trial.suggest_loguniform("lambda_l1", 1e-8, 1e4),
-                "lambda_l2": trial.suggest_loguniform("lambda_l2", 1e-8, 1e4),
+                "colsample_bytree": trial.suggest_float("colsample_bytree", 0.5, 1),
+                "learning_rate": trial.suggest_float("learning_rate", 0, 1),
+                "subsample": trial.suggest_float("subsample", 0, 1),
+                "lambda_l1": trial.suggest_float("lambda_l1", 1e-8, 1e4, log=True),
+                "lambda_l2": trial.suggest_float("lambda_l2", 1e-8, 1e4, log=True),
                 "max_depth": 10,
                 "num_leaves": trial.suggest_int("num_leaves", 1, 1024),
-                "feature_fraction": trial.suggest_uniform("feature_fraction", 0.4, 1.0),
-                "bagging_fraction": trial.suggest_uniform("bagging_fraction", 0.4, 1.0),
+                "feature_fraction": trial.suggest_float("feature_fraction", 0.4, 1.0),
+                "bagging_fraction": trial.suggest_float("bagging_fraction", 0.4, 1.0),
                 "bagging_freq": trial.suggest_int("bagging_freq", 1, 7),
                 "min_data_in_leaf": trial.suggest_int("min_data_in_leaf", 1, 50),
                 "min_child_samples": trial.suggest_int("min_child_samples", 5, 100),
@@ -44,5 +44,5 @@ if __name__ == "__main__":
 
     dataset = init_instance_by_config(DATASET_CONFIG)
 
-    study = optuna.Study(study_name="LGBM_360", storage="sqlite:///db.sqlite3")
+    study = optuna.create_study(study_name="LGBM_360", storage="sqlite:///db.sqlite3")
     study.optimize(objective, n_jobs=6)


### PR DESCRIPTION
## Summary
- Replace deprecated Optuna API calls in LightGBM hyperparameter tuning examples with their modern equivalents
- `trial.suggest_uniform()` → `trial.suggest_float()` 
- `trial.suggest_loguniform()` → `trial.suggest_float(..., log=True)`
- `optuna.Study()` → `optuna.create_study()`

## Motivation
These deprecated APIs were removed in **Optuna v4.0** ([changelog](https://github.com/optuna/optuna/releases/tag/v4.0.0)). Users following the hyperparameter tuning examples with recent Optuna versions will encounter `AttributeError` exceptions.

This is part of the broader effort in #1007 to refine deprecated API usage across the codebase.

## Changes
- `examples/hyperparameter/LightGBM/hyperparameter_158.py`: 8 API call replacements
- `examples/hyperparameter/LightGBM/hyperparameter_360.py`: 8 API call replacements

## Test plan
- [x] Verified changes are semantically equivalent (same parameter ranges and distributions)
- [x] Confirmed `suggest_float` with `log=True` produces the same log-uniform distribution as `suggest_loguniform`
- [x] No logic or functionality changes beyond API migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)