### PR TITLE
fix: DDG-DA workflow - LightGBM 4.0+ compatibility and pandas issues

### DIFF
--- a/qlib/contrib/meta/data_selection/dataset.py
+++ b/qlib/contrib/meta/data_selection/dataset.py
@@ -95,6 +95,9 @@ class InternalData:
             pred = rec.load_object("pred.pkl")
             task = rec.load_object("task")
             data_key = task["dataset"]["kwargs"]["segments"]["train"]
+            # Convert list to tuple to make it hashable (fix for unhashable type error)
+            if isinstance(data_key, list):
+                data_key = tuple(data_key)
             key_l.append(data_key)
             ic_l.append(delayed(self._calc_perf)(pred.iloc[:, 0], label_df.iloc[:, 0]))
 
@@ -106,8 +109,9 @@ class InternalData:
 
     def _calc_perf(self, pred, label):
         df = pd.DataFrame({"pred": pred, "label": label})
-        df = df.groupby("datetime", group_keys=False).corr(method="spearman")
-        corr = df.loc(axis=0)[:, "pred"]["label"].droplevel(axis=0, level=-1)
+        df = df.groupby("datetime").corr(method="spearman")
+        # Use xs to select 'label' from the second level of MultiIndex, then get 'pred' column
+        corr = df.xs("label", level=1)["pred"]
         return corr
 
     def update(self):

--- a/qlib/contrib/model/gbdt.py
+++ b/qlib/contrib/model/gbdt.py
@@ -68,19 +68,26 @@ class LGBModel(ModelFT, LightGBMFInt):
             evals_result = {}  # in case of unsafety of Python default values
         ds_l = self._prepare_data(dataset, reweighter)
         ds, names = list(zip(*ds_l))
-        early_stopping_callback = lgb.early_stopping(
-            self.early_stopping_rounds if early_stopping_rounds is None else early_stopping_rounds
-        )
+
+        # Build callbacks list
+        callbacks = []
+
+        # Only add early_stopping callback if rounds is not None (LightGBM 4.0+ compatibility)
+        early_stop_rounds = self.early_stopping_rounds if early_stopping_rounds is None else early_stopping_rounds
+        if early_stop_rounds is not None:
+            callbacks.append(lgb.early_stopping(early_stop_rounds))
+
         # NOTE: if you encounter error here. Please upgrade your lightgbm
-        verbose_eval_callback = lgb.log_evaluation(period=verbose_eval)
-        evals_result_callback = lgb.record_evaluation(evals_result)
+        callbacks.append(lgb.log_evaluation(period=verbose_eval))
+        callbacks.append(lgb.record_evaluation(evals_result))
+
         self.model = lgb.train(
             self.params,
             ds[0],  # training dataset
             num_boost_round=self.num_boost_round if num_boost_round is None else num_boost_round,
             valid_sets=ds,
             valid_names=names,
-            callbacks=[early_stopping_callback, verbose_eval_callback, evals_result_callback],
+            callbacks=callbacks,
             **kwargs,
         )
         for k in names:

--- a/qlib/contrib/model/highfreq_gdbt_model.py
+++ b/qlib/contrib/model/highfreq_gdbt_model.py
@@ -124,16 +124,24 @@ class HFLGBModel(ModelFT, LightGBMFInt):
         if evals_result is None:
             evals_result = dict()
         dtrain, dvalid = self._prepare_data(dataset)
-        early_stopping_callback = lgb.early_stopping(early_stopping_rounds)
-        verbose_eval_callback = lgb.log_evaluation(period=verbose_eval)
-        evals_result_callback = lgb.record_evaluation(evals_result)
+
+        # Build callbacks list
+        callbacks = []
+
+        # Only add early_stopping callback if rounds is not None (LightGBM 4.0+ compatibility)
+        if early_stopping_rounds is not None:
+            callbacks.append(lgb.early_stopping(early_stopping_rounds))
+
+        callbacks.append(lgb.log_evaluation(period=verbose_eval))
+        callbacks.append(lgb.record_evaluation(evals_result))
+
         self.model = lgb.train(
             self.params,
             dtrain,
             num_boost_round=num_boost_round,
             valid_sets=[dtrain, dvalid],
             valid_names=["train", "valid"],
-            callbacks=[early_stopping_callback, verbose_eval_callback, evals_result_callback],
+            callbacks=callbacks,
         )
         evals_result["train"] = list(evals_result["train"].values())[0]
         evals_result["valid"] = list(evals_result["valid"].values())[0]

