### PR TITLE
fix: pass --interval from BaseRun to Normalize in normalize_data

### DIFF
--- a/scripts/data_collector/base.py
+++ b/scripts/data_collector/base.py
@@ -440,6 +440,7 @@ class BaseRun(abc.ABC):
             $ python collector.py normalize_data --source_dir ~/.qlib/instrument_data/source --normalize_dir ~/.qlib/instrument_data/normalize --region CN --interval 1d
         """
         _class = getattr(self._cur_module, self.normalize_class_name)
+        kwargs.setdefault("interval", self.interval)
         yc = Normalize(
             source_dir=self.source_dir,
             target_dir=self.normalize_dir,


### PR DESCRIPTION
## Description
Fixed the issue where the Fire CLI consumed the `--interval` parameter for `BaseRun.__init__` but did not forward it to the `Normalize` constructor.
Added `interval` parameter passing to ensure `PitNormalize` uses the user-provided interval value instead of defaulting to "quarterly".

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The CLI flag `--interval` was not being passed to the normalization component, causing `PitNormalize` to always use the default "quarterly" format regardless of user input.
This PR ensures the interval configuration works correctly in the data normalization workflow.

## How Has This Been Tested?
python qlib/scripts/data_collector/pit/collector.py normalize_data \
  --interval annual \
  --source_dir "~/.qlib/qlib_data/custom_data_hfq/pit_annual" \
  --normalize_dir "~/.qlib/qlib_data/custom_data_hfq/pit_normalized_annual"

## Types of changes
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation