### PR TITLE
fix: keep TCN TS singleton batch outputs 1d

### DIFF
--- a/qlib/contrib/model/pytorch_tcn_ts.py
+++ b/qlib/contrib/model/pytorch_tcn_ts.py
@@ -294,4 +294,4 @@ class TCNModel(nn.Module):
     def forward(self, x):
         output = self.tcn(x)
         output = self.linear(output[:, :, -1])
-        return output.squeeze()
+        return output.squeeze(-1)

--- a/tests/model/test_pytorch_tcn_ts.py
+++ b/tests/model/test_pytorch_tcn_ts.py
@@ -1,0 +1,10 @@
+import torch
+
+from qlib.contrib.model.pytorch_tcn_ts import TCNModel
+
+
+def test_tcn_ts_model_keeps_batch_dimension_for_single_sample():
+    model = TCNModel(num_input=3, output_size=1, num_channels=[4], kernel_size=2, dropout=0.0)
+
+    assert model(torch.randn(1, 3, 8)).shape == (1,)
+    assert model(torch.randn(2, 3, 8)).shape == (2,)


### PR DESCRIPTION
﻿## Summary
- Keep the time-series TCN model output as a 1-D batch vector for singleton batches.
- Add a regression test that checks batch size 1 and batch size 2 both keep the batch dimension.

Fixes #1752.

## To verify
- python -m ruff check qlib/contrib/model/pytorch_tcn_ts.py tests/model/test_pytorch_tcn_ts.py
- python -m py_compile qlib/contrib/model/pytorch_tcn_ts.py tests/model/test_pytorch_tcn_ts.py

## Notes
- python -m pytest tests/model/test_pytorch_tcn_ts.py -q is blocked in my Windows checkout because qlib requires its Cython extensions to be compiled before import. python -m pip install -e . --no-deps reaches the qlib.data._libs.rolling build, but MSVC fails while reading the Python headers with missing io.h.
