### PR TITLE
fix: LightGBM 4.0+ compatibility for early_stopping_rounds=None

### DIFF
--- a/qlib/contrib/model/gbdt.py
+++ b/qlib/contrib/model/gbdt.py
@@ -68,19 +68,26 @@ class LGBModel(ModelFT, LightGBMFInt):
             evals_result = {}  # in case of unsafety of Python default values
         ds_l = self._prepare_data(dataset, reweighter)
         ds, names = list(zip(*ds_l))
-        early_stopping_callback = lgb.early_stopping(
-            self.early_stopping_rounds if early_stopping_rounds is None else early_stopping_rounds
-        )
+
+        # Build callbacks list
+        callbacks = []
+
+        # Only add early_stopping callback if rounds is not None (LightGBM 4.0+ doesn't accept None)
+        early_stop_rounds = self.early_stopping_rounds if early_stopping_rounds is None else early_stopping_rounds
+        if early_stop_rounds is not None:
+            callbacks.append(lgb.early_stopping(early_stop_rounds))
+
         # NOTE: if you encounter error here. Please upgrade your lightgbm
-        verbose_eval_callback = lgb.log_evaluation(period=verbose_eval)
-        evals_result_callback = lgb.record_evaluation(evals_result)
+        callbacks.append(lgb.log_evaluation(period=verbose_eval))
+        callbacks.append(lgb.record_evaluation(evals_result))
+
         self.model = lgb.train(
             self.params,
             ds[0],  # training dataset
             num_boost_round=self.num_boost_round if num_boost_round is None else num_boost_round,
             valid_sets=ds,
             valid_names=names,
-            callbacks=[early_stopping_callback, verbose_eval_callback, evals_result_callback],
+            callbacks=callbacks,
             **kwargs,
         )
         for k in names:

--- a/qlib/contrib/model/highfreq_gdbt_model.py
+++ b/qlib/contrib/model/highfreq_gdbt_model.py
@@ -124,16 +124,21 @@ class HFLGBModel(ModelFT, LightGBMFInt):
         if evals_result is None:
             evals_result = dict()
         dtrain, dvalid = self._prepare_data(dataset)
-        early_stopping_callback = lgb.early_stopping(early_stopping_rounds)
-        verbose_eval_callback = lgb.log_evaluation(period=verbose_eval)
-        evals_result_callback = lgb.record_evaluation(evals_result)
+
+        # Build callbacks list
+        callbacks = []
+        if early_stopping_rounds is not None:
+            callbacks.append(lgb.early_stopping(early_stopping_rounds))
+        callbacks.append(lgb.log_evaluation(period=verbose_eval))
+        callbacks.append(lgb.record_evaluation(evals_result))
+
         self.model = lgb.train(
             self.params,
             dtrain,
             num_boost_round=num_boost_round,
             valid_sets=[dtrain, dvalid],
             valid_names=["train", "valid"],
-            callbacks=[early_stopping_callback, verbose_eval_callback, evals_result_callback],
+            callbacks=callbacks,
         )
         evals_result["train"] = list(evals_result["train"].values())[0]
         evals_result["valid"] = list(evals_result["valid"].values())[0]

--- a/qlib/contrib/rolling/ddgda.py
+++ b/qlib/contrib/rolling/ddgda.py
@@ -241,7 +241,9 @@ class DDGDA(Rolling):
         sim_task = replace_task_handler_with_cache(sim_task, self.working_dir)
 
         if self.sim_task_model == "gbdt":
-            sim_task["model"].setdefault("kwargs", {}).update({"early_stopping_rounds": None, "num_boost_round": 150})
+            sim_task["model"].setdefault("kwargs", {}).update({"num_boost_round": 150})
+            # Don't set early_stopping_rounds to disable it (LightGBM 4.0+ doesn't accept None)
+            sim_task["model"]["kwargs"].pop("early_stopping_rounds", None)
 
         exp_name_sim = f"data_sim_s{self.step}"
 


### PR DESCRIPTION
## Description

This PR fixes a compatibility issue with LightGBM 4.0+ where passing `early_stopping_rounds=None` causes a `TypeError`. 

**Changes:**
- Only create early_stopping callback when rounds is not None
- LightGBM 4.0+ requires stopping_rounds to be an integer, not None
- Apply fix to gbdt.py, ddgda.py, and highfreq_gdbt_model.py
- Follow the pattern already used in double_ensemble.py

**Affected files:**
- `qlib/contrib/model/gbdt.py`: Core LGBModel fix
- `qlib/contrib/rolling/ddgda.py`: Remove explicit None assignment
- `qlib/contrib/model/highfreq_gdbt_model.py`: Add robustness check

## Motivation and Context

Fixes #2226

**Problem:** Starting from LightGBM 4.0, the `lgb.early_stopping()` function requires `stopping_rounds` to be an integer and no longer accepts `None`. This breaks qlib's code that attempts to disable early stopping by passing `None`.

**Error:**
```
TypeError: early_stopping_round should be an integer. Got 'NoneType'
```

**Root cause:** 
- `qlib/contrib/model/gbdt.py:71-73` directly passes `early_stopping_rounds` to `lgb.early_stopping()` without checking for None
- `qlib/contrib/rolling/ddgda.py:244` explicitly sets `early_stopping_rounds: None`

**Solution:** Only create the early_stopping callback when the value is not None, following the pattern already correctly implemented in `double_ensemble.py`.

## How Has This Been Tested?

- [x] If you are adding a new feature, test on your own test scripts.

**Testing environment:**
- LightGBM: 4.6.0
- Python: 3.8
- OS: Linux (Ubuntu)

**Test method:**
1. Applied fix from PR #2213 (required to reach this code path)
2. Ran DDG-DA example:
   ```bash
   cd examples/benchmarks_dynamic/DDG-DA
   rm -rf mlruns
   python workflow.py run
   ```
3. Verified that the `TypeError: early_stopping_round should be an integer` no longer occurs
4. Confirmed training completes successfully (154/154 tasks)

**Note:** The standard `pytest qlib/tests/test_all_pipeline.py` does not cover this specific scenario as it requires:
- LightGBM 4.0+
- Explicit `early_stopping_rounds=None` usage
- The DDG-DA workflow

## Screenshots of Test Results (if appropriate):

**Before fix:**
```
TypeError: early_stopping_round should be an integer. Got 'NoneType'
  File "qlib/contrib/model/gbdt.py", line 71, in fit
    early_stopping_callback = lgb.early_stopping(...)
```

**After fix:**
```
train tasks: 100%|████████████████████████████| 154/154 [05:23<00:00,  2.10s/it]
calc: 100%|█████████████████████████████████████| 154/154 [00:01<00:00, 101.63it/s]
```
Training completes successfully without TypeError.

## Types of changes

- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation

## Additional Notes

**Known issue discovered during testing:**

After fixing this LightGBM bug, the DDG-DA workflow encounters another bug:
```
TypeError: unhashable type: 'slice'
  File "qlib/contrib/meta/data_selection/dataset.py", line 101, in setup
```

This is a separate issue in the DDG-DA code itself (not related to LightGBM) where a slice object is being used as a dictionary key. This should be tracked and fixed in a separate issue/PR.

## References

- LightGBM 4.0 Release: https://github.com/microsoft/LightGBM/releases/tag/v4.0.0
- Related: #2130 (UnpicklingError that currently masks this bug)
- Related: PR #2213 (Required to reproduce this bug)
