### PR TITLE
fix(model): use `in` instead of `==` for metric comparison in HIST and IGMTF

### DIFF
--- a/qlib/contrib/model/pytorch_hist.py
+++ b/qlib/contrib/model/pytorch_hist.py
@@ -170,7 +170,7 @@ class HIST(Model):
             vy = y - torch.mean(y)
             return torch.sum(vx * vy) / (torch.sqrt(torch.sum(vx**2)) * torch.sqrt(torch.sum(vy**2)))
 
-        if self.metric == ("", "loss"):
+        if self.metric in ("", "loss"):
             return -self.loss_fn(pred[mask], label[mask])
 
         raise ValueError("unknown metric `%s`" % self.metric)

--- a/qlib/contrib/model/pytorch_igmtf.py
+++ b/qlib/contrib/model/pytorch_igmtf.py
@@ -163,7 +163,7 @@ class IGMTF(Model):
             vy = y - torch.mean(y)
             return torch.sum(vx * vy) / (torch.sqrt(torch.sum(vx**2)) * torch.sqrt(torch.sum(vy**2)))
 
-        if self.metric == ("", "loss"):
+        if self.metric in ("", "loss"):
             return -self.loss_fn(pred[mask], label[mask])
 
         raise ValueError("unknown metric `%s`" % self.metric)


### PR DESCRIPTION
## Summary

Fixes #2163

`metric_fn()` in `pytorch_hist.py` and `pytorch_igmtf.py` compares `self.metric` against the tuple `("", "loss")` using `==`. Since `self.metric` is always a string, this condition is never true, causing `ValueError("unknown metric")` on the default metric path.

All other models (ALSTM, GRU, LSTM, ALSTM_TS) correctly use `in ("", "loss")`.

## Changes

- `qlib/contrib/model/pytorch_hist.py`: `==` → `in` (line 173)
- `qlib/contrib/model/pytorch_igmtf.py`: `==` → `in` (line 166)

## Before / After

```python
# Before (broken): string == tuple is always False
if self.metric == ("", "loss"):

# After (correct): matches when metric is "" or "loss"
if self.metric in ("", "loss"):
```