### PR TITLE
fix: assign sort_index() result in filter.py

### DIFF
--- a/qlib/data/filter.py
+++ b/qlib/data/filter.py
@@ -160,7 +160,7 @@ class SeriesDFilter(BaseDFilter):
             the list of tuple (timestamp, timestamp).
         """
         # sort the timestamp_series according to the timestamps
-        timestamp_series.sort_index()
+        timestamp_series = timestamp_series.sort_index()
         timestamp = []
         _lbool = None
         _ltime = None


### PR DESCRIPTION
## Summary

Fixes #2165

`pandas.Series.sort_index()` returns a new Series and does **not** modify in place. The return value was discarded, causing the timestamp series to remain unsorted and potentially produce incorrect filter boundaries.

## Changes

- Assigned `sort_index()` result back to `timestamp_series` in `qlib/data/filter.py` (line 163)

```diff
- timestamp_series.sort_index()
+ timestamp_series = timestamp_series.sort_index()
```

## Test Plan

- [x] Verified the sorted series is correctly assigned
- [x] Existing filter-related tests should pass
- [x] Manual verification: unsorted index no longer produces incorrect filter boundaries
