### PR TITLE
fix: parse mixed Yahoo date index

### DIFF
--- a/scripts/data_collector/yahoo/collector.py
+++ b/scripts/data_collector/yahoo/collector.py
@@ -369,6 +369,23 @@ class YahooNormalize(BaseNormalize):
     DAILY_FORMAT = "%Y-%m-%d"
 
     @staticmethod
+    def _parse_datetime_index(index) -> pd.DatetimeIndex:
+        try:
+            parsed = pd.to_datetime(index)
+            if isinstance(parsed, pd.DatetimeIndex):
+                return parsed.tz_localize(None) if parsed.tz is not None else parsed
+        except ValueError:
+            pass
+
+        parsed_values = []
+        for value in index:
+            timestamp = pd.to_datetime(value)
+            if getattr(timestamp, "tzinfo", None) is not None:
+                timestamp = timestamp.tz_localize(None)
+            parsed_values.append(timestamp)
+        return pd.DatetimeIndex(parsed_values)
+
+    @staticmethod
     def calc_change(df: pd.DataFrame, last_close: float) -> pd.Series:
         df = df.copy()
         _tmp_series = df["close"].ffill()
@@ -392,8 +409,7 @@ class YahooNormalize(BaseNormalize):
         columns = copy.deepcopy(YahooNormalize.COLUMNS)
         df = df.copy()
         df.set_index(date_field_name, inplace=True)
-        df.index = pd.to_datetime(df.index)
-        df.index = df.index.tz_localize(None)
+        df.index = YahooNormalize._parse_datetime_index(df.index)
         df = df[~df.index.duplicated(keep="first")]
         if calendar_list is not None:
             df = df.reindex(

--- a/tests/test_yahoo_collector.py
+++ b/tests/test_yahoo_collector.py
@@ -1,0 +1,23 @@
+import pandas as pd
+import pytest
+
+from scripts.data_collector.yahoo.collector import YahooNormalize
+
+
+def test_normalize_yahoo_accepts_mixed_daily_and_timezone_dates():
+    df = pd.DataFrame(
+        {
+            "date": ["2025-09-01", "2025-09-02 09:30:00+08:00"],
+            "symbol": ["sh600468", "sh600468"],
+            "open": [10.0, 11.0],
+            "close": [10.0, 11.0],
+            "high": [10.0, 11.0],
+            "low": [10.0, 11.0],
+            "volume": [100.0, 100.0],
+        }
+    )
+
+    result = YahooNormalize.normalize_yahoo(df)
+
+    assert result["date"].tolist() == [pd.Timestamp("2025-09-01"), pd.Timestamp("2025-09-02 09:30:00")]
+    assert result["change"].iloc[1] == pytest.approx(0.1)


### PR DESCRIPTION
﻿## What
- make Yahoo normalization tolerate a mixed date index containing both daily dates and timezone-bearing timestamps
- keep the existing timezone-stripping behavior after parsing
- add a small regression test for the mixed daily/timestamp shape from #2014

## To verify
- `python -m py_compile scripts\data_collector\yahoo\collector.py tests\test_yahoo_collector.py`
- `git diff --check -- scripts\data_collector\yahoo\collector.py tests\test_yahoo_collector.py`

## Local note
- `python -m pytest tests\test_yahoo_collector.py -q` is blocked in this Windows checkout because qlib's local C extensions are not built: `ModuleNotFoundError: No module named 'qlib.data._libs.rolling'`.
- `python setup.py build_ext --inplace` also fails before tests with Conda Python's `pyconfig.h` unable to include `io.h`, so I did not classify that as a patch failure.

Fixes #2014
