### PR TITLE
fix(data/filter): apply sort_index result in SeriesDFilter

### DIFF
--- a/qlib/data/filter.py
+++ b/qlib/data/filter.py
@@ -160,7 +160,7 @@ class SeriesDFilter(BaseDFilter):
             the list of tuple (timestamp, timestamp).
         """
         # sort the timestamp_series according to the timestamps
-        timestamp_series.sort_index()
+        timestamp_series = timestamp_series.sort_index()
         timestamp = []
         _lbool = None
         _ltime = None


### PR DESCRIPTION
## Description

Closes #2165.

In `qlib/data/filter.py`, `SeriesDFilter._getFilterSeries` sorts the timestamp series but discards the result:

```python
# sort the timestamp_series according to the timestamps
timestamp_series.sort_index()
```

`pandas.Series.sort_index()` returns a **new** sorted Series and does not sort in place (that would require `inplace=True`). The series is therefore iterated **unsorted** in the loop that builds the `(timestamp, timestamp)` ranges, which can yield incorrect filter boundaries when the input index is not already ordered.

## Change

Assign the sorted result back: `timestamp_series = timestamp_series.sort_index()`. This matches the intent of the existing comment and the in-order assumption of the boundary scan that follows.

## Testing

With an out-of-order input index, the boundary scan now iterates ascending timestamps and produces correctly ordered ranges. Already-sorted inputs are unaffected.