### PR TITLE
fix: respect disabled backtest benchmark

### DIFF
--- a/qlib/backtest/__init__.py
+++ b/qlib/backtest/__init__.py
@@ -163,7 +163,7 @@ def create_account_instance(
         position_dict=position_dict,
         pos_type=pos_type,
         benchmark_config=(
-            {}
+            {"benchmark": None}
             if benchmark is None
             else {
                 "benchmark": benchmark,

--- a/tests/backtest/test_account.py
+++ b/tests/backtest/test_account.py
@@ -1,0 +1,13 @@
+from qlib.backtest import create_account_instance
+
+
+def test_create_account_instance_keeps_disabled_benchmark():
+    account = create_account_instance(
+        start_time="2020-01-01",
+        end_time="2020-01-31",
+        benchmark=None,
+        account=1000000,
+    )
+
+    assert account.benchmark_config == {"benchmark": None}
+    assert account.portfolio_metrics.bench is None


### PR DESCRIPTION
﻿## Summary
- keep `benchmark=None` as an explicit disabled benchmark when creating the backtest account
- add a regression test for the disabled-benchmark path

Fixes #2205.

## To verify
- python -m py_compile qlib\backtest\__init__.py tests\backtest\test_account.py
- git diff --check

I also tried to run `python -m pytest tests\backtest\test_account.py -q`, but this Windows clean clone could not import qlib before compiling the Cython extensions. `pip install -e .` then failed in MSVC because this machine is missing the Windows UCRT header `io.h`, so I could not complete the local pytest run here.