--- a/qlib/utils/pickle_utils.py
+++ b/qlib/utils/pickle_utils.py
@@ -87,6 +87,8 @@ SAFE_PICKLE_CLASSES: Set[Tuple[str, str]] = {
     ("qlib.data.dataset.processor", "TimeRangeFlt"),
     # Utility functions used in data processing
     ("qlib.utils.data", "zscore"),
+    # Meta-learning data selection classes used in DDG-DA workflow
+    ("qlib.contrib.meta.data_selection.dataset", "InternalData"),
 }
 
 

--- a/qlib/utils/pickle_utils.py
+++ b/qlib/utils/pickle_utils.py
@@ -85,6 +85,8 @@ SAFE_PICKLE_CLASSES: Set[Tuple[str, str]] = {
     ("qlib.data.dataset.processor", "CSZFillna"),
     ("qlib.data.dataset.processor", "HashStockFormat"),
     ("qlib.data.dataset.processor", "TimeRangeFlt"),
+    # Utility functions used in data processing
+    ("qlib.utils.data", "zscore"),
 }
 
 

--- a/qlib/utils/pickle_utils.py
+++ b/qlib/utils/pickle_utils.py
@@ -46,9 +46,45 @@ SAFE_PICKLE_CLASSES: Set[Tuple[str, str]] = {
     ("pathlib", "Path"),
     ("pathlib", "PosixPath"),
     ("pathlib", "WindowsPath"),
+    ("qlib.data.dataset.handler", "DataHandlerABC"),
     ("qlib.data.dataset.handler", "DataHandler"),
     ("qlib.data.dataset.handler", "DataHandlerLP"),
+    ("qlib.data.dataset.loader", "DataLoader"),
+    ("qlib.data.dataset.loader", "DLWParser"),
+    ("qlib.data.dataset.loader", "QlibDataLoader"),
     ("qlib.data.dataset.loader", "StaticDataLoader"),
+    ("qlib.data.dataset.loader", "NestedDataLoader"),
+    ("qlib.data.dataset.loader", "DataLoaderDH"),
+    # Dataset hierarchy - needed when a recorder/rolling workflow pickles a
+    # full dataset and the unpickler walks the wrapped handler/loader graph.
+    ("qlib.data.dataset", "Dataset"),
+    ("qlib.data.dataset", "DatasetH"),
+    ("qlib.data.dataset", "TSDatasetH"),
+    # Stock-data handlers shipped in qlib.contrib. Without these the
+    # ``Rolling._train_rolling_tasks`` -> recorder load path fails with
+    # ``Forbidden class: qlib.contrib.data.handler.Alpha158`` (issue #2130).
+    ("qlib.contrib.data.handler", "Alpha158"),
+    ("qlib.contrib.data.handler", "Alpha158vwap"),
+    ("qlib.contrib.data.handler", "Alpha360"),
+    ("qlib.contrib.data.handler", "Alpha360vwap"),
+    # Processors are part of every Dataset's processor chain and must be
+    # restorable when the dataset is reloaded from disk.
+    ("qlib.data.dataset.processor", "Processor"),
+    ("qlib.data.dataset.processor", "DropnaProcessor"),
+    ("qlib.data.dataset.processor", "DropnaLabel"),
+    ("qlib.data.dataset.processor", "DropCol"),
+    ("qlib.data.dataset.processor", "FilterCol"),
+    ("qlib.data.dataset.processor", "TanhProcess"),
+    ("qlib.data.dataset.processor", "ProcessInf"),
+    ("qlib.data.dataset.processor", "Fillna"),
+    ("qlib.data.dataset.processor", "MinMaxNorm"),
+    ("qlib.data.dataset.processor", "ZScoreNorm"),
+    ("qlib.data.dataset.processor", "RobustZScoreNorm"),
+    ("qlib.data.dataset.processor", "CSZScoreNorm"),
+    ("qlib.data.dataset.processor", "CSRankNorm"),
+    ("qlib.data.dataset.processor", "CSZFillna"),
+    ("qlib.data.dataset.processor", "HashStockFormat"),
+    ("qlib.data.dataset.processor", "TimeRangeFlt"),
 }
 
 

--- a/tests/misc/test_pickle_safelist.py
+++ b/tests/misc/test_pickle_safelist.py
@@ -93,6 +93,14 @@ class SafePickleClassesContainDatasetHierarchyTest(unittest.TestCase):
                 self.assertTrue(_is_safe("qlib.data.dataset.processor", cls))
 
 
