### PR TITLE
fix(model): add pretrain toggle to HIST model

### DIFF
--- a/qlib/contrib/model/pytorch_hist.py
+++ b/qlib/contrib/model/pytorch_hist.py
@@ -59,6 +59,7 @@ class HIST(Model):
         optimizer="adam",
         GPU=0,
         seed=None,
+        pretrain=True,
         **kwargs,
     ):
         # Set logger.
@@ -82,6 +83,7 @@ class HIST(Model):
         self.stock_index = stock_index
         self.device = torch.device("cuda:%d" % (GPU) if torch.cuda.is_available() and GPU >= 0 else "cpu")
         self.seed = seed
+        self.pretrain = pretrain
 
         self.logger.info(
             "HIST parameters setting:"
@@ -277,24 +279,25 @@ class HIST(Model):
         evals_result["valid"] = []
 
         # load pretrained base_model
-        if self.base_model == "LSTM":
-            pretrained_model = LSTMModel()
-        elif self.base_model == "GRU":
-            pretrained_model = GRUModel()
-        else:
-            raise ValueError("unknown base model name `%s`" % self.base_model)
+        if self.pretrain:
+            if self.base_model == "LSTM":
+                pretrained_model = LSTMModel()
+            elif self.base_model == "GRU":
+                pretrained_model = GRUModel()
+            else:
+                raise ValueError("unknown base model name `%s`" % self.base_model)
 
-        if self.model_path is not None:
-            self.logger.info("Loading pretrained model...")
-            pretrained_model.load_state_dict(torch.load(self.model_path))
+            if self.model_path is not None:
+                self.logger.info("Loading pretrained model...")
+                pretrained_model.load_state_dict(torch.load(self.model_path))
 
-        model_dict = self.HIST_model.state_dict()
-        pretrained_dict = {
-            k: v for k, v in pretrained_model.state_dict().items() if k in model_dict  # pylint: disable=E1135
-        }
-        model_dict.update(pretrained_dict)
-        self.HIST_model.load_state_dict(model_dict)
-        self.logger.info("Loading pretrained model Done...")
+            model_dict = self.HIST_model.state_dict()
+            pretrained_dict = {
+                k: v for k, v in pretrained_model.state_dict().items() if k in model_dict  # pylint: disable=E1135
+            }
+            model_dict.update(pretrained_dict)
+            self.HIST_model.load_state_dict(model_dict)
+            self.logger.info("Loading pretrained model Done...")
 
         # train
         self.logger.info("training...")


### PR DESCRIPTION
## Summary

Fixes #2074

Added a `pretrain` parameter (default `True` for backward compatibility) to HIST model. When `pretrain=False`, the model trains from scratch without loading pretrained base_model weights.

## Changes

- `qlib/contrib/model/pytorch_hist.py`:
  - Add `pretrain=True` parameter to `__init__`
  - Wrap weight-loading logic in `if self.pretrain:`

## Usage

```python
# Default: loads pretrained weights (backward compatible)
model = HISTModel(model_path="path/to/weights")

# Train from scratch
model = HISTModel(pretrain=False)
```