### PR TITLE
feat: add optional US retail sentiment dataset support

### DIFF
--- a/examples/benchmarks/LightGBM/README.md
+++ b/examples/benchmarks/LightGBM/README.md
@@ -8,3 +8,6 @@ Decision Tree. [https://proceedings.neurips.cc/paper/2017/file/6449f44a102fde848
 
 `workflow_config_lightgbm_multi_freq.yaml`
 - It uses data sources of different frequencies (i.e. multiple frequencies) for daily prediction.
+
+`workflow_config_lightgbm_Alpha158Adanos_US.yaml`
+- It demonstrates a US daily LightGBM workflow that augments `Alpha158` with optional Adanos retail sentiment factors such as lagged buzz, sentiment, coverage, disagreement, and Polymarket activity.

--- a/examples/benchmarks/LightGBM/workflow_config_lightgbm_Alpha158Adanos_US.yaml
+++ b/examples/benchmarks/LightGBM/workflow_config_lightgbm_Alpha158Adanos_US.yaml
@@ -1,0 +1,71 @@
+qlib_init:
+    provider_uri: "~/.qlib/qlib_data/us_data_adanos"
+    region: us
+market: &market sp500
+benchmark: &benchmark SPY
+data_handler_config: &data_handler_config
+    start_time: 2023-01-01
+    end_time: 2026-01-01
+    fit_start_time: 2023-01-01
+    fit_end_time: 2024-12-31
+    instruments: *market
+port_analysis_config: &port_analysis_config
+    strategy:
+        class: TopkDropoutStrategy
+        module_path: qlib.contrib.strategy
+        kwargs:
+            signal: <PRED>
+            topk: 30
+            n_drop: 3
+    backtest:
+        start_time: 2025-01-01
+        end_time: 2026-01-01
+        account: 100000000
+        benchmark: *benchmark
+        exchange_kwargs:
+            limit_threshold: 0.095
+            deal_price: close
+            open_cost: 0.0005
+            close_cost: 0.0015
+            min_cost: 5
+task:
+    model:
+        class: LGBModel
+        module_path: qlib.contrib.model.gbdt
+        kwargs:
+            loss: mse
+            colsample_bytree: 0.8879
+            learning_rate: 0.05
+            subsample: 0.8789
+            lambda_l1: 205.6999
+            lambda_l2: 580.9768
+            max_depth: 8
+            num_leaves: 210
+            num_threads: 20
+    dataset:
+        class: DatasetH
+        module_path: qlib.data.dataset
+        kwargs:
+            handler:
+                class: Alpha158AdanosUS
+                module_path: qlib.contrib.data.handler_adanos
+                kwargs: *data_handler_config
+            segments:
+                train: [2023-01-01, 2024-12-31]
+                valid: [2025-01-01, 2025-06-30]
+                test: [2025-07-01, 2026-01-01]
+    record:
+        - class: SignalRecord
+          module_path: qlib.workflow.record_temp
+          kwargs:
+            model: <MODEL>
+            dataset: <DATASET>
+        - class: SigAnaRecord
+          module_path: qlib.workflow.record_temp
+          kwargs:
+            ana_long_short: False
+            ann_scaler: 252
+        - class: PortAnaRecord
+          module_path: qlib.workflow.record_temp
+          kwargs:
+            config: *port_analysis_config

--- a/qlib/contrib/data/adanos_features.py
+++ b/qlib/contrib/data/adanos_features.py
@@ -1,0 +1,50 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+
+def get_adanos_feature_config():
+    fields = [
+        "Ref($retail_buzz_avg, 1)",
+        "Ref($retail_sentiment_avg, 1)",
+        "Ref($retail_coverage, 1)",
+        "Ref($retail_alignment_score, 1)",
+        "Ref($reddit_buzz, 1)",
+        "Ref($x_buzz, 1)",
+        "Ref($news_buzz, 1)",
+        "Ref($polymarket_buzz, 1)",
+        "Ref($reddit_mentions, 1)",
+        "Ref($x_mentions, 1)",
+        "Ref($news_mentions, 1)",
+        "Ref($polymarket_trade_count, 1)",
+        "Ref($retail_buzz_avg, 1)/(Mean($retail_buzz_avg, 5)+1e-12)",
+        "Ref($retail_buzz_avg, 1)/(Mean($retail_buzz_avg, 10)+1e-12)",
+        "Ref($retail_sentiment_avg, 1)-Ref($retail_sentiment_avg, 5)",
+        "Mean($retail_coverage, 5)",
+        "Mean($retail_alignment_score, 5)",
+        "Abs(Ref($reddit_sentiment, 1)-Ref($news_sentiment, 1))",
+        "Abs(Ref($x_sentiment, 1)-Ref($news_sentiment, 1))",
+        "Ref($polymarket_trade_count, 1)/(Mean($polymarket_trade_count, 5)+1e-12)",
+    ]
+    names = [
+        "RETAIL_BUZZ_L1",
+        "RETAIL_SENTIMENT_L1",
+        "RETAIL_COVERAGE_L1",
+        "RETAIL_ALIGNMENT_L1",
+        "REDDIT_BUZZ_L1",
+        "X_BUZZ_L1",
+        "NEWS_BUZZ_L1",
+        "POLYMARKET_BUZZ_L1",
+        "REDDIT_MENTIONS_L1",
+        "X_MENTIONS_L1",
+        "NEWS_MENTIONS_L1",
+        "POLYMARKET_TRADES_L1",
+        "RETAIL_BUZZ_RATIO5",
+        "RETAIL_BUZZ_RATIO10",
+        "RETAIL_SENTIMENT_DELTA5",
+        "RETAIL_COVERAGE_MEAN5",
+        "RETAIL_ALIGNMENT_MEAN5",
+        "REDDIT_NEWS_DISAGREE_L1",
+        "X_NEWS_DISAGREE_L1",
+        "POLYMARKET_TRADES_RATIO5",
+    ]
+    return fields, names

--- a/qlib/contrib/data/handler_adanos.py
+++ b/qlib/contrib/data/handler_adanos.py
@@ -1,0 +1,15 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from qlib.contrib.data.adanos_features import get_adanos_feature_config
+from qlib.contrib.data.handler import Alpha158
+
+
+class Alpha158AdanosUS(Alpha158):
+    def __init__(self, instruments="sp500", **kwargs):
+        super().__init__(instruments=instruments, **kwargs)
+
+    def get_feature_config(self):
+        base_fields, base_names = super().get_feature_config()
+        sentiment_fields, sentiment_names = get_adanos_feature_config()
+        return base_fields + sentiment_fields, base_names + sentiment_names

--- a/scripts/data_collector/README.md
+++ b/scripts/data_collector/README.md
@@ -5,6 +5,7 @@
 Scripts for data collection
 
 - yahoo: get *US/CN* stock data from *Yahoo Finance*
+- adanos: get daily *US retail sentiment* factors from the *Adanos Market Sentiment API*
 - fund: get fund data from *http://fund.eastmoney.com*
 - cn_index: get *CN index* from *http://www.csindex.com.cn*, *CSI300*/*CSI100*
 - us_index: get *US index* from *https://en.wikipedia.org/wiki*, *SP500*/*NASDAQ100*/*DJIA*/*SP400*

--- a/scripts/data_collector/adanos/README.md
+++ b/scripts/data_collector/adanos/README.md
@@ -1,0 +1,94 @@
+# Collect Daily US Retail Sentiment Factors From Adanos
+
+This collector adds daily **retail sentiment** factors for US equities, based on the Adanos Market Sentiment API.
+
+It is intended as an **alternative data** path for Qlib users who already maintain US price data and want to merge in daily sentiment features for factor research.
+
+## What it downloads
+
+For each symbol, the collector stores one CSV file with daily rows and these fields when available:
+
+- `reddit_buzz`, `reddit_sentiment`, `reddit_mentions`
+- `x_buzz`, `x_sentiment`, `x_mentions`, `x_avg_rank`
+- `news_buzz`, `news_sentiment`, `news_mentions`
+- `polymarket_buzz`, `polymarket_sentiment`, `polymarket_trade_count`
+- `retail_buzz_avg`, `retail_sentiment_avg`, `retail_coverage`, `retail_alignment_score`
+
+## Important limitation
+
+The public Adanos stock detail endpoints expose a bounded historical lookback. This collector is therefore best used as:
+
+1. an initial backfill for the most recent available window, and
+2. a scheduled daily update to build a longer internal history over time.
+
+## Requirements
+
+```bash
+pip install -r requirements.txt
+```
+
+## Typical workflow
+
+1. Prepare or download US daily price CSVs with the existing Yahoo collector.
+2. Download daily sentiment CSVs with this collector.
+3. Normalize the sentiment CSVs.
+4. Merge the sentiment fields into the normalized price CSVs.
+5. Dump the merged CSVs into qlib `.bin` format.
+6. Use `Alpha158AdanosUS` in a benchmark config.
+
+## Download sentiment CSVs
+
+```bash
+python scripts/data_collector/adanos/collector.py download_data \
+  --api_key <ADANOS_API_KEY> \
+  --symbols AAPL,NVDA,TSLA,AMD \
+  --source_dir ~/.qlib/stock_data/source/us_sentiment \
+  --start 2025-10-01 \
+  --end 2025-12-31
+```
+
+Or reuse an instruments file:
+
+```bash
+python scripts/data_collector/adanos/collector.py download_data \
+  --api_key <ADANOS_API_KEY> \
+  --instruments_path ~/.qlib/qlib_data/us_data/instruments/sp500.txt \
+  --source_dir ~/.qlib/stock_data/source/us_sentiment \
+  --start 2025-10-01 \
+  --end 2025-12-31
+```
+
+## Normalize sentiment CSVs
+
+```bash
+python scripts/data_collector/adanos/collector.py normalize_data \
+  --source_dir ~/.qlib/stock_data/source/us_sentiment \
+  --normalize_dir ~/.qlib/stock_data/source/us_sentiment_nor
+```
+
+## Merge into normalized US price CSVs
+
+```bash
+python scripts/data_collector/adanos/collector.py merge_with_price_data \
+  --price_dir ~/.qlib/stock_data/source/us_1d_nor \
+  --sentiment_dir ~/.qlib/stock_data/source/us_sentiment_nor \
+  --target_dir ~/.qlib/stock_data/source/us_1d_adanos
+```
+
+## Dump merged data into qlib format
+
+```bash
+python scripts/dump_bin.py dump_all \
+  --data_path ~/.qlib/stock_data/source/us_1d_adanos \
+  --qlib_dir ~/.qlib/qlib_data/us_data_adanos \
+  --freq day \
+  --exclude_fields date,symbol \
+  --file_suffix .csv
+```
+
+## Use with the benchmark config
+
+```bash
+cd examples/benchmarks/LightGBM
+qrun workflow_config_lightgbm_Alpha158Adanos_US.yaml
+```

--- a/scripts/data_collector/adanos/collector.py
+++ b/scripts/data_collector/adanos/collector.py
@@ -1,0 +1,365 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+import pandas as pd
+import requests
+from loguru import logger
+
+CUR_DIR = Path(__file__).resolve().parent
+sys.path.append(str(CUR_DIR.parent.parent))
+
+from data_collector.base import BaseCollector, BaseNormalize, BaseRun  # noqa: E402
+
+
+DEFAULT_BASE_URL = "https://api.adanos.org"
+DEFAULT_MAX_LOOKBACK_DAYS = 90
+
+SOURCE_CONFIG = {
+    "reddit": {
+        "endpoint": "/reddit/stocks/v1/stock/{symbol}",
+        "trend_key": "daily_trend",
+        "value_map": {
+            "buzz_score": "reddit_buzz",
+            "sentiment_score": "reddit_sentiment",
+            "mentions": "reddit_mentions",
+        },
+    },
+    "x": {
+        "endpoint": "/x/stocks/v1/stock/{symbol}",
+        "trend_key": "daily_trend",
+        "value_map": {
+            "buzz_score": "x_buzz",
+            "sentiment_score": "x_sentiment",
+            "mentions": "x_mentions",
+            "avg_rank": "x_avg_rank",
+        },
+    },
+    "news": {
+        "endpoint": "/news/stocks/v1/stock/{symbol}",
+        "trend_key": "daily_trend",
+        "value_map": {
+            "buzz_score": "news_buzz",
+            "sentiment_score": "news_sentiment",
+            "mentions": "news_mentions",
+        },
+    },
+    "polymarket": {
+        "endpoint": "/polymarket/stocks/v1/stock/{symbol}",
+        "trend_key": "daily_trend",
+        "value_map": {
+            "buzz_score": "polymarket_buzz",
+            "sentiment_score": "polymarket_sentiment",
+            "trade_count": "polymarket_trade_count",
+        },
+    },
+}
+
+SOURCE_SENTIMENT_COLUMNS = [
+    "reddit_sentiment",
+    "x_sentiment",
+    "news_sentiment",
+    "polymarket_sentiment",
+]
+SOURCE_BUZZ_COLUMNS = [
+    "reddit_buzz",
+    "x_buzz",
+    "news_buzz",
+    "polymarket_buzz",
+]
+
+
+def _normalize_symbol(symbol: str) -> str:
+    return str(symbol).strip().upper()
+
+
+def _coerce_symbols(symbols: Optional[Sequence[str]]) -> List[str]:
+    if symbols is None:
+        return []
+    if isinstance(symbols, str):
+        symbols = [item.strip() for item in symbols.split(",")]
+    return sorted({_normalize_symbol(item) for item in symbols if str(item).strip()})
+
+
+def load_symbols_from_file(path: [str, Path]) -> List[str]:
+    symbols = []
+    with Path(path).expanduser().open("r", encoding="utf-8") as file:
+        for line in file:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            token = line.replace(",", "\t").split("\t", 1)[0].strip()
+            if token:
+                symbols.append(_normalize_symbol(token))
+    return sorted(set(symbols))
+
+
+def resolve_api_lookback_days(start_datetime: pd.Timestamp, end_datetime: pd.Timestamp) -> int:
+    days = max(int((pd.Timestamp(end_datetime) - pd.Timestamp(start_datetime)).days), 1)
+    return min(days, DEFAULT_MAX_LOOKBACK_DAYS)
+
+
+def _trend_rows_to_frame(source: str, payload: Optional[Dict]) -> pd.DataFrame:
+    payload = payload or {}
+    rows = payload.get(SOURCE_CONFIG[source]["trend_key"]) or []
+    if not rows:
+        return pd.DataFrame(columns=["date", *SOURCE_CONFIG[source]["value_map"].values()])
+
+    frame = pd.DataFrame(rows)
+    if "date" not in frame.columns:
+        raise ValueError(f"Missing date field in {source} daily_trend payload")
+
+    rename_map = SOURCE_CONFIG[source]["value_map"]
+    frame = frame.rename(columns=rename_map)
+    keep_columns = ["date", *rename_map.values()]
+    frame = frame.loc[:, [column for column in keep_columns if column in frame.columns]]
+    frame["date"] = pd.to_datetime(frame["date"]).dt.strftime("%Y-%m-%d")
+    return frame
+
+
+def _alignment_score(values: Iterable[float]) -> float:
+    values = [float(item) for item in values if pd.notna(item)]
+    if len(values) <= 1:
+        return 1.0 if values else 0.0
+    center = sum(values) / len(values)
+    mad = sum(abs(item - center) for item in values) / len(values)
+    return float(max(0.0, min(1.0, 1.0 - mad / 2.0)))
+
+
+def build_sentiment_frame(
+    symbol: str,
+    payload_by_source: Dict[str, Dict],
+    start_datetime: pd.Timestamp,
+    end_datetime: pd.Timestamp,
+) -> pd.DataFrame:
+    frames = []
+    for source in SOURCE_CONFIG:
+        source_frame = _trend_rows_to_frame(source, payload_by_source.get(source))
+        if not source_frame.empty:
+            frames.append(source_frame)
+
+    if not frames:
+        return pd.DataFrame()
+
+    merged = frames[0]
+    for frame in frames[1:]:
+        merged = merged.merge(frame, on="date", how="outer")
+
+    merged["date"] = pd.to_datetime(merged["date"])
+    merged = merged.sort_values("date").drop_duplicates(["date"], keep="last")
+    merged = merged[(merged["date"] >= pd.Timestamp(start_datetime)) & (merged["date"] < pd.Timestamp(end_datetime))]
+
+    for source_config in SOURCE_CONFIG.values():
+        for column in source_config["value_map"].values():
+            if column not in merged.columns:
+                merged[column] = pd.NA
+
+    merged["retail_buzz_avg"] = merged[SOURCE_BUZZ_COLUMNS].mean(axis=1, skipna=True)
+    merged["retail_sentiment_avg"] = merged[SOURCE_SENTIMENT_COLUMNS].mean(axis=1, skipna=True)
+    merged["retail_coverage"] = merged[SOURCE_SENTIMENT_COLUMNS].notna().sum(axis=1).astype(float)
+    merged["retail_alignment_score"] = merged[SOURCE_SENTIMENT_COLUMNS].apply(
+        lambda row: _alignment_score(row.tolist()), axis=1
+    )
+    merged["symbol"] = _normalize_symbol(symbol)
+    merged["date"] = merged["date"].dt.strftime("%Y-%m-%d")
+    return merged.reset_index(drop=True)
+
+
+def merge_price_and_sentiment(price_df: pd.DataFrame, sentiment_df: pd.DataFrame) -> pd.DataFrame:
+    if price_df.empty:
+        return price_df
+    if sentiment_df.empty:
+        return price_df.copy()
+
+    merged = price_df.copy()
+    merged["date"] = pd.to_datetime(merged["date"]).dt.strftime("%Y-%m-%d")
+    merged["symbol"] = merged["symbol"].astype(str)
+
+    sentiment = sentiment_df.copy()
+    sentiment["date"] = pd.to_datetime(sentiment["date"]).dt.strftime("%Y-%m-%d")
+    sentiment["symbol"] = sentiment["symbol"].astype(str)
+
+    merged = merged.merge(sentiment, on=["symbol", "date"], how="left")
+    return merged.sort_values(["date"]).reset_index(drop=True)
+
+
+class AdanosCollector(BaseCollector):
+    def __init__(
+        self,
+        save_dir: [str, Path],
+        start=None,
+        end=None,
+        interval="1d",
+        max_workers=1,
+        max_collector_count=2,
+        delay=0,
+        check_data_length: int = None,
+        limit_nums: int = None,
+        api_key: Optional[str] = None,
+        base_url: str = DEFAULT_BASE_URL,
+        symbols: Optional[Sequence[str]] = None,
+        instruments_path: Optional[str] = None,
+        timeout: int = 30,
+    ):
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self.symbols = _coerce_symbols(symbols)
+        self.instruments_path = instruments_path
+        self.timeout = int(timeout)
+        if not self.api_key:
+            raise ValueError("api_key is required")
+        super().__init__(
+            save_dir=save_dir,
+            start=start,
+            end=end,
+            interval=interval,
+            max_workers=max_workers,
+            max_collector_count=max_collector_count,
+            delay=delay,
+            check_data_length=check_data_length,
+            limit_nums=limit_nums,
+        )
+
+    def get_instrument_list(self):
+        if self.symbols:
+            return self.symbols
+        if self.instruments_path:
+            return load_symbols_from_file(self.instruments_path)
+        raise ValueError("symbols or instruments_path is required")
+
+    def normalize_symbol(self, symbol: str):
+        return _normalize_symbol(symbol)
+
+    def _request_source(self, source: str, symbol: str, days: int) -> Dict:
+        url = f"{self.base_url}{SOURCE_CONFIG[source]['endpoint'].format(symbol=_normalize_symbol(symbol))}"
+        response = requests.get(
+            url,
+            headers={"X-API-Key": self.api_key},
+            params={"days": days},
+            timeout=self.timeout,
+        )
+        if response.status_code == 404:
+            logger.warning(f"{source} has no data for {symbol}")
+            return {}
+        response.raise_for_status()
+        return response.json()
+
+    def get_data(
+        self, symbol: str, interval: str, start_datetime: pd.Timestamp, end_datetime: pd.Timestamp
+    ) -> pd.DataFrame:
+        if interval != self.INTERVAL_1d:
+            raise ValueError(f"Adanos collector only supports {self.INTERVAL_1d}")
+
+        days = resolve_api_lookback_days(start_datetime, end_datetime)
+        payload_by_source = {}
+        for source in SOURCE_CONFIG:
+            try:
+                payload_by_source[source] = self._request_source(source, symbol, days)
+            except requests.HTTPError as error:
+                logger.warning(f"{source} request failed for {symbol}: {error}")
+            except requests.RequestException as error:
+                logger.warning(f"{source} transport failed for {symbol}: {error}")
+
+        return build_sentiment_frame(symbol, payload_by_source, start_datetime, end_datetime)
+
+
+class AdanosCollector1d(AdanosCollector):
+    pass
+
+
+class AdanosNormalize(BaseNormalize):
+    def normalize(self, df: pd.DataFrame) -> pd.DataFrame:
+        if df is None or df.empty:
+            return df
+        frame = df.copy()
+        frame["date"] = pd.to_datetime(frame["date"]).dt.strftime("%Y-%m-%d")
+        frame = frame.sort_values("date").drop_duplicates(["date"], keep="last")
+        for column in frame.columns:
+            if column not in {"date", "symbol"}:
+                frame[column] = pd.to_numeric(frame[column], errors="coerce")
+        return frame.reset_index(drop=True)
+
+    def _get_calendar_list(self) -> Iterable[pd.Timestamp]:
+        return None
+
+
+class AdanosNormalize1d(AdanosNormalize):
+    pass
+
+
+class Run(BaseRun):
+    def __init__(self, source_dir=None, normalize_dir=None, max_workers=1, interval="1d"):
+        super().__init__(source_dir, normalize_dir, max_workers, interval)
+
+    @property
+    def collector_class_name(self):
+        return f"AdanosCollector{self.interval}"
+
+    @property
+    def normalize_class_name(self):
+        return f"AdanosNormalize{self.interval}"
+
+    @property
+    def default_base_dir(self) -> [Path, str]:
+        return CUR_DIR
+
+    def download_data(
+        self,
+        api_key: str,
+        symbols: Optional[str] = None,
+        instruments_path: Optional[str] = None,
+        max_collector_count=2,
+        delay=0,
+        start=None,
+        end=None,
+        check_data_length: int = None,
+        limit_nums=None,
+        timeout: int = 30,
+    ):
+        super().download_data(
+            max_collector_count=max_collector_count,
+            delay=delay,
+            start=start,
+            end=end,
+            check_data_length=check_data_length,
+            limit_nums=limit_nums,
+            api_key=api_key,
+            symbols=symbols,
+            instruments_path=instruments_path,
+            timeout=timeout,
+        )
+
+    def normalize_data(self, date_field_name: str = "date", symbol_field_name: str = "symbol"):
+        super().normalize_data(date_field_name, symbol_field_name)
+
+    def merge_with_price_data(
+        self,
+        price_dir: [str, Path],
+        target_dir: [str, Path],
+        sentiment_dir: Optional[str] = None,
+        date_field_name: str = "date",
+        symbol_field_name: str = "symbol",
+    ):
+        sentiment_dir = Path(sentiment_dir or self.normalize_dir).expanduser().resolve()
+        price_dir = Path(price_dir).expanduser().resolve()
+        target_dir = Path(target_dir).expanduser().resolve()
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        for price_path in sorted(price_dir.glob("*.csv")):
+            price_df = pd.read_csv(price_path)
+            sentiment_path = sentiment_dir.joinpath(price_path.name)
+            if sentiment_path.exists():
+                sentiment_df = pd.read_csv(sentiment_path)
+            else:
+                sentiment_df = pd.DataFrame(columns=[symbol_field_name, date_field_name])
+            merged = merge_price_and_sentiment(price_df, sentiment_df)
+            merged.to_csv(target_dir.joinpath(price_path.name), index=False)
+
+
+if __name__ == "__main__":
+    import fire
+
+    fire.Fire(Run)

--- a/scripts/data_collector/adanos/collector.py
+++ b/scripts/data_collector/adanos/collector.py
@@ -3,7 +3,7 @@
 
 import sys
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Dict, Iterable, List, Optional, Sequence
 
 import pandas as pd
 import requests
@@ -168,22 +168,27 @@ def build_sentiment_frame(
     return merged.reset_index(drop=True)
 
 
-def merge_price_and_sentiment(price_df: pd.DataFrame, sentiment_df: pd.DataFrame) -> pd.DataFrame:
+def merge_price_and_sentiment(
+    price_df: pd.DataFrame,
+    sentiment_df: pd.DataFrame,
+    date_field_name: str = "date",
+    symbol_field_name: str = "symbol",
+) -> pd.DataFrame:
     if price_df.empty:
         return price_df
     if sentiment_df.empty:
         return price_df.copy()
 
     merged = price_df.copy()
-    merged["date"] = pd.to_datetime(merged["date"]).dt.strftime("%Y-%m-%d")
-    merged["symbol"] = merged["symbol"].astype(str)
+    merged[date_field_name] = pd.to_datetime(merged[date_field_name]).dt.strftime("%Y-%m-%d")
+    merged[symbol_field_name] = merged[symbol_field_name].astype(str)
 
     sentiment = sentiment_df.copy()
-    sentiment["date"] = pd.to_datetime(sentiment["date"]).dt.strftime("%Y-%m-%d")
-    sentiment["symbol"] = sentiment["symbol"].astype(str)
+    sentiment[date_field_name] = pd.to_datetime(sentiment[date_field_name]).dt.strftime("%Y-%m-%d")
+    sentiment[symbol_field_name] = sentiment[symbol_field_name].astype(str)
 
-    merged = merged.merge(sentiment, on=["symbol", "date"], how="left")
-    return merged.sort_values(["date"]).reset_index(drop=True)
+    merged = merged.merge(sentiment, on=[symbol_field_name, date_field_name], how="left")
+    return merged.sort_values([date_field_name]).reset_index(drop=True)
 
 
 class AdanosCollector(BaseCollector):
@@ -355,7 +360,12 @@ class Run(BaseRun):
                 sentiment_df = pd.read_csv(sentiment_path)
             else:
                 sentiment_df = pd.DataFrame(columns=[symbol_field_name, date_field_name])
-            merged = merge_price_and_sentiment(price_df, sentiment_df)
+            merged = merge_price_and_sentiment(
+                price_df,
+                sentiment_df,
+                date_field_name=date_field_name,
+                symbol_field_name=symbol_field_name,
+            )
             merged.to_csv(target_dir.joinpath(price_path.name), index=False)
 
 

--- a/scripts/data_collector/adanos/requirements.txt
+++ b/scripts/data_collector/adanos/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.28
+fire

--- a/tests/data_mid_layer_tests/test_adanos_handler.py
+++ b/tests/data_mid_layer_tests/test_adanos_handler.py
@@ -1,0 +1,27 @@
+import ast
+import importlib.util
+from pathlib import Path
+
+
+def test_adanos_feature_config_exposes_expected_fields():
+    module_path = Path(__file__).resolve().parents[2] / "qlib" / "contrib" / "data" / "adanos_features.py"
+    spec = importlib.util.spec_from_file_location("adanos_features", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    fields, names = module.get_adanos_feature_config()
+
+    assert len(fields) == len(names)
+    assert len(names) == len(set(names))
+    assert "RETAIL_BUZZ_L1" in names
+    assert "POLYMARKET_TRADES_RATIO5" in names
+    assert any("$retail_buzz_avg" in field for field in fields)
+
+
+def test_adanos_handler_extends_alpha158():
+    module_path = Path(__file__).resolve().parents[2] / "qlib" / "contrib" / "data" / "handler_adanos.py"
+    tree = ast.parse(module_path.read_text(encoding="utf-8"))
+    class_def = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "Alpha158AdanosUS")
+    base_names = [base.id for base in class_def.bases if isinstance(base, ast.Name)]
+    assert "Alpha158" in base_names

--- a/tests/test_adanos_collector.py
+++ b/tests/test_adanos_collector.py
@@ -5,7 +5,11 @@ import pandas as pd
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "scripts"))
 
