### PR TITLE
fix(ops): WMA divides by window length twice

### DIFF
--- a/qlib/data/ops.py
+++ b/qlib/data/ops.py
@@ -1337,7 +1337,7 @@ class WMA(Rolling):
         def weighted_mean(x):
             w = np.arange(len(x)) + 1
             w = w / w.sum()
-            return np.nanmean(w * x)
+            return np.nansum(w * x)
 
         if self.N == 0:
             series = series.expanding(min_periods=1).apply(weighted_mean, raw=True)

--- a/tests/ops/test_elem_operator.py
+++ b/tests/ops/test_elem_operator.py
@@ -1,5 +1,6 @@
 import unittest
 import numpy as np
+import pandas as pd
 import pytest
 
 from qlib.data import DatasetProvider
@@ -38,6 +39,39 @@ class TestElementOperator(TestMockData):
         change[change < 0] = -1.0
         golden = change.to_numpy()
         self.assertIsNone(np.testing.assert_allclose(result, golden))
+
+    def test_WMA(self):
+        # Regression test for issue #1993: WMA.weighted_mean divided by the
+        # window length twice (normalized weights, then np.nanmean) producing
+        # values ~N times smaller than a correct weighted moving average.
+        # The sister operator EMA.exp_weighted_mean correctly uses np.nansum.
+        N = 5
+        field = f"WMA($close, {N})"
+        result = ExpressionD.expression(self.instrument, field, self.start_time, self.end_time, self.freq)
+        result = result.to_numpy()
+
+        close = self.mock_df["close"].reset_index(drop=True).to_numpy()
+
+        def reference_weighted_mean(x):
+            w = np.arange(len(x)) + 1
+            w = w / w.sum()
+            return np.nansum(w * x)
+
+        golden = (
+            pd.Series(close)
+            .rolling(N, min_periods=1)
+            .apply(reference_weighted_mean, raw=True)
+            .to_numpy()
+        )
+        np.testing.assert_allclose(result, golden, rtol=1e-5)
+
+        # A weighted moving average with non-negative weights summing to one
+        # must stay inside the input series' range. The pre-fix implementation
+        # produced values ~close/N, far below close.min().
+        close_min = float(np.nanmin(close))
+        close_max = float(np.nanmax(close))
+        self.assertGreaterEqual(float(np.nanmin(result)), close_min - 1e-9)
+        self.assertLessEqual(float(np.nanmax(result)), close_max + 1e-9)
 
 
 class TestOperatorDataSetting(TestOperatorData):


### PR DESCRIPTION
## Summary

`WMA.weighted_mean` in `qlib/data/ops.py` normalized the weight vector to sum to 1 and then returned `np.nanmean(w * x)`, which divides the weighted sum by `len(x)` a second time. This produced WMA values that were roughly a factor of N smaller than a correct weighted moving average.

The sister operator `EMA.exp_weighted_mean` already uses `np.nansum` on a normalized weight vector — this PR aligns `WMA` with that correct form.

```diff
 def weighted_mean(x):
     w = np.arange(len(x)) + 1
     w = w / w.sum()
-    return np.nanmean(w * x)
+    return np.nansum(w * x)
```

## Impact

Alpha158 uses WMA. Any Alpha158-based factor/backtest has been running against silently wrong rolling averages, roughly a factor of N smaller than intended. Empirical proof from the mock TW 0050 close series (prices ~146):

| Window | Pre-fix | Post-fix |
|--------|---------|----------|
| 1 | 146.40 | 146.40 |
| 2 | 74.27  | 148.53 |
| 3 | 49.64  | 148.92 |
| 4 | 37.13  | 148.51 |
| 5 | 29.57  | 147.87 |

The pre-fix output (29.57 for a series ranging 141–152) violates a fundamental property of any weighted average: with non-negative weights summing to 1, the result must lie inside the input range.

## Test

Adds `test_WMA` in `tests/ops/test_elem_operator.py`:

1. Compares `WMA($close, 5)` against a NumPy reference using the same rolling + normalized-weights formula with `np.nansum`.
2. Asserts the result stays inside the input series' `[min, max]` range (a property the pre-fix implementation violates by ~5x).

```
pytest tests/ops/test_elem_operator.py::TestElementOperator -v
```
All 3 `TestElementOperator` tests pass; full `tests/ops/` suite stays green.

## Related

Fixes #1993. Supersedes the stale #2109 by adding the missing regression test.