### PR TITLE
fix: upgrade deprecated LightGBM API in docs and version constraints

### DIFF
--- a/docs/start/integration.rst
+++ b/docs/start/integration.rst
@@ -57,16 +57,17 @@ The Custom models need to inherit `qlib.model.base.Model <../reference/api.html#
                 dtrain = lgb.Dataset(x_train.values, label=y_train)
                 dvalid = lgb.Dataset(x_valid.values, label=y_valid)
 
-                # fit the model
+                # fit the model using callbacks (LightGBM >= 3.3.0)
+                early_stopping_callback = lgb.early_stopping(early_stopping_rounds)
+                verbose_eval_callback = lgb.log_evaluation(period=verbose_eval)
+                evals_result_callback = lgb.record_evaluation(evals_result)
                 self.model = lgb.train(
                     self.params,
                     dtrain,
                     num_boost_round=num_boost_round,
                     valid_sets=[dtrain, dvalid],
                     valid_names=["train", "valid"],
-                    early_stopping_rounds=early_stopping_rounds,
-                    verbose_eval=verbose_eval,
-                    evals_result=evals_result,
+                    callbacks=[early_stopping_callback, verbose_eval_callback, evals_result_callback],
                     **kwargs
                 )
 
@@ -94,6 +95,7 @@ The Custom models need to inherit `qlib.model.base.Model <../reference/api.html#
             def finetune(self, dataset: DatasetH, num_boost_round=10, verbose_eval=20):
                 # Based on existing model and finetune by train more rounds
                 dtrain, _ = self._prepare_data(dataset)
+                verbose_eval_callback = lgb.log_evaluation(period=verbose_eval)
                 self.model = lgb.train(
                     self.params,
                     dtrain,
@@ -101,7 +103,7 @@ The Custom models need to inherit `qlib.model.base.Model <../reference/api.html#
                     init_model=self.model,
                     valid_sets=[dtrain],
                     valid_names=["train"],
-                    verbose_eval=verbose_eval,
+                    callbacks=[verbose_eval_callback],
                 )
 
 Configuration File

--- a/examples/benchmarks/DoubleEnsemble/requirements.txt
+++ b/examples/benchmarks/DoubleEnsemble/requirements.txt
@@ -1,3 +1,3 @@
 pandas==1.1.2
 numpy==1.21.0
-lightgbm==3.1.0
+lightgbm>=3.3.0

--- a/examples/hyperparameter/LightGBM/requirements.txt
+++ b/examples/hyperparameter/LightGBM/requirements.txt
@@ -1,5 +1,5 @@
 pandas==1.1.2
 numpy==1.21.0
-lightgbm==3.1.0
+lightgbm>=3.3.0
 optuna==2.7.0
 optuna-dashboard==0.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,10 @@ dependencies = [
   "tqdm",
   "pymongo",
   "loguru",
-  "lightgbm",
+  # Since version 3.3.0, lightgbm supports the callback-based API
+  # (early_stopping(), log_evaluation(), record_evaluation()).
+  # The deprecated parameter-based API was removed in lightgbm 4.0.
+  "lightgbm>=3.3.0",
   "gym",
   "cvxpy",
   "joblib",


### PR DESCRIPTION
## Summary
- Update documentation (`docs/start/integration.rst`) to use LightGBM's modern callback-based API instead of deprecated parameters
- Set minimum `lightgbm>=3.3.0` in `pyproject.toml` (callback API was introduced in 3.3.0)
- Update example `requirements.txt` files from `lightgbm==3.1.0` to `lightgbm>=3.3.0`

## Problem
The core model code was already fixed in PR #974 to use callbacks (`lgb.early_stopping()`, `lgb.log_evaluation()`, `lgb.record_evaluation()`), but:
1. The **documentation** still showed the deprecated API (`early_stopping_rounds`, `verbose_eval`, `evals_result` passed directly to `lgb.train()`), which was removed in LightGBM 4.0
2. The **minimum version** in `pyproject.toml` had no lower bound, allowing installation of LightGBM versions that don't support the callback API
3. Example **requirements.txt** files pinned `lightgbm==3.1.0`, which predates the callback API (introduced in 3.3.0)

## Changes
| File | Change |
|------|--------|
| `docs/start/integration.rst` | Replace deprecated `lgb.train()` parameters with callback equivalents |
| `pyproject.toml` | `"lightgbm"` → `"lightgbm>=3.3.0"` |
| `examples/benchmarks/DoubleEnsemble/requirements.txt` | `lightgbm==3.1.0` → `lightgbm>=3.3.0` |
| `examples/hyperparameter/LightGBM/requirements.txt` | `lightgbm==3.1.0` → `lightgbm>=3.3.0` |

## Test plan
- [x] Verified core model files (`gbdt.py`, `highfreq_gdbt_model.py`, `double_ensemble.py`) already use callback API correctly
- [x] Documentation examples now match the actual implementation in `qlib/contrib/model/gbdt.py`
- [x] Version constraint ensures compatibility with the callback-based code

Closes #904

🤖 Generated with [Claude Code](https://claude.com/claude-code)