### PR TITLE
fix: remove erroneous lstrip("/") in FileLock path construction

### DIFF
--- a/qlib/workflow/expm.py
+++ b/qlib/workflow/expm.py
@@ -233,7 +233,7 @@ class ExpManager:
             # So we supported it in the interface wrapper
             pr = urlparse(self.uri)
             if pr.scheme == "file":
-                with FileLock(Path(os.path.join(pr.netloc, pr.path.lstrip("/"), "filelock"))):  # pylint: disable=E0110
+                with FileLock(Path(os.path.join(pr.netloc, pr.path, "filelock"))):  # pylint: disable=E0110
                     return self.create_exp(experiment_name), True
             # NOTE: for other schemes like http, we double check to avoid create exp conflicts
             try:


### PR DESCRIPTION
## Summary

`lstrip("/")` on `pr.path` in `MLflowExpManager._get_or_create_exp` turns absolute `file://` URIs into relative paths, causing `mlruns/filelock` to be created under a spurious `home/<user>/<cwd>/...` directory tree relative to the working directory.

- **Root cause**: In `qlib/workflow/expm.py` (line 236), `urlparse` on a local `file:///...` URI produces `netloc=""` and `path="/home/.../mlruns"`. The `.lstrip("/")` strips the leading `/`, so `os.path.join("", "home/.../mlruns", "filelock")` yields a relative path instead of the correct absolute path.
- **Introduced in**: a0cef033 ("update python version #1868") as part of a bulk lint/CI cleanup — not an intentional logic change.
- **Original behavior**: commit 45ea4bae ("Add file lock for MLflowExpManager #619") correctly used `pr.path` without stripping.

## Fix

Remove the `.lstrip("/")` call. `os.path.join("", "/absolute/path", "filelock")` already produces the correct absolute path when `netloc` is empty.

```diff
- with FileLock(Path(os.path.join(pr.netloc, pr.path.lstrip("/"), "filelock"))):
+ with FileLock(Path(os.path.join(pr.netloc, pr.path, "filelock"))):
```

## Related note

A similar misuse of `lstrip` exists in `qlib/workflow/recorder.py` (lines 321–323), where `.lstrip("file:")` is used to strip a URI prefix. Since `str.lstrip` strips **characters** (not a prefix), this can over-strip in edge cases. The correct approach would be `str.removeprefix("file:")` (Python 3.9+). This is not addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)