### PR TITLE
fix: replace mutable default evals_result=dict() across 27 contrib models

### DIFF
--- a/qlib/contrib/model/catboost_model.py
+++ b/qlib/contrib/model/catboost_model.py
@@ -31,10 +31,13 @@ class CatBoostModel(Model, FeatureInt):
         num_boost_round=1000,
         early_stopping_rounds=50,
         verbose_eval=20,
-        evals_result=dict(),
+        evals_result=None,
         reweighter=None,
         **kwargs,
     ):
+        if evals_result is None:
+            evals_result = {}
+
         df_train, df_valid = dataset.prepare(
             ["train", "valid"],
             col_set=["feature", "label"],

--- a/qlib/contrib/model/pytorch_adarnn.py
+++ b/qlib/contrib/model/pytorch_adarnn.py
@@ -242,9 +242,12 @@ class ADARNN(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
+
         df_train, df_valid = dataset.prepare(
             ["train", "valid"],
             col_set=["feature", "label"],

--- a/qlib/contrib/model/pytorch_add.py
+++ b/qlib/contrib/model/pytorch_add.py
@@ -363,9 +363,12 @@ class ADD(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
+
         label_train, label_valid = dataset.prepare(
             ["train", "valid"],
             col_set=["label"],

--- a/qlib/contrib/model/pytorch_alstm.py
+++ b/qlib/contrib/model/pytorch_alstm.py
@@ -209,9 +209,12 @@ class ALSTM(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
+
         df_train, df_valid, df_test = dataset.prepare(
             ["train", "valid", "test"],
             col_set=["feature", "label"],

--- a/qlib/contrib/model/pytorch_alstm_ts.py
+++ b/qlib/contrib/model/pytorch_alstm_ts.py
@@ -206,10 +206,13 @@ class ALSTM(Model):
     def fit(
         self,
         dataset,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
         reweighter=None,
     ):
+        if evals_result is None:
+            evals_result = {}
+
         dl_train = dataset.prepare("train", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)
         dl_valid = dataset.prepare("valid", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)
         if dl_train.empty or dl_valid.empty:

--- a/qlib/contrib/model/pytorch_gats.py
+++ b/qlib/contrib/model/pytorch_gats.py
@@ -224,9 +224,12 @@ class GATs(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
+
         df_train, df_valid, df_test = dataset.prepare(
             ["train", "valid", "test"],
             col_set=["feature", "label"],

--- a/qlib/contrib/model/pytorch_gats_ts.py
+++ b/qlib/contrib/model/pytorch_gats_ts.py
@@ -233,9 +233,12 @@ class GATs(Model):
     def fit(
         self,
         dataset,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
+
         dl_train = dataset.prepare("train", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)
         dl_valid = dataset.prepare("valid", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)
         if dl_train.empty or dl_valid.empty:

--- a/qlib/contrib/model/pytorch_general_nn.py
+++ b/qlib/contrib/model/pytorch_general_nn.py
@@ -235,10 +235,13 @@ class GeneralPTNN(Model):
     def fit(
         self,
         dataset: Union[DatasetH, TSDatasetH],
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
         reweighter=None,
     ):
+        if evals_result is None:
+            evals_result = {}
+
         ists = isinstance(dataset, TSDatasetH)  # is this time series dataset
 
         dl_train = dataset.prepare("train", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)

--- a/qlib/contrib/model/pytorch_gru.py
+++ b/qlib/contrib/model/pytorch_gru.py
@@ -209,9 +209,12 @@ class GRU(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
+
         # prepare training and validation data
         dfs = {
             k: dataset.prepare(

--- a/qlib/contrib/model/pytorch_gru_ts.py
+++ b/qlib/contrib/model/pytorch_gru_ts.py
@@ -200,10 +200,13 @@ class GRU(Model):
     def fit(
         self,
         dataset,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
         reweighter=None,
     ):
+        if evals_result is None:
+            evals_result = {}
+
         dl_train = dataset.prepare("train", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)
         dl_valid = dataset.prepare("valid", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)
         if dl_train.empty or dl_valid.empty:

--- a/qlib/contrib/model/pytorch_hist.py
+++ b/qlib/contrib/model/pytorch_hist.py
@@ -244,9 +244,12 @@ class HIST(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
+
         df_train, df_valid, df_test = dataset.prepare(
             ["train", "valid", "test"],
             col_set=["feature", "label"],

--- a/qlib/contrib/model/pytorch_igmtf.py
+++ b/qlib/contrib/model/pytorch_igmtf.py
@@ -248,9 +248,12 @@ class IGMTF(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
+
         df_train, df_valid = dataset.prepare(
             ["train", "valid"],
             col_set=["feature", "label"],

--- a/qlib/contrib/model/pytorch_krnn.py
+++ b/qlib/contrib/model/pytorch_krnn.py
@@ -432,9 +432,12 @@ class KRNN(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
+
         df_train, df_valid, df_test = dataset.prepare(
             ["train", "valid", "test"],
             col_set=["feature", "label"],

--- a/qlib/contrib/model/pytorch_localformer.py
+++ b/qlib/contrib/model/pytorch_localformer.py
@@ -158,9 +158,12 @@ class LocalformerModel(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
+
         df_train, df_valid, df_test = dataset.prepare(
             ["train", "valid", "test"],
             col_set=["feature", "label"],

--- a/qlib/contrib/model/pytorch_localformer_ts.py
+++ b/qlib/contrib/model/pytorch_localformer_ts.py
@@ -140,9 +140,12 @@ class LocalformerModel(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
+
         dl_train = dataset.prepare("train", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)
         dl_valid = dataset.prepare("valid", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)
         if dl_train.empty or dl_valid.empty:

--- a/qlib/contrib/model/pytorch_lstm.py
+++ b/qlib/contrib/model/pytorch_lstm.py
@@ -204,9 +204,12 @@ class LSTM(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
+
         df_train, df_valid, df_test = dataset.prepare(
             ["train", "valid", "test"],
             col_set=["feature", "label"],

--- a/qlib/contrib/model/pytorch_lstm_ts.py
+++ b/qlib/contrib/model/pytorch_lstm_ts.py
@@ -195,10 +195,13 @@ class LSTM(Model):
     def fit(
         self,
         dataset,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
         reweighter=None,
     ):
+        if evals_result is None:
+            evals_result = {}
+
         dl_train = dataset.prepare("train", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)
         dl_valid = dataset.prepare("valid", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)
         if dl_train.empty or dl_valid.empty:

--- a/qlib/contrib/model/pytorch_nn.py
+++ b/qlib/contrib/model/pytorch_nn.py
@@ -190,11 +190,14 @@ class DNNModelPytorch(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         verbose=True,
         save_path=None,
         reweighter=None,
     ):
+        if evals_result is None:
+            evals_result = {}
+
         has_valid = "valid" in dataset.segments
         segments = ["train", "valid"]
         vars = ["x", "y", "w"]

--- a/qlib/contrib/model/pytorch_sandwich.py
+++ b/qlib/contrib/model/pytorch_sandwich.py
@@ -302,9 +302,12 @@ class Sandwich(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
+
         df_train, df_valid, df_test = dataset.prepare(
             ["train", "valid", "test"],
             col_set=["feature", "label"],

--- a/qlib/contrib/model/pytorch_sfm.py
+++ b/qlib/contrib/model/pytorch_sfm.py
@@ -360,9 +360,12 @@ class SFM(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
+
         df_train, df_valid = dataset.prepare(
             ["train", "valid"],
             col_set=["feature", "label"],

--- a/qlib/contrib/model/pytorch_tabnet.py
+++ b/qlib/contrib/model/pytorch_tabnet.py
@@ -151,9 +151,12 @@ class TabnetModel(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
+
         if self.pretrain:
             # there is a  pretrained model, load the model
             self.logger.info("Pretrain...")

--- a/qlib/contrib/model/pytorch_tcn.py
+++ b/qlib/contrib/model/pytorch_tcn.py
@@ -216,9 +216,12 @@ class TCN(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
+
         df_train, df_valid, df_test = dataset.prepare(
             ["train", "valid", "test"],
             col_set=["feature", "label"],

--- a/qlib/contrib/model/pytorch_tcn_ts.py
+++ b/qlib/contrib/model/pytorch_tcn_ts.py
@@ -203,9 +203,12 @@ class TCN(Model):
     def fit(
         self,
         dataset,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
+
         dl_train = dataset.prepare("train", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)
         dl_valid = dataset.prepare("valid", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)
 

--- a/qlib/contrib/model/pytorch_tra.py
+++ b/qlib/contrib/model/pytorch_tra.py
@@ -413,8 +413,11 @@ class TRAModel(Model):
 
         return best_score
 
-    def fit(self, dataset, evals_result=dict()):
+    def fit(self, dataset, evals_result=None):
         assert isinstance(dataset, MTSDatasetH), "TRAModel only supports `qlib.contrib.data.dataset.MTSDatasetH`"
+
+        if evals_result is None:
+            evals_result = {}
 
         train_set, valid_set, test_set = dataset.prepare(["train", "valid", "test"])
 

--- a/qlib/contrib/model/pytorch_transformer.py
+++ b/qlib/contrib/model/pytorch_transformer.py
@@ -157,9 +157,12 @@ class TransformerModel(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
+
         df_train, df_valid, df_test = dataset.prepare(
             ["train", "valid", "test"],
             col_set=["feature", "label"],

--- a/qlib/contrib/model/pytorch_transformer_ts.py
+++ b/qlib/contrib/model/pytorch_transformer_ts.py
@@ -137,9 +137,12 @@ class TransformerModel(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
+
         dl_train = dataset.prepare("train", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)
         dl_valid = dataset.prepare("valid", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)
 

--- a/qlib/contrib/model/xgboost.py
+++ b/qlib/contrib/model/xgboost.py
@@ -26,10 +26,13 @@ class XGBModel(Model, FeatureInt):
         num_boost_round=1000,
         early_stopping_rounds=50,
         verbose_eval=20,
-        evals_result=dict(),
+        evals_result=None,
         reweighter=None,
         **kwargs,
     ):
+        if evals_result is None:
+            evals_result = {}
+
         df_train, df_valid = dataset.prepare(
             ["train", "valid"],
             col_set=["feature", "label"],

--- a/tests/test_model_state_leakage.py
+++ b/tests/test_model_state_leakage.py
@@ -1,0 +1,136 @@
+"""Test for Issue #1890: Model result state leakage between sequential fits.
+
+The root cause was a mutable default argument `evals_result=dict()` in
+TRAModel.fit(), which is a classic Python antipattern where the same dict
+object is shared across all calls that use the default.
+"""
+import ast
+import os
+import pytest
+
+
+class TestMutableDefaultArgs:
+    """Verify that mutable default arguments are not used in model fit/predict."""
+
+    def _get_default_args(self, filepath, method_name):
+        """Parse a Python file's AST and return default values for a method."""
+        with open(filepath) as f:
+            tree = ast.parse(f.read())
+
+        results = []
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if node.name == method_name:
+                    # Collect defaults for the function
+                    defaults = node.args.defaults
+                    for d in defaults:
+                        results.append(ast.dump(d))
+        return results
+
+    def test_tra_fit_no_mutable_default(self):
+        """TRAModel.fit should use None, not dict(), as the default for evals_result."""
+        tra_path = os.path.join(
+            os.path.dirname(__file__), "..", "qlib", "contrib", "model", "pytorch_tra.py"
+        )
+        with open(tra_path) as f:
+            tree = ast.parse(f.read())
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "fit":
+                # Check the last default argument (evals_result)
+                for default in node.args.defaults:
+                    # Should NOT be Call(func=Name(id='dict')) i.e. dict()
+                    if isinstance(default, ast.Call):
+                        if isinstance(default.func, ast.Name) and default.func.id == "dict":
+                            pytest.fail(
+                                "TRAModel.fit still has mutable default `evals_result=dict()`. "
+                                "Should be `evals_result=None`."
+                            )
+                    # Should NOT be Dict (i.e. {})
+                    if isinstance(default, ast.Dict) and len(default.keys) == 0:
+                        pytest.fail(
+                            "TRAModel.fit still has mutable default `evals_result={}`. "
+                            "Should be `evals_result=None`."
+                        )
+
+    def test_dict_default_shared_across_calls(self):
+        """Demonstrate the mutable default antipattern is fixed.
+
+        With `def f(x=dict())`, calling f() twice returns the SAME dict object.
+        After fix with `def f(x=None)`, each call gets a fresh dict.
+        """
+        # Simulate the fixed pattern
+        def fixed_func(evals_result=None):
+            if evals_result is None:
+                evals_result = {}
+            evals_result["key"] = "value"
+            return evals_result
+
+        result1 = fixed_func()
+        result2 = fixed_func()
+        # Each call should get an independent dict
+        assert result1 is not result2
+
+    def test_mutable_default_antipattern(self):
+        """Demonstrate why dict() default is dangerous."""
+        # This is the BAD pattern (for demonstration only)
+        def bad_func(evals_result={}):  # noqa: B006
+            evals_result["data"] = evals_result.get("data", [])
+            evals_result["data"].append(1)
+            return evals_result
+
+        r1 = bad_func()
+        r2 = bad_func()
+        # r1 and r2 are the SAME object — state leaked!
+        assert r1 is r2  # This proves the antipattern leaks state
+        assert len(r1["data"]) == 2  # Two appends to the same list
+
+    def test_no_mutable_defaults_in_model_fit_predict(self):
+        """Scan all contrib model files for mutable defaults in fit/predict via AST."""
+        model_dir = os.path.join(
+            os.path.dirname(__file__), "..", "qlib", "contrib", "model"
+        )
+        mutable_defaults = []
+
+        for fname in os.listdir(model_dir):
+            if not fname.endswith(".py"):
+                continue
+            fpath = os.path.join(model_dir, fname)
+            try:
+                with open(fpath) as f:
+                    tree = ast.parse(f.read())
+            except SyntaxError:
+                continue
+
+            for node in ast.walk(tree):
+                if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                if node.name not in ("fit", "predict"):
+                    continue
+
+                # Check defaults
+                arg_names = [a.arg for a in node.args.args]
+                # defaults align to the last N args
+                n_defaults = len(node.args.defaults)
+                defaulted_args = arg_names[-n_defaults:] if n_defaults else []
+
+                for arg_name, default in zip(defaulted_args, node.args.defaults):
+                    is_mutable = False
+                    if isinstance(default, (ast.Dict, ast.List, ast.Set)):
+                        is_mutable = True
+                    elif isinstance(default, ast.Call):
+                        func = default.func
+                        if isinstance(func, ast.Name) and func.id in ("dict", "list", "set"):
+                            is_mutable = True
+                    if is_mutable:
+                        mutable_defaults.append(
+                            f"{fname}:{node.name}({arg_name}=<mutable>) @ line {node.lineno}"
+                        )
+
+        assert mutable_defaults == [], (
+            f"Mutable default arguments found in model fit/predict methods: {mutable_defaults}"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fixes #1890. Mutable default argument `evals_result=dict()` caused state leakage between sequential `model.fit()` calls. Replaced with `evals_result=None` + guard pattern.