### PR TITLE
fix(model): correct default-metric check in HIST and IGMTF

### DIFF
--- a/qlib/contrib/model/pytorch_hist.py
+++ b/qlib/contrib/model/pytorch_hist.py
@@ -170,7 +170,7 @@ class HIST(Model):
             vy = y - torch.mean(y)
             return torch.sum(vx * vy) / (torch.sqrt(torch.sum(vx**2)) * torch.sqrt(torch.sum(vy**2)))
 
-        if self.metric == ("", "loss"):
+        if self.metric in ("", "loss"):
             return -self.loss_fn(pred[mask], label[mask])
 
         raise ValueError("unknown metric `%s`" % self.metric)

--- a/qlib/contrib/model/pytorch_igmtf.py
+++ b/qlib/contrib/model/pytorch_igmtf.py
@@ -163,7 +163,7 @@ class IGMTF(Model):
             vy = y - torch.mean(y)
             return torch.sum(vx * vy) / (torch.sqrt(torch.sum(vx**2)) * torch.sqrt(torch.sum(vy**2)))
 
-        if self.metric == ("", "loss"):
+        if self.metric in ("", "loss"):
             return -self.loss_fn(pred[mask], label[mask])
 
         raise ValueError("unknown metric `%s`" % self.metric)


### PR DESCRIPTION
## Description

Closes #2163.

`metric_fn` in `qlib/contrib/model/pytorch_hist.py` and `qlib/contrib/model/pytorch_igmtf.py` compares `self.metric` against a **tuple** with `==`:

```python
if self.metric == ("", "loss"):
    return -self.loss_fn(pred[mask], label[mask])
```

`self.metric` is a string (default `""`), so `self.metric == ("", "loss")` is never true. The default / `"loss"` metric therefore falls through to `raise ValueError("unknown metric")`, breaking validation/early-stopping for these two models with the default config.

Every other torch model uses a membership test — e.g. `pytorch_lstm.py:147`, `pytorch_alstm.py:151`, `pytorch_gru.py:151`:

```python
if self.metric in ("", "loss"):
```

## Change

Change `==` to `in` in both `metric_fn` methods so the default metric returns the negative loss, matching the rest of the model zoo.

## Testing

With `metric=""` (default) or `"loss"`, `metric_fn` now returns `-loss_fn(...)` instead of raising. `metric="ic"` and unknown metrics are unaffected.