### PR TITLE
fix: add 5min collector defaults

### DIFF
--- a/scripts/data_collector/base.py
+++ b/scripts/data_collector/base.py
@@ -23,10 +23,13 @@ class BaseCollector(abc.ABC):
 
     DEFAULT_START_DATETIME_1D = pd.Timestamp("2000-01-01")
     DEFAULT_START_DATETIME_1MIN = pd.Timestamp(datetime.datetime.now() - pd.Timedelta(days=5 * 6 - 1)).date()
+    DEFAULT_START_DATETIME_5MIN = DEFAULT_START_DATETIME_1MIN
     DEFAULT_END_DATETIME_1D = pd.Timestamp(datetime.datetime.now() + pd.Timedelta(days=1)).date()
     DEFAULT_END_DATETIME_1MIN = DEFAULT_END_DATETIME_1D
+    DEFAULT_END_DATETIME_5MIN = DEFAULT_END_DATETIME_1MIN
 
     INTERVAL_1min = "1min"
+    INTERVAL_5min = "5min"
     INTERVAL_1d = "1d"
 
     def __init__(

--- a/tests/test_data_collector_base.py
+++ b/tests/test_data_collector_base.py
@@ -1,0 +1,30 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+
+sys.path.append(str(Path(__file__).resolve().parent.parent.joinpath("scripts")))
+
+from data_collector.base import BaseCollector
+
+
+class DummyCollector(BaseCollector):
+    def get_instrument_list(self):
+        return []
+
+    def normalize_symbol(self, symbol: str):
+        return symbol
+
+    def get_data(self, symbol: str, interval: str, start_datetime: pd.Timestamp, end_datetime: pd.Timestamp):
+        return pd.DataFrame()
+
+
+def test_base_collector_supports_default_5min_date_range(tmp_path):
+    collector = DummyCollector(save_dir=tmp_path, interval="5min")
+
+    assert collector.start_datetime == DummyCollector.DEFAULT_START_DATETIME_5MIN
+    assert collector.end_datetime == DummyCollector.DEFAULT_END_DATETIME_5MIN


### PR DESCRIPTION
﻿## Summary
- add `5min` default start/end date aliases to `BaseCollector`
- cover the default path with a small dummy collector test

Fixes #1885

## To verify
- `.venv/Scripts/python.exe -m pytest tests/test_data_collector_base.py -q`
- `.venv/Scripts/python.exe -m py_compile scripts/data_collector/base.py scripts/data_collector/baostock_5min/collector.py tests/test_data_collector_base.py`
- `git diff --check`

Note: I first tried `pip install -e .[test]` in a local Windows venv, but editable install hit the existing qlib C-extension build path on this machine (`pyconfig.h` could not include `io.h`). The focused test only needs the source tree and Python-level imports, so I used the local venv with `PYTHONPATH` pointed at the checkout.
