### PR TITLE
fix: avoid np.int in feature inf analysis

### DIFF
--- a/qlib/contrib/report/data/ana.py
+++ b/qlib/contrib/report/data/ana.py
@@ -99,7 +99,7 @@ class FeaInfAna(NumFeaAnalyser):
         self._inf_cnt = {}
         for col, item in self._dataset.items():
             if not super().skip(col):
-                self._inf_cnt[col] = item.apply(np.isinf).astype(np.int).groupby(DT_COL_NAME, group_keys=False).sum()
+                self._inf_cnt[col] = item.apply(np.isinf).astype(int).groupby(DT_COL_NAME, group_keys=False).sum()
         self._inf_cnt = pd.DataFrame(self._inf_cnt)
 
     def skip(self, col):

--- a/tests/test_contrib_report_data_ana.py
+++ b/tests/test_contrib_report_data_ana.py
@@ -1,0 +1,29 @@
+import numpy as np
+import pandas as pd
+
+from qlib.contrib.report.data.ana import FeaInfAna
+
+
+def test_fea_inf_ana_counts_inf_values_with_numpy_2():
+    index = pd.MultiIndex.from_tuples(
+        [
+            (pd.Timestamp("2024-01-01"), "SH000001"),
+            (pd.Timestamp("2024-01-01"), "SH000002"),
+            (pd.Timestamp("2024-01-02"), "SH000001"),
+            (pd.Timestamp("2024-01-02"), "SH000002"),
+        ],
+        names=["datetime", "instrument"],
+    )
+    dataset = pd.DataFrame(
+        {
+            "feature": [1.0, np.inf, -np.inf, 2.0],
+            "clean": [1.0, 2.0, 3.0, 4.0],
+        },
+        index=index,
+    )
+
+    analyser = FeaInfAna(dataset)
+
+    assert analyser._inf_cnt.loc[pd.Timestamp("2024-01-01"), "feature"] == 1
+    assert analyser._inf_cnt.loc[pd.Timestamp("2024-01-02"), "feature"] == 1
+    assert analyser.skip("clean")


### PR DESCRIPTION
## Summary

- replace the removed NumPy `np.int` alias in `FeaInfAna` with the built-in `int`
- add a regression test covering infinite-value counting under NumPy 2.x

## Why

NumPy 2.x raises `AttributeError` when code accesses `np.int`. That makes `FeaInfAna` fail before it can summarize infinite feature values. The built-in `int` preserves the current integer mask behavior without pinning to a platform-specific NumPy dtype.

## Checks

- `python -m pytest tests/test_contrib_report_data_ana.py -q`
- `python -m compileall -q qlib/contrib/report/data/ana.py tests/test_contrib_report_data_ana.py`
- `python -m black --check --diff -l 120 qlib/contrib/report/data/ana.py tests/test_contrib_report_data_ana.py`
- `git diff --cached --check`