+class SafePickleClassesContainUtilityFunctionsTest(unittest.TestCase):
+    """DDG-DA workflow requires utility functions like zscore to be safelisted
+    because they are used in data processing and get pickled with the dataset."""
+
+    def test_zscore_is_safelisted(self) -> None:
+        self.assertTrue(_is_safe("qlib.utils.data", "zscore"))
+
+
 class RestrictedUnpicklerFindClassForAlpha158Test(unittest.TestCase):
     """End-to-end: ``RestrictedUnpickler.find_class`` must return the real
     ``Alpha158`` class object, not raise."""

--- a/tests/misc/test_pickle_safelist.py
+++ b/tests/misc/test_pickle_safelist.py
@@ -1,0 +1,118 @@
+"""Regression tests for issue #2130.
+
+The RestrictedUnpickler introduced in the recent security hardening
+(#2099 / #2076 / #2153) rejects any class outside of an explicit safelist.
+The original safelist only covered the abstract ``DataHandler`` and
+``DataHandlerLP`` classes, so reloading a Dataset that wrapped one of the
+shipped contrib handlers (e.g. ``Alpha158``) crashed
+``Rolling._train_rolling_tasks`` with::
+
+    UnpicklingError: Forbidden class: qlib.contrib.data.handler.Alpha158.
+    Only whitelisted classes are allowed for security reasons. ...
+
+These tests pin the safelist additions so a future cleanup cannot
+silently re-introduce the regression.
+"""
+
+from __future__ import annotations
+
+import pickle
+import unittest
+
+from qlib.utils.pickle_utils import (
+    SAFE_PICKLE_CLASSES,
+    RestrictedUnpickler,
+    restricted_pickle_loads,
+)
+
+
+def _is_safe(module: str, name: str) -> bool:
+    return (module, name) in SAFE_PICKLE_CLASSES
+
+
+class SafePickleClassesContainAlphaHandlersTest(unittest.TestCase):
+    """Issue #2130: stock-data handlers shipped in ``qlib.contrib`` must be
+    safelisted because every default rolling/recorder workflow serializes
+    a Dataset that wraps one of them."""
+
+    def test_alpha158_is_safelisted(self) -> None:
+        self.assertTrue(_is_safe("qlib.contrib.data.handler", "Alpha158"))
+
+    def test_alpha158_vwap_is_safelisted(self) -> None:
+        self.assertTrue(_is_safe("qlib.contrib.data.handler", "Alpha158vwap"))
+
+    def test_alpha360_is_safelisted(self) -> None:
+        self.assertTrue(_is_safe("qlib.contrib.data.handler", "Alpha360"))
+
+    def test_alpha360_vwap_is_safelisted(self) -> None:
+        self.assertTrue(_is_safe("qlib.contrib.data.handler", "Alpha360vwap"))
+
+
+class SafePickleClassesContainDatasetHierarchyTest(unittest.TestCase):
+    """The dataset wrapper, additional loaders, and the processor chain all
+    sit on the recorder pickle path -- without them the unpickler would walk
+    into a forbidden class on the very next attribute after the handler."""
+
+    def test_dataset_classes_are_safelisted(self) -> None:
+        for cls in ("Dataset", "DatasetH", "TSDatasetH"):
+            with self.subTest(cls=cls):
+                self.assertTrue(_is_safe("qlib.data.dataset", cls))
+
+    def test_loaders_are_safelisted(self) -> None:
+        for cls in (
+            "DataLoader",
+            "DLWParser",
+            "QlibDataLoader",
+            "StaticDataLoader",
+            "NestedDataLoader",
+            "DataLoaderDH",
+        ):
+            with self.subTest(cls=cls):
+                self.assertTrue(_is_safe("qlib.data.dataset.loader", cls))
+
+    def test_processors_are_safelisted(self) -> None:
+        for cls in (
+            "Processor",
+            "DropnaProcessor",
+            "DropnaLabel",
+            "DropCol",
+            "FilterCol",
+            "TanhProcess",
+            "ProcessInf",
+            "Fillna",
+            "MinMaxNorm",
+            "ZScoreNorm",
+            "RobustZScoreNorm",
+            "CSZScoreNorm",
+            "CSRankNorm",
+            "CSZFillna",
+            "HashStockFormat",
+            "TimeRangeFlt",
+        ):
+            with self.subTest(cls=cls):
+                self.assertTrue(_is_safe("qlib.data.dataset.processor", cls))
+
+
+class RestrictedUnpicklerFindClassForAlpha158Test(unittest.TestCase):
+    """End-to-end: ``RestrictedUnpickler.find_class`` must return the real
+    ``Alpha158`` class object, not raise."""
+
+    def test_find_class_returns_alpha158(self) -> None:
+        from qlib.contrib.data.handler import Alpha158
+
+        unpickler = RestrictedUnpickler(__import__("io").BytesIO())
+        resolved = unpickler.find_class("qlib.contrib.data.handler", "Alpha158")
+        self.assertIs(resolved, Alpha158)
+
+    def test_restricted_pickle_loads_rejects_unknown_qlib_class(self) -> None:
+        """Defensive: classes not in the safelist must still be rejected so
+        the security model is preserved."""
+
+        # Use a fake but plausible qlib path that is *not* in the safelist.
+        payload = pickle.dumps({"x": 1})
+        # Sanity: a trivial dict still loads fine.
+        self.assertEqual(restricted_pickle_loads(payload), {"x": 1})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/misc/test_pickle_safelist.py
+++ b/tests/misc/test_pickle_safelist.py
@@ -101,6 +101,14 @@ class SafePickleClassesContainUtilityFunctionsTest(unittest.TestCase):
         self.assertTrue(_is_safe("qlib.utils.data", "zscore"))
 
 
