### PR TITLE
fix(data): provide _dataset_uri fallback on DatasetProvider

### DIFF
--- a/qlib/data/data.py
+++ b/qlib/data/data.py
@@ -507,6 +507,31 @@ class DatasetProvider(abc.ABC):
         # TODO: qlib-server support inst_processors
         return DiskDatasetCache._uri(instruments, fields, start_time, end_time, freq, disk_cache, inst_processors)
 
+    def _dataset_uri(
+        self,
+        instruments,
+        fields,
+        start_time=None,
+        end_time=None,
+        freq="day",
+        disk_cache=1,
+        inst_processors=[],
+    ):
+        """Default `_dataset_uri` for dataset providers that have no cache wrapper.
+
+        When no `DatasetCache` is configured the wrapped provider (e.g.
+        `LocalDatasetProvider`) is registered directly as `DatasetD`, so the
+        `features_uri` -> `DatasetD._dataset_uri(...)` call would otherwise
+        raise `AttributeError`. Returning an empty string signals the caller
+        that the client should load the data itself (the same convention
+        `DiskDatasetCache._dataset_uri` already uses for `disk_cache == 0`).
+        Cache subclasses such as `DiskDatasetCache` continue to override this
+        method with a real URI implementation.
+
+        See issue #1843.
+        """
+        return ""
+
     @staticmethod
     def get_instruments_d(instruments, freq):
         """

--- a/tests/misc/test_dataset_provider_uri.py
+++ b/tests/misc/test_dataset_provider_uri.py
@@ -1,0 +1,56 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Unit tests for ``DatasetProvider._dataset_uri`` fallback (issue #1843).
+
+When qlib runs without a ``DatasetCache`` wrapper the ``DatasetD`` ``Wrapper``
+points directly at a ``LocalDatasetProvider`` instance. ``LocalProvider.features_uri``
+unconditionally calls ``DatasetD._dataset_uri(...)``, so the bare provider must
+expose the method even though it has no cache to address. The base class now
+returns an empty string by convention (``""`` = "no URI, fetch directly"),
+matching ``DiskDatasetCache._dataset_uri`` 's behaviour for the ``disk_cache==0``
+branch.
+"""
+
+import unittest
+
+from qlib.data.data import LocalDatasetProvider
+
+
+class DatasetProviderURITest(unittest.TestCase):
+    def test_local_dataset_provider_has_dataset_uri(self):
+        provider = LocalDatasetProvider()
+        # Should not raise AttributeError (regression for #1843).
+        self.assertTrue(hasattr(provider, "_dataset_uri"))
+
+    def test_local_dataset_provider_returns_empty_uri(self):
+        provider = LocalDatasetProvider()
+        uri = provider._dataset_uri(
+            instruments={"market": "csi300"},
+            fields=["$close"],
+            start_time="2020-01-01",
+            end_time="2020-12-31",
+            freq="day",
+            disk_cache=1,
+        )
+        # Empty string == "no cache configured, client should fetch directly".
+        self.assertEqual(uri, "")
+
+    def test_disk_cache_value_is_ignored_in_fallback(self):
+        # The fallback returns "" regardless of disk_cache value because there
+        # is no cache to address. Cache subclasses (DiskDatasetCache) override
+        # this with the disk_cache-aware behaviour.
+        provider = LocalDatasetProvider()
+        for disk_cache in (0, 1, 2):
+            self.assertEqual(
+                provider._dataset_uri(
+                    instruments=[],
+                    fields=[],
+                    disk_cache=disk_cache,
+                ),
+                "",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #1843. When qlib runs without a \`DatasetCache\` wrapper, the global \`DatasetD\` \`Wrapper\` is registered with a bare \`LocalDatasetProvider\` instance. \`LocalProvider.features_uri\` (\`qlib/data/data.py:1221\`) then calls:

\`\`\`python
return DatasetD._dataset_uri(instruments, fields, start_time, end_time, freq, disk_cache)
\`\`\`

That goes through \`Wrapper.__getattr__\` to find \`_dataset_uri\` on the provider — and \`LocalDatasetProvider\` doesn't have one. The cache-aware override lives on \`DatasetCache\` / \`DiskDatasetCache\` only, so the no-cache code path crashes with:

\`\`\`
AttributeError: 'LocalDatasetProvider' object has no attribute '_dataset_uri'
\`\`\`

## Approach

Add a base \`_dataset_uri\` to \`DatasetProvider\` that returns \`""\` by convention. That mirrors the existing \`""\` = "no URI, fetch directly" signal that \`DiskDatasetCache._dataset_uri\` already emits on its \`disk_cache == 0\` branch (\`qlib/data/cache.py:750\`), so the contract isn't a new invention — the caller already handles \`""\` correctly.

Cache subclasses keep their explicit overrides, so the wrapped-with-cache path is unchanged. The fallback also covers \`ClientDatasetProvider\` and any third-party providers that subclass \`DatasetProvider\` without routing through a cache, not just \`LocalDatasetProvider\` specifically.

## Test

New \`tests/misc/test_dataset_provider_uri.py\` with three regressions:

- attribute presence on \`LocalDatasetProvider\` (the AttributeError pinned exactly)
- the empty-string return for the standard parameter shape
- stability across \`disk_cache\` values 0/1/2 so a future refactor can't reintroduce the crash by adding a misplaced branch

\`\`\`
$ .venv/bin/python -m pytest tests/misc/test_dataset_provider_uri.py -v
tests/misc/test_dataset_provider_uri.py::DatasetProviderURITest::test_disk_cache_value_is_ignored_in_fallback PASSED
tests/misc/test_dataset_provider_uri.py::DatasetProviderURITest::test_local_dataset_provider_has_dataset_uri PASSED
tests/misc/test_dataset_provider_uri.py::DatasetProviderURITest::test_local_dataset_provider_returns_empty_uri PASSED
============================== 3 passed in 0.94s ===============================
\`\`\`

Fixes #1843