### PR TITLE
fix(data): assign sort_index() result in filter.py

### DIFF
--- a/qlib/data/filter.py
+++ b/qlib/data/filter.py
@@ -160,7 +160,7 @@ class SeriesDFilter(BaseDFilter):
             the list of tuple (timestamp, timestamp).
         """
         # sort the timestamp_series according to the timestamps
-        timestamp_series.sort_index()
+        timestamp_series = timestamp_series.sort_index()
         timestamp = []
         _lbool = None
         _ltime = None


### PR DESCRIPTION
## Summary

Fixes #2165

`timestamp_series.sort_index()` in `filter.py:163` discards the return value. Since `pandas.Series.sort_index()` is not in-place by default, the series remains unsorted, potentially producing incorrect timestamp ranges.

## Change

```diff
- timestamp_series.sort_index()
+ timestamp_series = timestamp_series.sort_index()
```

One line, one file.