### PR TITLE
fix(model): replace mutable default evals_result=dict() with None in 28 fit() methods

### DIFF
--- a/examples/benchmarks/TRA/src/model.py
+++ b/examples/benchmarks/TRA/src/model.py
@@ -200,7 +200,9 @@ class TRAModel(Model):
 
         return metrics, preds
 
-    def fit(self, dataset, evals_result=dict()):
+    def fit(self, dataset, evals_result=None):
+        if evals_result is None:
+            evals_result = {}
         train_set, valid_set, test_set = dataset.prepare(["train", "valid", "test"])
 
         best_score = -1

--- a/qlib/contrib/model/catboost_model.py
+++ b/qlib/contrib/model/catboost_model.py
@@ -31,10 +31,12 @@ class CatBoostModel(Model, FeatureInt):
         num_boost_round=1000,
         early_stopping_rounds=50,
         verbose_eval=20,
-        evals_result=dict(),
+        evals_result=None,
         reweighter=None,
         **kwargs,
     ):
+        if evals_result is None:
+            evals_result = {}
         df_train, df_valid = dataset.prepare(
             ["train", "valid"],
             col_set=["feature", "label"],

--- a/qlib/contrib/model/pytorch_adarnn.py
+++ b/qlib/contrib/model/pytorch_adarnn.py
@@ -242,9 +242,11 @@ class ADARNN(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
         df_train, df_valid = dataset.prepare(
             ["train", "valid"],
             col_set=["feature", "label"],

--- a/qlib/contrib/model/pytorch_add.py
+++ b/qlib/contrib/model/pytorch_add.py
@@ -363,9 +363,11 @@ class ADD(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
         label_train, label_valid = dataset.prepare(
             ["train", "valid"],
             col_set=["label"],

--- a/qlib/contrib/model/pytorch_alstm.py
+++ b/qlib/contrib/model/pytorch_alstm.py
@@ -209,9 +209,11 @@ class ALSTM(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
         df_train, df_valid, df_test = dataset.prepare(
             ["train", "valid", "test"],
             col_set=["feature", "label"],

--- a/qlib/contrib/model/pytorch_alstm_ts.py
+++ b/qlib/contrib/model/pytorch_alstm_ts.py
@@ -206,10 +206,12 @@ class ALSTM(Model):
     def fit(
         self,
         dataset,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
         reweighter=None,
     ):
+        if evals_result is None:
+            evals_result = {}
         dl_train = dataset.prepare("train", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)
         dl_valid = dataset.prepare("valid", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)
         if dl_train.empty or dl_valid.empty:

--- a/qlib/contrib/model/pytorch_gats.py
+++ b/qlib/contrib/model/pytorch_gats.py
@@ -224,9 +224,11 @@ class GATs(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
         df_train, df_valid, df_test = dataset.prepare(
             ["train", "valid", "test"],
             col_set=["feature", "label"],

--- a/qlib/contrib/model/pytorch_gats_ts.py
+++ b/qlib/contrib/model/pytorch_gats_ts.py
@@ -233,9 +233,11 @@ class GATs(Model):
     def fit(
         self,
         dataset,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
         dl_train = dataset.prepare("train", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)
         dl_valid = dataset.prepare("valid", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)
         if dl_train.empty or dl_valid.empty:

--- a/qlib/contrib/model/pytorch_general_nn.py
+++ b/qlib/contrib/model/pytorch_general_nn.py
@@ -235,10 +235,12 @@ class GeneralPTNN(Model):
     def fit(
         self,
         dataset: Union[DatasetH, TSDatasetH],
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
         reweighter=None,
     ):
+        if evals_result is None:
+            evals_result = {}
         ists = isinstance(dataset, TSDatasetH)  # is this time series dataset
 
         dl_train = dataset.prepare("train", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)

--- a/qlib/contrib/model/pytorch_gru.py
+++ b/qlib/contrib/model/pytorch_gru.py
@@ -209,9 +209,11 @@ class GRU(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
         # prepare training and validation data
         dfs = {
             k: dataset.prepare(

--- a/qlib/contrib/model/pytorch_gru_ts.py
+++ b/qlib/contrib/model/pytorch_gru_ts.py
@@ -200,10 +200,12 @@ class GRU(Model):
     def fit(
         self,
         dataset,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
         reweighter=None,
     ):
+        if evals_result is None:
+            evals_result = {}
         dl_train = dataset.prepare("train", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)
         dl_valid = dataset.prepare("valid", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)
         if dl_train.empty or dl_valid.empty:

--- a/qlib/contrib/model/pytorch_hist.py
+++ b/qlib/contrib/model/pytorch_hist.py
@@ -244,9 +244,11 @@ class HIST(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
         df_train, df_valid, df_test = dataset.prepare(
             ["train", "valid", "test"],
             col_set=["feature", "label"],

--- a/qlib/contrib/model/pytorch_igmtf.py
+++ b/qlib/contrib/model/pytorch_igmtf.py
@@ -248,9 +248,11 @@ class IGMTF(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
         df_train, df_valid = dataset.prepare(
             ["train", "valid"],
             col_set=["feature", "label"],

--- a/qlib/contrib/model/pytorch_krnn.py
+++ b/qlib/contrib/model/pytorch_krnn.py
@@ -432,9 +432,11 @@ class KRNN(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
         df_train, df_valid, df_test = dataset.prepare(
             ["train", "valid", "test"],
             col_set=["feature", "label"],

--- a/qlib/contrib/model/pytorch_localformer.py
+++ b/qlib/contrib/model/pytorch_localformer.py
@@ -158,9 +158,11 @@ class LocalformerModel(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
         df_train, df_valid, df_test = dataset.prepare(
             ["train", "valid", "test"],
             col_set=["feature", "label"],

--- a/qlib/contrib/model/pytorch_localformer_ts.py
+++ b/qlib/contrib/model/pytorch_localformer_ts.py
@@ -140,9 +140,11 @@ class LocalformerModel(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
         dl_train = dataset.prepare("train", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)
         dl_valid = dataset.prepare("valid", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)
         if dl_train.empty or dl_valid.empty:

--- a/qlib/contrib/model/pytorch_lstm.py
+++ b/qlib/contrib/model/pytorch_lstm.py
@@ -204,9 +204,11 @@ class LSTM(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
         df_train, df_valid, df_test = dataset.prepare(
             ["train", "valid", "test"],
             col_set=["feature", "label"],

--- a/qlib/contrib/model/pytorch_lstm_ts.py
+++ b/qlib/contrib/model/pytorch_lstm_ts.py
@@ -195,10 +195,12 @@ class LSTM(Model):
     def fit(
         self,
         dataset,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
         reweighter=None,
     ):
+        if evals_result is None:
+            evals_result = {}
         dl_train = dataset.prepare("train", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)
         dl_valid = dataset.prepare("valid", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)
         if dl_train.empty or dl_valid.empty:

--- a/qlib/contrib/model/pytorch_nn.py
+++ b/qlib/contrib/model/pytorch_nn.py
@@ -190,11 +190,13 @@ class DNNModelPytorch(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         verbose=True,
         save_path=None,
         reweighter=None,
     ):
+        if evals_result is None:
+            evals_result = {}
         has_valid = "valid" in dataset.segments
         segments = ["train", "valid"]
         vars = ["x", "y", "w"]

--- a/qlib/contrib/model/pytorch_sandwich.py
+++ b/qlib/contrib/model/pytorch_sandwich.py
@@ -302,9 +302,11 @@ class Sandwich(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
         df_train, df_valid, df_test = dataset.prepare(
             ["train", "valid", "test"],
             col_set=["feature", "label"],

--- a/qlib/contrib/model/pytorch_sfm.py
+++ b/qlib/contrib/model/pytorch_sfm.py
@@ -360,9 +360,11 @@ class SFM(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
         df_train, df_valid = dataset.prepare(
             ["train", "valid"],
             col_set=["feature", "label"],

--- a/qlib/contrib/model/pytorch_tabnet.py
+++ b/qlib/contrib/model/pytorch_tabnet.py
@@ -151,9 +151,11 @@ class TabnetModel(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
         if self.pretrain:
             # there is a  pretrained model, load the model
             self.logger.info("Pretrain...")

--- a/qlib/contrib/model/pytorch_tcn.py
+++ b/qlib/contrib/model/pytorch_tcn.py
@@ -216,9 +216,11 @@ class TCN(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
         df_train, df_valid, df_test = dataset.prepare(
             ["train", "valid", "test"],
             col_set=["feature", "label"],

--- a/qlib/contrib/model/pytorch_tcn_ts.py
+++ b/qlib/contrib/model/pytorch_tcn_ts.py
@@ -203,9 +203,11 @@ class TCN(Model):
     def fit(
         self,
         dataset,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
         dl_train = dataset.prepare("train", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)
         dl_valid = dataset.prepare("valid", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)
 

--- a/qlib/contrib/model/pytorch_tra.py
+++ b/qlib/contrib/model/pytorch_tra.py
@@ -413,7 +413,9 @@ class TRAModel(Model):
 
         return best_score
 
-    def fit(self, dataset, evals_result=dict()):
+    def fit(self, dataset, evals_result=None):
+        if evals_result is None:
+            evals_result = {}
         assert isinstance(dataset, MTSDatasetH), "TRAModel only supports `qlib.contrib.data.dataset.MTSDatasetH`"
 
         train_set, valid_set, test_set = dataset.prepare(["train", "valid", "test"])

--- a/qlib/contrib/model/pytorch_transformer.py
+++ b/qlib/contrib/model/pytorch_transformer.py
@@ -157,9 +157,11 @@ class TransformerModel(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
         df_train, df_valid, df_test = dataset.prepare(
             ["train", "valid", "test"],
             col_set=["feature", "label"],

--- a/qlib/contrib/model/pytorch_transformer_ts.py
+++ b/qlib/contrib/model/pytorch_transformer_ts.py
@@ -137,9 +137,11 @@ class TransformerModel(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result=None,
         save_path=None,
     ):
+        if evals_result is None:
+            evals_result = {}
         dl_train = dataset.prepare("train", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)
         dl_valid = dataset.prepare("valid", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)
 

--- a/qlib/contrib/model/xgboost.py
+++ b/qlib/contrib/model/xgboost.py
@@ -26,10 +26,12 @@ class XGBModel(Model, FeatureInt):
         num_boost_round=1000,
         early_stopping_rounds=50,
         verbose_eval=20,
-        evals_result=dict(),
+        evals_result=None,
         reweighter=None,
         **kwargs,
     ):
+        if evals_result is None:
+            evals_result = {}
         df_train, df_valid = dataset.prepare(
             ["train", "valid"],
             col_set=["feature", "label"],

--- a/tests/test_mutable_default_evals_result.py
+++ b/tests/test_mutable_default_evals_result.py
@@ -1,0 +1,85 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""
+Regression test for https://github.com/microsoft/qlib/issues/2167
+
+Ensures that model.fit() methods use ``evals_result=None`` (with a guard)
+instead of the mutable default ``evals_result=dict()``.  The latter is a
+well-known Python antipattern that causes state leakage between calls.
+"""
+
+import ast
+import os
+import unittest
+from pathlib import Path
+
+MODEL_DIR = Path(__file__).resolve().parent.parent / "qlib" / "contrib" / "model"
+EXAMPLE_TRA = Path(__file__).resolve().parent.parent / "examples" / "benchmarks" / "TRA" / "src" / "model.py"
+
+
+def _get_fit_defaults(filepath: Path):
+    """Parse a Python file and return the default value node for evals_result
+    in any fit() method found, along with the full source for body inspection."""
+    source = filepath.read_text(encoding="utf-8", errors="replace")
+    tree = ast.parse(source)
+    results = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "fit":
+            args = node.args
+            # defaults are aligned to the end of args.args
+            num_defaults = len(args.defaults)
+            num_args = len(args.args)
+            for i, default in enumerate(args.defaults):
+                arg_index = num_args - num_defaults + i
+                arg_name = args.args[arg_index].arg
+                if arg_name == "evals_result":
+                    results.append((node, default, source))
+    return results
+
+
+class TestNoMutableDefaultEvalsResult(unittest.TestCase):
+    """Verify that no fit() method uses a mutable default for evals_result."""
+
+    def _check_file(self, filepath: Path):
+        fits = _get_fit_defaults(filepath)
+        for func_node, default, source in fits:
+            # The default must be None, not dict() or {}
+            is_none = isinstance(default, ast.Constant) and default.value is None
+            self.assertTrue(
+                is_none,
+                f"{filepath.name}:{func_node.lineno} - fit() uses mutable default "
+                f"for evals_result (should be None)",
+            )
+            # The function body must contain the guard:
+            #   if evals_result is None:
+            #       evals_result = {}
+            body_source = ast.get_source_segment(source, func_node)
+            self.assertIn(
+                "if evals_result is None:",
+                body_source or "",
+                f"{filepath.name}:{func_node.lineno} - fit() missing "
+                f"if evals_result is None: evals_result = {{}} guard",
+            )
+
+    def test_all_contrib_models(self):
+        """Check every .py file in qlib/contrib/model/."""
+        py_files = sorted(MODEL_DIR.glob("*.py"))
+        self.assertTrue(len(py_files) > 0, "No model files found")
+        checked = 0
+        for f in py_files:
+            fits = _get_fit_defaults(f)
+            if fits:
+                self._check_file(f)
+                checked += 1
+        # Sanity: we expect at least 25 files to have evals_result in fit()
+        self.assertGreaterEqual(checked, 25, "Too few model files checked")
+
+    def test_example_tra_model(self):
+        """Check the TRA example model too."""
+        if EXAMPLE_TRA.exists():
+            self._check_file(EXAMPLE_TRA)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #2167

## Summary

- Replace `evals_result=dict()` with `evals_result=None` + explicit guard in **28 model `fit()` methods** across `qlib/contrib/model/` and `examples/benchmarks/TRA/src/model.py`
- Add regression test using AST parsing to prevent reintroduction

## Problem

Using `evals_result=dict()` as a default argument is a [well-known Python antipattern](https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments): the dict is created once at function definition time and shared across all calls, causing state leakage between separate `fit()` invocations.

## Fix

Applied the same pattern already used in `gbdt.py` and `highfreq_gdbt_model.py`:

```python
# Before
def fit(self, dataset, evals_result=dict()):

# After
def fit(self, dataset, evals_result=None):
    if evals_result is None:
        evals_result = {}
```

## Verification

- All 28 affected files fixed consistently
- `tests/test_contrib_model.py` passes (model initialization)
- `tests/misc/` test suite passes
- New regression test (`tests/test_mutable_default_evals_result.py`) passes
- black and flake8 checks pass