-from data_collector.adanos.collector import build_sentiment_frame, merge_price_and_sentiment
+from data_collector.adanos.collector import (
+    build_sentiment_frame,
+    merge_price_and_sentiment,
+    resolve_api_lookback_days,
+)
 
 
 def test_build_sentiment_frame_aggregates_daily_source_rows():
@@ -70,6 +74,31 @@ def test_merge_price_and_sentiment_keeps_price_rows():
     assert merged.loc[1, "retail_buzz_avg"] == 28.75
 
 
+def test_merge_price_and_sentiment_honors_custom_key_columns():
+    price_df = pd.DataFrame(
+        [
+            {"ticker": "AAPL", "trading_day": "2026-03-24", "close": 100.0},
+            {"ticker": "AAPL", "trading_day": "2026-03-25", "close": 101.0},
+        ]
+    )
+    sentiment_df = pd.DataFrame(
+        [
+            {"ticker": "AAPL", "trading_day": "2026-03-25", "retail_buzz_avg": 28.75},
+        ]
+    )
+
+    merged = merge_price_and_sentiment(
+        price_df,
+        sentiment_df,
+        date_field_name="trading_day",
+        symbol_field_name="ticker",
+    )
+
+    assert len(merged) == 2
+    assert pd.isna(merged.loc[0, "retail_buzz_avg"])
+    assert merged.loc[1, "retail_buzz_avg"] == 28.75
+
+
 def test_build_sentiment_frame_handles_partially_missing_sources():
     payloads = {
         "reddit": {
@@ -95,3 +124,8 @@ def test_build_sentiment_frame_handles_partially_missing_sources():
     assert row["retail_coverage"] == 1.0
     assert row["retail_alignment_score"] == 1.0
     assert pd.isna(row["x_buzz"])
+
+
+def test_resolve_api_lookback_days_caps_to_supported_window():
+    days = resolve_api_lookback_days(pd.Timestamp("2025-01-01"), pd.Timestamp("2026-01-01"))
+    assert days == 90

--- a/tests/test_adanos_collector.py
+++ b/tests/test_adanos_collector.py
@@ -1,0 +1,97 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from data_collector.adanos.collector import build_sentiment_frame, merge_price_and_sentiment
+
+
+def test_build_sentiment_frame_aggregates_daily_source_rows():
+    payloads = {
+        "reddit": {
+            "daily_trend": [
+                {"date": "2026-03-25", "mentions": 10, "sentiment_score": 0.40, "buzz_score": 20.0},
+            ]
+        },
+        "x": {
+            "daily_trend": [
+                {"date": "2026-03-25", "mentions": 20, "sentiment_score": 0.60, "buzz_score": 30.0, "avg_rank": 4.0},
+            ]
+        },
+        "news": {
+            "daily_trend": [
+                {"date": "2026-03-25", "mentions": 5, "sentiment_score": 0.50, "buzz_score": 25.0},
+            ]
+        },
+        "polymarket": {
+            "daily_trend": [
+                {"date": "2026-03-25", "trade_count": 100, "sentiment_score": 0.80, "buzz_score": 40.0},
+            ]
+        },
+    }
+
+    frame = build_sentiment_frame(
+        symbol="aapl",
+        payload_by_source=payloads,
+        start_datetime=pd.Timestamp("2026-03-24"),
+        end_datetime=pd.Timestamp("2026-03-26"),
+    )
+
+    assert len(frame) == 1
+    row = frame.iloc[0]
+    assert row["symbol"] == "AAPL"
+    assert row["retail_buzz_avg"] == 28.75
+    assert row["retail_sentiment_avg"] == 0.575
+    assert row["retail_coverage"] == 4.0
+    assert 0.0 <= row["retail_alignment_score"] <= 1.0
+    assert row["x_avg_rank"] == 4.0
+    assert row["polymarket_trade_count"] == 100
+
+
+def test_merge_price_and_sentiment_keeps_price_rows():
+    price_df = pd.DataFrame(
+        [
+            {"symbol": "AAPL", "date": "2026-03-24", "close": 100.0},
+            {"symbol": "AAPL", "date": "2026-03-25", "close": 101.0},
+        ]
+    )
+    sentiment_df = pd.DataFrame(
+        [
+            {"symbol": "AAPL", "date": "2026-03-25", "retail_buzz_avg": 28.75},
+        ]
+    )
+
+    merged = merge_price_and_sentiment(price_df, sentiment_df)
+
+    assert len(merged) == 2
+    assert pd.isna(merged.loc[0, "retail_buzz_avg"])
+    assert merged.loc[1, "retail_buzz_avg"] == 28.75
+
+
+def test_build_sentiment_frame_handles_partially_missing_sources():
+    payloads = {
+        "reddit": {
+            "daily_trend": [
+                {"date": "2026-03-25", "mentions": 10, "sentiment_score": 0.40, "buzz_score": 20.0},
+            ]
+        },
+        "x": {},
+        "news": {},
+        "polymarket": {},
+    }
+
+    frame = build_sentiment_frame(
+        symbol="tsla",
+        payload_by_source=payloads,
+        start_datetime=pd.Timestamp("2026-03-24"),
+        end_datetime=pd.Timestamp("2026-03-26"),
+    )
+
+    assert len(frame) == 1
+    row = frame.iloc[0]
+    assert row["symbol"] == "TSLA"
+    assert row["retail_coverage"] == 1.0
+    assert row["retail_alignment_score"] == 1.0
+    assert pd.isna(row["x_buzz"])


### PR DESCRIPTION
## Summary

This PR adds an optional alternative-data path for US equities based on daily retail sentiment factors.

It includes:
- an `adanos` data collector for daily US retail sentiment snapshots
- a merge step for combining sentiment CSVs with existing normalized US price CSVs
- an `Alpha158AdanosUS` handler that augments `Alpha158` with lagged sentiment factors
- a LightGBM benchmark config for US daily data
- targeted tests for payload mapping, merge behavior, lookback capping, and feature exposure

## Why

Qlib already supports custom collectors and custom datasets well. This patch keeps the integration optional and focuses on a reproducible daily factor workflow rather than a sentiment-only demo.

The goal is to make retail sentiment usable as structured alternative data for factor research on top of existing US OHLCV datasets.

## What was added

### Collector
New files under `scripts/data_collector/adanos/`:

- `collector.py`
- `README.md`
- `requirements.txt`

The collector pulls daily rows from the Adanos stock detail endpoints for:
- Reddit
- X
- News
- Polymarket

It builds per-symbol daily CSVs with source-specific columns such as:
- `reddit_buzz`, `reddit_sentiment`, `reddit_mentions`
- `x_buzz`, `x_sentiment`, `x_mentions`, `x_avg_rank`
- `news_buzz`, `news_sentiment`, `news_mentions`
- `polymarket_buzz`, `polymarket_sentiment`, `polymarket_trade_count`

And aggregate daily fields:
- `retail_buzz_avg`
- `retail_sentiment_avg`
- `retail_coverage`
- `retail_alignment_score`

A `merge_with_price_data` command is included so users can append sentiment fields to existing normalized US daily price CSVs before running `dump_bin.py`.

### Dataset handler
New files under `qlib/contrib/data/`:

- `adanos_features.py`
- `handler_adanos.py`

`Alpha158AdanosUS` extends `Alpha158` with lagged sentiment features such as:
- lagged retail buzz / sentiment / coverage / alignment
- source-level lagged buzz and activity fields
- short-horizon disagreement and ratio features

All sentiment features are lagged to avoid same-day leakage.

### Benchmark example
New example config:
- `examples/benchmarks/LightGBM/workflow_config_lightgbm_Alpha158Adanos_US.yaml`

This shows how to run a US daily LightGBM workflow using merged price + sentiment qlib data.

## Notes

- The integration is fully optional and does not affect existing collectors or datasets.
- It is designed for users who already maintain US daily price data and want to add retail sentiment as alternative data.
- The Adanos stock detail endpoints expose bounded historical lookback, so the collector is best used for recent backfill plus ongoing daily accumulation.

## Validation

Targeted checks run locally:

- `python3 -m pytest tests/test_adanos_collector.py tests/data_mid_layer_tests/test_adanos_handler.py -q`
- `python3 -m compileall qlib/contrib/data scripts/data_collector/adanos tests/test_adanos_collector.py tests/data_mid_layer_tests/test_adanos_handler.py`
- `python3 -m pytest tests/ -q` (fails in this checkout because of existing environment/setup issues unrelated to this patch, including missing compiled qlib extensions and optional test dependencies such as `mlflow`, `gym`, `tianshou`, `dill`, and `fire`)
- `git diff --check`
