### PR TITLE
fix(workflow): correct filelock path for file:// URIs

### DIFF
--- a/qlib/workflow/expm.py
+++ b/qlib/workflow/expm.py
@@ -233,7 +233,7 @@ class ExpManager:
             # So we supported it in the interface wrapper
             pr = urlparse(self.uri)
             if pr.scheme == "file":
-                with FileLock(Path(os.path.join(pr.netloc, pr.path.lstrip("/"), "filelock"))):  # pylint: disable=E0110
+                with FileLock(Path(pr.netloc + pr.path) / "filelock"):  # pylint: disable=E0110
                     return self.create_exp(experiment_name), True
             # NOTE: for other schemes like http, we double check to avoid create exp conflicts
             try:


### PR DESCRIPTION
## Summary

Fixes #2129

For `file:///home/user/project/mlruns`, `urlparse` gives `netloc=""` and `path="/home/user/project/mlruns"`. The previous code used `pr.path.lstrip("/")` which stripped the leading `/`, making the path relative. `os.path.join("", "home/user/...", "filelock")` then resolved it relative to cwd, producing a doubled path:

```
/home/user/project/home/user/project/mlruns/filelock
```

## Fix

```diff
- Path(os.path.join(pr.netloc, pr.path.lstrip("/"), "filelock"))
+ Path(pr.netloc + pr.path) / "filelock"
```

Preserves the absolute path from the URI directly.