### PR TITLE
fix: correct typo occured -> occurred in br_index/collector.py

### DIFF
--- a/scripts/data_collector/br_index/collector.py
+++ b/scripts/data_collector/br_index/collector.py
@@ -226,7 +226,7 @@ class IBOVIndex(IndexBase):
             return df
 
         except Exception as E:
-            logger.error("An error occured while downloading 2008 index composition - {}".format(E))
+            logger.error("An error occurred while downloading 2008 index composition - {}".format(E))
 
     def get_new_companies(self):
         """
@@ -274,7 +274,7 @@ class IBOVIndex(IndexBase):
             return df
 
         except Exception as E:
-            logger.error("An error occured while getting new companies - {}".format(E))
+            logger.error("An error occurred while getting new companies - {}".format(E))
 
     def filter_df(self, df: pd.DataFrame) -> pd.DataFrame:
         if "Código" in df.columns:


### PR DESCRIPTION
Good day,

Found a typo in the br_index/collector.py file where `occured` should be `occurred`.

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly, RoomWithOutRoof