+class SafePickleClassesContainMetaLearningClassesTest(unittest.TestCase):
+    """DDG-DA workflow requires meta-learning classes like InternalData to be
+    safelisted because they are pickled and reloaded during the workflow."""
+
+    def test_internal_data_is_safelisted(self) -> None:
+        self.assertTrue(_is_safe("qlib.contrib.meta.data_selection.dataset", "InternalData"))
+
+
 class RestrictedUnpicklerFindClassForAlpha158Test(unittest.TestCase):
     """End-to-end: ``RestrictedUnpickler.find_class`` must return the real
     ``Alpha158`` class object, not raise."""


### PR DESCRIPTION
## Description

This PR fixes the DDG-DA (Data Distribution Guided Domain Adaptation) workflow, which is completely broken due to a chain of three sequential bugs. Each bug masks the next one, making them impossible to discover without fixing the previous bug first.

**The three bugs fixed in this PR:**

1. **LightGBM 4.0+ Compatibility Issue**
   - LightGBM 4.0+ no longer accepts `None` for `early_stopping_rounds` parameter
   - Modified `qlib/contrib/model/gbdt.py` and `qlib/contrib/model/highfreq_gdbt_model.py` to only create early_stopping callback when the value is not `None`

2. **Unhashable List Type Error**
   - `data_key` was a list `[start_date, end_date]`, which cannot be used as dictionary keys or DataFrame column names
   - Modified `qlib/contrib/meta/data_selection/dataset.py` to convert list to tuple (line 99-100)

3. **Incorrect Pandas MultiIndex Selection**
   - Used wrong syntax `df.loc(axis=0)[:, "pred"]` and `group_keys=False` caused loss of datetime index
   - Modified `qlib/contrib/meta/data_selection/dataset.py` to use `df.xs("label", level=1)` for correct MultiIndex selection (line 112-114)

**Files changed:**
- `qlib/contrib/model/gbdt.py` - LightGBM 4.0+ compatibility
- `qlib/contrib/model/highfreq_gdbt_model.py` - LightGBM 4.0+ compatibility
- `qlib/contrib/meta/data_selection/dataset.py` - Unhashable list fix + pandas indexing fix

## Motivation and Context

**Related Issues:**
- Fixes #2233 (DDG-DA workflow fails with chain of sequential bugs)
- Related to #2130 (Original UnpicklingError report)
- Depends on PR #2230 (zscore and InternalData pickle whitelist)

**Why is this change required?**

The DDG-DA workflow has been completely non-functional due to these bugs. The bugs form a dependency chain where each bug completely blocks execution, masking all subsequent bugs:

1. **Bug 1 (LightGBM)** - Occurs first after meta-model training completes
2. **Bug 2 (unhashable list)** - Only revealed after fixing Bug 1
3. **Bug 3 (pandas indexing)** - Only revealed after fixing Bug 2

**Root Causes:**

**Bug 1:** LightGBM 4.0 introduced a breaking change where `lgb.early_stopping()` no longer accepts `None`. The DDG-DA workflow explicitly sets `early_stopping_rounds=None` to disable early stopping, causing:
```python
TypeError: early_stopping_round should be an integer. Got 'NoneType'
```

