### PR TITLE
ci: add black + flake8 lint check workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,53 @@
+name: Lint check
+
+# Read-only lint check on pull requests. Runs the existing Makefile lint
+# targets (black, flake8) and fails the workflow if any issues are found,
+# so PRs surface formatting and lint regressions at review time instead of
+# the maintainer having to run them locally. Pylint, mypy and nbqa from the
+# `lint` aggregate target are intentionally left out of this initial workflow
+# so the CI signal stays green-or-red without flagging long-standing
+# diagnostics; they can be added in follow-up changes if maintainers want
+# the broader gate.
+#
+# Auto-fix and auto-commit are explicitly NOT performed here. Pushing
+# generated commits back into a PR head requires `pull_request_target` and
+# `contents: write`, which is unsafe when the PR comes from an external fork
+# (the auto-fix step would run with repo-write secrets in the context of
+# untrusted code). A check-only workflow gives the same lint enforcement
+# benefit with no fork-PR security tradeoff.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: black + flake8
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install lint dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --no-cache-dir -e .[lint]
+
+      - name: Check formatting with black
+        run: make black
+
+      - name: Check style with flake8
+        run: make flake8


### PR DESCRIPTION
## Summary

Fixes #2060.

Adds a \`Lint check\` GitHub Actions workflow that runs the existing \`make black\` and \`make flake8\` targets on every push to \`main\` and every pull request. PRs surface formatting and style regressions at review time instead of relying on contributors to remember to run the local Makefile targets first.

Confirmed locally that both targets are clean against current \`main\` (\`231 files would be left unchanged\` for black, no output for flake8), so the workflow will be green on day one.

## Why this deviates from the issue's sample

The issue's sample workflow pushed auto-fix commits back to the PR branch. I intentionally **did not** include that for one reason:

- Auto-commit on a PR requires \`pull_request_target\` + \`contents: write\`. That combination runs with repo-write secrets in the context of an external fork's code, which is the canonical fork-PR privilege-escalation vector. Maintainers would (rightly) need to vet every PR before letting that workflow run, which defeats the "automated" part.

A read-only check gives the same lint-enforcement benefit with no fork-PR security tradeoff; contributors run \`make black\` / \`make flake8\` locally to fix issues. Happy to add the auto-fix variant in a separate workflow guarded by \`workflow_dispatch\` or \`pull_request\` (not \`_target\`) if maintainers prefer that direction.

## Why only black + flake8, not all of \`make lint\`

\`make lint\` chains \`black\`, \`pylint\`, \`flake8\`, \`mypy\` and \`nbqa\`. The Makefile shows long disable-lists for pylint and mypy carrying historical warnings the team has left intentionally unaddressed. Folding those into a hard gate would either fail the workflow on every PR or require maintainers to first burn down the backlog. Keeping the initial CI binary on the two strict tools means PRs land green or red without a noisy yellow channel; the heavier checks can be folded in via follow-up once maintainers decide what threshold they want there.

## Files

- \`.github/workflows/lint.yml\` — new, 53 lines.

## Validation

\`\`\`
$ make black
black . -l 120 --check --diff --exclude qlib/_version.py
All done! ✨ 🍰 ✨
231 files would be left unchanged.

$ make flake8
flake8 --ignore=E501,F541,E266,E402,W503,E731,E203 --per-file-ignores="__init__.py:F401,F403" qlib
(no output)
\`\`\`

The workflow uses Python 3.10 — middle of the supported range from \`test_qlib_from_source.yml\` — so the lint job stays fast and doesn't re-run identical lint over the full test matrix.

Fixes #2060