### PR TITLE
fix(config): keep QlibConfig.registered safe in joblib worker subprocesses

### DIFF
--- a/qlib/config.py
+++ b/qlib/config.py
@@ -112,7 +112,16 @@ class Config:
     def register_from_C(config, skip_register=True):
         from .utils import set_log_with_config  # pylint: disable=C0415
 
-        if C.registered and skip_register:
+        # ``C.registered`` resolves through ``QlibConfig.registered``, which
+        # reads ``self._registered`` -- a key stored inside ``self._config`` via
+        # the overridden ``__setattr__``.  In freshly-spawned joblib worker
+        # processes that key may be absent (e.g. when ``Config.reset()`` rebuilt
+        # ``_config`` from ``_default_config`` between ``QlibConfig.__init__``
+        # and this call), and ``Config.__getattr__`` would then raise
+        # ``AttributeError: No such ``registered`` in self._config`` and crash
+        # the backtest worker (issue #2038).  Falling back to ``False`` lets
+        # the worker re-register safely instead of dying.
+        if getattr(C, "registered", False) and skip_register:
             return
 
         C.set_conf_from_C(config)
@@ -520,7 +529,14 @@ class QlibConfig(Config):
 
     @property
     def registered(self):
-        return self._registered
+        # ``_registered`` is stored inside ``self._config`` because the
+        # overridden ``__setattr__`` routes attribute writes there.  After a
+        # ``Config.reset()`` (or in joblib worker subprocesses where ``_config``
+        # is recreated from ``_default_config`` before ``QlibConfig.__init__``
+        # finishes), the key may be missing.  Treat missing as ``False`` so
+        # callers see a consistent "not yet registered" signal instead of
+        # ``AttributeError`` (issue #2038).
+        return self.__dict__.get("_config", {}).get("_registered", False)
 
 
 # global config

--- a/tests/misc/test_config_registered.py
+++ b/tests/misc/test_config_registered.py
@@ -1,0 +1,70 @@
+"""Regression tests for issue #2038.
+
+In freshly spawned joblib worker processes ``register_from_C`` reads
+``C.registered`` before ``set_conf_from_C`` syncs the parent's config.  When
+``_config`` does not carry the ``_registered`` key (for instance after a
+``Config.reset()`` call), the previous implementation surfaced as
+``AttributeError: No such ``registered`` in self._config`` and crashed the
+backtest worker.  The fixed property and the defensive ``getattr`` in
+``register_from_C`` must keep these scenarios safe.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from qlib.config import C, Config, QlibConfig, _default_config
+
+
+class QlibConfigRegisteredAccessTest(unittest.TestCase):
+    """Issue #2038: ``C.registered`` must never raise even if the
+    ``_registered`` key was scrubbed from ``self._config``."""
+
+    def test_registered_property_returns_false_when_key_missing(self) -> None:
+        config = QlibConfig(_default_config)
+        # Simulate the worker state where ``_config`` was rebuilt from
+        # ``_default_config`` (which does not contain ``_registered``).
+        config.__dict__["_config"].pop("_registered", None)
+
+        try:
+            value = config.registered
+        except AttributeError as exc:  # pragma: no cover - failure path
+            self.fail(f"QlibConfig.registered raised AttributeError: {exc}")
+
+        self.assertFalse(value)
+
+    def test_registered_property_returns_false_when_config_missing(self) -> None:
+        # Defensive: even if ``_config`` itself has not been initialised yet
+        # (e.g. partially-constructed instance during unpickling), the property
+        # must surface ``False`` rather than blow up.
+        config = QlibConfig.__new__(QlibConfig)
+        self.assertFalse(config.registered)
+
+    def test_register_from_C_does_not_raise_when_registered_missing(self) -> None:
+        original_config = dict(C.__dict__["_config"])
+        original_registered = C.__dict__["_config"].pop("_registered", False)
+        try:
+            # Should hit the defensive ``getattr`` path and NOT raise.  We do
+            # not call ``register_from_C`` end-to-end (it would touch the
+            # workflow exit handler) -- instead we exercise the guarded
+            # boolean expression directly, which is the exact line that
+            # raised in the original bug report.
+            self.assertFalse(getattr(C, "registered", False))
+        finally:
+            # Restore C so other tests are not affected.
+            C.__dict__["_config"].clear()
+            C.__dict__["_config"].update(original_config)
+            if original_registered is not None:
+                C.__dict__["_config"]["_registered"] = original_registered
+
+    def test_registered_property_after_normal_construction(self) -> None:
+        # The defensive change must not regress the happy path.
+        config = QlibConfig(_default_config)
+        self.assertFalse(config.registered)
+
+        config.__dict__["_config"]["_registered"] = True
+        self.assertTrue(config.registered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Fixes #2038. `QlibConfig.registered` is implemented as a `@property` that returns `self._registered`, but because the overridden `__setattr__` routes attribute writes through `self.__dict__["_config"]`, the `_registered` flag actually lives inside the `_config` dict. If `_config` is rebuilt from `_default_config` without the `_registered` key (e.g. inside a freshly-spawned joblib worker that re-imports `qlib`, or transiently inside `Config.reset()` before `QlibConfig.__init__` re-sets the flag), the property's inner `self._registered` access raises `AttributeError`, Python falls back to `Config.__getattr__` for the original attribute name `registered`, and the worker dies with:

  ```
  AttributeError: No such ``registered`` in self._config
  ```

  This terminates backtests along `PortfolioMetrics._cal_benchmark` -> `get_higher_eq_freq_feature` -> `D.features` -> `ParallelExt` -> `inst_calculator` -> `register_from_C`.

- Make the property defensive: read `_registered` out of `self.__dict__["_config"]` via a safe `.get()` chain so a missing key returns `False` instead of triggering the property -> `__getattr__` cascade.
- Harden `register_from_C` with `getattr(C, "registered", False)` so the second top-level caller (`qlib/config.py:115`) is double-protected against the same failure mode.

## Validation
- `uv run pytest tests/misc/test_config_registered.py` -- 4 passed.
- Pre-fix sanity check: stashing the patch and running the new test suite reproduces the reporter's exact error message (`AttributeError: No such ``registered`` in self._config`) on `test_registered_property_returns_false_when_key_missing` and `test_registered_property_returns_false_when_config_missing`; reapplying the patch turns both green.
- `uv run black qlib/config.py tests/misc/test_config_registered.py -l 120 --check --diff` -- clean.
- `uv run flake8 --ignore=E501,F541,E266,E402,W503,E731,E203 qlib/config.py` -- clean.

## Tests added
- `test_registered_property_returns_false_when_key_missing` -- worker scenario where `_config` lacks the `_registered` key.
- `test_registered_property_returns_false_when_config_missing` -- partially-constructed instance (e.g. mid-unpickle) where even `_config` is absent.
- `test_register_from_C_does_not_raise_when_registered_missing` -- exact guarded boolean from the original bug report does not raise on the global `C` when the key is removed.
- `test_registered_property_after_normal_construction` -- happy path still reflects the assigned value.

Fixes #2038