**Bug 2:** The code attempts to use a list as a dictionary key when creating a DataFrame:
```python
data_key = task["dataset"]["kwargs"]["segments"]["train"]  # Returns [start_date, end_date]
self.data_ic_df = pd.DataFrame(dict(zip(key_l, ic_l)))  # ❌ Lists are unhashable
```

**Bug 3:** Incorrect pandas syntax and `group_keys=False` caused index structure issues:
```python
df = df.groupby("datetime", group_keys=False).corr(method="spearman")  # Loses datetime index
corr = df.loc(axis=0)[:, "pred"]["label"].droplevel(axis=0, level=-1)  # Wrong syntax
```

## How Has This Been Tested?

- [x] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [x] If you are adding a new feature, test on your own test scripts.

**Additional Testing:**

**Test Environment:**
- Python: 3.8.10
- OS: Linux (Ubuntu 22.04)
- LightGBM version: 4.6.0
- qlib version: 0.9.8.dev34

**Test Command:**
```bash
cd examples/benchmarks_dynamic/DDG-DA
rm -rf mlruns
python workflow.py run
```

**Test Results:**
✅ All 154 meta-model training tasks completed successfully
✅ Data similarity matrix calculated correctly
✅ Meta-learning model trained with data selection
✅ Final predictions and backtest results generated

## Screenshots of Test Results (if appropriate):

1. Pipeline test: ✅ Passed

2. Your own tests:

**Before the fix:**
```
# Bug 1: LightGBM error
TypeError: early_stopping_round should be an integer. Got 'NoneType'
File "qlib/contrib/model/gbdt.py", line 71

# Bug 2: Unhashable list error (after fixing Bug 1)
TypeError: unhashable type: 'list'
File "qlib/contrib/meta/data_selection/dataset.py", line 102

# Bug 3: Pandas indexing error (after fixing Bug 2)
ValueError: Cannot remove 1 levels from an index with 1 levels
File "qlib/contrib/meta/data_selection/dataset.py", line 113
```

**After the fix:**
```
train tasks: 100%|████████████████████████████████████| 154/154 [05:31<00:00,  2.15s/it]
calc: 100%|█████████████████████████████████████████| 154/154 [00:01<00:00, 100.48it/s]

[Meta-learning training completed successfully]

Final backtest results:
{'IC': 0.09811810334105552,
 'ICIR': 0.6205460160090581,
 'Long-Avg Ann Return': 1.9030504301190376,
 'Long-Avg Ann Sharpe': 1.9758248184919691,
 'Long-Short Ann Return': 2.6031273677945137,
 'Long-Short Ann Sharpe': 7.502124201699991,
 'Rank IC': 0.11010890300163573,
 'Rank ICIR': 0.669655699598572}
```
<img width="972" height="688" alt="图片" src="https://github.com/user-attachments/assets/3c6a1007-fe74-4635-b743-a2b5fba8cd26" />

**DDG-DA workflow now runs successfully end-to-end!** 🎉

## Types of changes

- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation

## Additional Notes

**Why are these fixes combined in one PR?**

These bugs form a true dependency chain, not an artificial grouping:
1. Each bug completely blocks the workflow, masking all subsequent bugs
2. They were discovered sequentially during testing - impossible to find without fixing the previous one
3. All three must be fixed together for DDG-DA to work
4. Splitting would create confusion about reproduction steps and dependencies

**Backward Compatibility:**

All fixes are backward compatible:
- LightGBM fix works with both LightGBM < 4.0 and >= 4.0
- List-to-tuple conversion preserves the same semantic meaning
- Pandas fix uses correct API that works across pandas versions

**Dependencies:**

⚠️ **This PR depends on PR #2230** (zscore and InternalData pickle whitelist)

Note: This PR's branch already includes PR #2230's changes. If PR #2230 is merged first, the commit history will be clean. If reviewing this PR independently, please note that commits `b5e58a00` and `0007720e` are from PR #2230.

**Impact:**

- 🔴 **Critical bug fix**: DDG-DA workflow is currently completely non-functional
- ✅ Fixes LightGBM 4.0+ compatibility issue that affects all LightGBM users
- ✅ Enables meta-learning data selection feature to work correctly
- ✅ Affects all users trying to use DDG-DA for domain adaptation

**References:**
- Issue #2233: DDG-DA workflow fails with chain of sequential bugs
- Issue #2130: Original UnpicklingError report
- PR #2213: Alpha158/Alpha360 handlers whitelist
- PR #2230: zscore and InternalData whitelist (prerequisite)
- LightGBM 4.0 Release Notes: https://github.com/microsoft/LightGBM/releases/tag/v4.0.0
