### PR TITLE
Fix typo: happend -> happen

### DIFF
--- a/qlib/contrib/meta/data_selection/utils.py
+++ b/qlib/contrib/meta/data_selection/utils.py
@@ -43,7 +43,7 @@ class ICLoss(nn.Module):
                 continue
             y_focus = y[start_i:end_i]
             if pred_focus.std() < EPS or y_focus.std() < EPS:
-                # These cases often happend at the end of test data.
+                # These cases often happen at the end of test data.
                 # Usually caused by fillna(0.)
                 skip_n += 1
                 continue


### PR DESCRIPTION
Tiny typo in a code comment in [qlib/contrib/meta/data_selection/utils.py:46](qlib/contrib/meta/data_selection/utils.py#L46). Comment only, no behavior change.