### PR TITLE
Fix UnpicklingError for qlib contrib handlers (Alpha158)

### DIFF
--- a/qlib/utils/pickle_utils.py
+++ b/qlib/utils/pickle_utils.py
@@ -46,15 +46,13 @@ SAFE_PICKLE_CLASSES: Set[Tuple[str, str]] = {
     ("pathlib", "Path"),
     ("pathlib", "PosixPath"),
     ("pathlib", "WindowsPath"),
-    ("qlib.data.dataset.handler", "DataHandler"),
-    ("qlib.data.dataset.handler", "DataHandlerLP"),
-    ("qlib.data.dataset.loader", "StaticDataLoader"),
 }
 
 
 TRUSTED_MODULE_PREFIXES = (
     "pandas",
     "numpy",
+    "qlib",
 )
 
 


### PR DESCRIPTION
## Summary
- Add qlib to TRUSTED_MODULE_PREFIXES in pickle_utils.py so all qlib internal classes are allowed during pickle deserialization
- Remove redundant individual qlib class entries from SAFE_PICKLE_CLASSES

## Root Cause
PR #2099 introduced RestrictedUnpickler but only whitelisted three specific qlib classes. Many contrib classes like Alpha158, Alpha360, etc. were missing, causing UnpicklingError during rolling train.

## Fix
Add qlib to TRUSTED_MODULE_PREFIXES (alongside pandas and numpy). This ensures all qlib internal classes are trusted for deserialization while still blocking arbitrary external classes.

## Test plan
- Existing test in tests/data_mid_layer_tests/test_handler.py continues to work
- Manual test: run rolling train with Alpha158 handler config

Fixes #2130