### PR TITLE
Fix lint issues in qlib/utils/ (W1309, W0612)

### DIFF
--- a/qlib/utils/data.py
+++ b/qlib/utils/data.py
@@ -113,5 +113,5 @@ def guess_horizon(label: List):
     Try to guess the horizon by parsing label
     """
     expr = DatasetProvider.parse_fields(label)[0]
-    lft_etd, rght_etd = expr.get_extended_window_size()
+    _lft_etd, rght_etd = expr.get_extended_window_size()
     return rght_etd

--- a/qlib/utils/index_data.py
+++ b/qlib/utils/index_data.py
@@ -33,7 +33,7 @@ def concat(data_list: Union[SingleData], axis=0) -> MultiData:
         the MultiData with ndim == 2
     """
     if axis == 0:
-        raise NotImplementedError(f"please implement this func when axis == 0")
+        raise NotImplementedError("please implement this func when axis == 0")
     elif axis == 1:
         # get all index and row
         all_index = set()
@@ -51,7 +51,7 @@ def concat(data_list: Union[SingleData], axis=0) -> MultiData:
             tmp_data[now_data_map, data_id] = index_data.data
         return MultiData(tmp_data, all_index)
     else:
-        raise ValueError(f"axis must be 0 or 1")
+        raise ValueError("axis must be 0 or 1")
 
 
 def sum_by_index(data_list: Union[SingleData], new_index: list, fill_value=0) -> SingleData:
@@ -432,7 +432,7 @@ class IndexData(metaclass=index_data_ops_creator):
         IndexData:
             the data in `other` with index aligned to `self`
         """
-        raise NotImplementedError(f"please implement _align_indices func")
+        raise NotImplementedError("please implement _align_indices func")
 
     def sort_index(self, axis=0, inplace=True):
         assert inplace, "Only support sorting inplace now"
@@ -483,7 +483,7 @@ class IndexData(metaclass=index_data_ops_creator):
             tmp_data = np.nansum(self.data, axis=1)
             return SingleData(tmp_data, self.index)
         else:
-            raise ValueError(f"axis must be None, 0 or 1")
+            raise ValueError("axis must be None, 0 or 1")
 
     def mean(self, axis=None, dtype=None, out=None):
         assert out is None and dtype is None, "`out` is just for compatible with numpy's aggregating function"
@@ -497,7 +497,7 @@ class IndexData(metaclass=index_data_ops_creator):
             tmp_data = np.nanmean(self.data, axis=1)
             return SingleData(tmp_data, self.index)
         else:
-            raise ValueError(f"axis must be None, 0 or 1")
+            raise ValueError("axis must be None, 0 or 1")
 
     def isna(self):
         return self.__class__(np.isnan(self.data), *self.indices)
@@ -563,7 +563,7 @@ class SingleData(IndexData):
             return other.reindex(self.index)
         else:
             raise ValueError(
-                f"The indexes of self and other do not meet the requirements of the four arithmetic operations"
+                "The indexes of self and other do not meet the requirements of the four arithmetic operations"
             )
 
     def reindex(self, index: Index, fill_value=np.nan) -> SingleData:
@@ -647,7 +647,7 @@ class MultiData(IndexData):
             return other
         else:
             raise ValueError(
-                f"The indexes of self and other do not meet the requirements of the four arithmetic operations"
+                "The indexes of self and other do not meet the requirements of the four arithmetic operations"
             )
 
     def __repr__(self) -> str:

--- a/qlib/utils/mod.py
+++ b/qlib/utils/mod.py
@@ -112,7 +112,7 @@ def get_callable_kwargs(config: InstConf, default_module: Union[str, ModuleType]
         _callable = getattr(module, cls)
         kwargs = {}
     else:
-        raise NotImplementedError(f"This type of input is not supported")
+        raise NotImplementedError("This type of input is not supported")
     return _callable, kwargs
 
 

--- a/qlib/utils/objm.py
+++ b/qlib/utils/objm.py
@@ -21,7 +21,7 @@ class ObjManager:
         name : str
             name of the object
         """
