### PR TITLE
fix(yahoo): use adjclose for $change calculation

### DIFF
--- a/scripts/data_collector/yahoo/collector.py
+++ b/scripts/data_collector/yahoo/collector.py
@@ -371,7 +371,9 @@ class YahooNormalize(BaseNormalize):
     @staticmethod
     def calc_change(df: pd.DataFrame, last_close: float) -> pd.Series:
         df = df.copy()
-        _tmp_series = df["close"].ffill()
+        # Use adjusted close to correctly account for splits/dividends
+        _close_col = "adjclose" if "adjclose" in df.columns else "close"
+        _tmp_series = df[_close_col].ffill()
         _tmp_shift_series = _tmp_series.shift(1)
         if last_close is not None:
             _tmp_shift_series.iloc[0] = float(last_close)

--- a/tests/test_yahoo_collector.py
+++ b/tests/test_yahoo_collector.py
@@ -1,0 +1,27 @@
+import pandas as pd
+import pytest
+
+from scripts.data_collector.yahoo.collector import YahooNormalize
+
+
+def test_calc_change_uses_adjusted_close_across_split() -> None:
+    frame = pd.DataFrame(
+        {
+            "close": [100.0, 50.0],
+            "adjclose": [25.0, 25.0],
+        }
+    )
+
+    change = YahooNormalize.calc_change(frame, last_close=None)
+
+    assert pd.isna(change.iloc[0])
+    assert change.iloc[1] == pytest.approx(0.0)
+
+
+def test_calc_change_falls_back_to_close() -> None:
+    frame = pd.DataFrame({"close": [100.0, 110.0]})
+
+    change = YahooNormalize.calc_change(frame, last_close=None)
+
+    assert pd.isna(change.iloc[0])
+    assert change.iloc[1] == pytest.approx(0.1)


### PR DESCRIPTION
## Summary

Fixes #1563. `YahooNormalize.calc_change()` previously used raw close prices, so splits and dividends could create artificial return spikes that were then interpreted as limit-up or limit-down events during backtests.

- Use `adjclose` when Yahoo provides it.
- Retain `close` as a fallback for sources without adjusted prices.
- Add focused regressions for split-adjusted and fallback behavior.

## Verification

- `python -m pytest tests/test_yahoo_collector.py -q` — 2 passed
- Ruff and formatting checks pass for the new test.
- Diff whitespace check passes.