### PR TITLE
fix: respect disabled benchmark config

### DIFF
--- a/qlib/backtest/__init__.py
+++ b/qlib/backtest/__init__.py
@@ -163,7 +163,7 @@ def create_account_instance(
         position_dict=position_dict,
         pos_type=pos_type,
         benchmark_config=(
-            {}
+            {"benchmark": None}
             if benchmark is None
             else {
                 "benchmark": benchmark,

--- a/tests/backtest/test_benchmark_config.py
+++ b/tests/backtest/test_benchmark_config.py
@@ -1,0 +1,15 @@
+from qlib.backtest import create_account_instance
+
+
+def test_create_account_instance_disables_benchmark_when_none():
+    account = create_account_instance(
+        start_time="2020-01-01",
+        end_time="2020-01-02",
+        benchmark=None,
+        account=100000,
+    )
+
+    assert account.benchmark_config["benchmark"] is None
+    assert "start_time" not in account.benchmark_config
+    assert "end_time" not in account.benchmark_config
+    assert account.portfolio_metrics.bench is None


### PR DESCRIPTION
﻿## Summary
- keep `benchmark=None` as an explicit disabled benchmark config when creating a backtest account
- add a regression test so custom-data backtests do not fall back to `SH000300`

Fixes #2205.

## To verify
- `python -m py_compile qlib/backtest/__init__.py tests/backtest/test_benchmark_config.py`
- `python -m pytest tests/backtest/test_benchmark_config.py -q`

I could not complete the pytest command locally on Windows because the clean clone does not have Qlib's Cython extension built, and editable build failed in the local MSVC/Windows SDK environment with `fatal error C1083: cannot open include file: 'io.h'`. The syntax check above passed.