-        raise NotImplementedError(f"Please implement `save_obj`")
+        raise NotImplementedError("Please implement `save_obj`")
 
     def save_objs(self, obj_name_l):
         """
@@ -31,7 +31,7 @@ class ObjManager:
         ----------
         obj_name_l : list of <obj, name>
         """
-        raise NotImplementedError(f"Please implement the `save_objs` method")
+        raise NotImplementedError("Please implement the `save_objs` method")
 
     def load_obj(self, name: str) -> object:
         """
@@ -47,7 +47,7 @@ class ObjManager:
         object:
             loaded object
         """
-        raise NotImplementedError(f"Please implement the `load_obj` method")
+        raise NotImplementedError("Please implement the `load_obj` method")
 
     def exists(self, name: str) -> bool:
         """
@@ -63,7 +63,7 @@ class ObjManager:
         bool:
             If the object exists
         """
-        raise NotImplementedError(f"Please implement the `exists` method")
+        raise NotImplementedError("Please implement the `exists` method")
 
     def list(self) -> list:
         """
@@ -74,7 +74,7 @@ class ObjManager:
         list:
             the list of returned objects
         """
-        raise NotImplementedError(f"Please implement the `list` method")
+        raise NotImplementedError("Please implement the `list` method")
 
     def remove(self, fname=None):
         """remove.
@@ -85,7 +85,7 @@ class ObjManager:
             if file name is provided. specific file is removed
             otherwise, The all the objects will be removed.
         """
-        raise NotImplementedError(f"Please implement the `remove` method")
+        raise NotImplementedError("Please implement the `remove` method")
 
 
 class FileManager(ObjManager):
@@ -104,7 +104,7 @@ class FileManager(ObjManager):
             return tempfile.mkdtemp(prefix=str(C["file_manager_path"]) + os.sep)
         except AttributeError as attribute_e:
             raise NotImplementedError(
-                f"If path is not given, the `create_path` function should be implemented"
+                "If path is not given, the `create_path` function should be implemented"
             ) from attribute_e
 
     def save_obj(self, obj, name):

--- a/qlib/utils/time.py
+++ b/qlib/utils/time.py
@@ -124,7 +124,7 @@ class Freq:
         elif isinstance(freq, Freq):
             self.count, self.base = freq.count, freq.base
         else:
-            raise NotImplementedError(f"This type of input is not supported")
+            raise NotImplementedError("This type of input is not supported")
 
     def __eq__(self, freq):
         freq = Freq(freq)


### PR DESCRIPTION
## Summary
- Remove unnecessary `f` prefix from 16 string literals in `qlib/utils/` that contain no interpolated variables (pylint W1309: `f-string-without-interpolation`)
- Prefix unused variable `lft_etd` with underscore in `qlib/utils/data.py` to indicate it is intentionally unused (pylint W0612: `unused-variable`)

Contributes to #1007

## Details

**Files changed:**
- `qlib/utils/index_data.py` — 7 f-string fixes
- `qlib/utils/objm.py` — 7 f-string fixes  
- `qlib/utils/mod.py` — 1 f-string fix
- `qlib/utils/time.py` — 1 f-string fix
- `qlib/utils/data.py` — 1 unused variable fix (`lft_etd` → `_lft_etd`)

All changes are safe cosmetic/lint fixes with no behavioral impact. The existing flake8 and pylint CI checks continue to pass, and the previously-disabled W1309 and W0612 rules now pass cleanly for `qlib/utils/`.

## Test plan
- [x] Verified `flake8` passes with project config (`make flake8` equivalent)
- [x] Verified `pylint` passes with project config (`make pylint` equivalent)
- [x] Verified W1309 (f-string-without-interpolation) reports 0 issues in `qlib/utils/`
- [x] Verified W0612 (unused-variable) reports 0 issues in `qlib/utils/`
- [x] All changes are purely cosmetic — no logic or behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)