### PR TITLE
fix: ensure time is logged even when exception is raised in logt()

### DIFF
--- a/qlib/log.py
+++ b/qlib/log.py
@@ -145,8 +145,7 @@ class TimeInspector:
         try:
             yield None
         finally:
-            pass
-        cls.log_cost_time(info=f"{name} Done")
+            cls.log_cost_time(info=f"{name} Done")
 
 
 def set_log_with_config(log_config: Dict[Text, Any]):


### PR DESCRIPTION
## Motivation and Context
The `logt` context manager in `qlib/log.py` places `log_cost_time` outside the `try/finally` block. This means if an exception is raised inside a `with TimeInspector.logt():` block, the time is never logged and the time mark pushed onto the stack is never popped, causing a stack leak.

## How Has This Been Tested?
- [x] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [x] If you are adding a new feature, test on your own test scripts.

## Types of changes
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation