### PR TITLE
fix: compare joblib versions semantically

### DIFF
--- a/qlib/utils/paral.py
+++ b/qlib/utils/paral.py
@@ -9,6 +9,7 @@ from typing import Callable, Text, Union
 import joblib
 from joblib import Parallel, delayed
 from joblib._parallel_backends import MultiprocessingBackend
+from packaging import version
 import pandas as pd
 
 from queue import Empty, Queue
@@ -24,7 +25,7 @@ class ParallelExt(Parallel):
         if isinstance(self._backend, MultiprocessingBackend):
             # 2025-05-04 joblib released version 1.5.0, in which _backend_args was removed and replaced by _backend_kwargs.
             # Ref: https://github.com/joblib/joblib/pull/1525/files#diff-e4dff8042ce45b443faf49605b75a58df35b8c195978d4a57f4afa695b406bdc
-            if joblib.__version__ < "1.5.0":
+            if version.parse(joblib.__version__) < version.parse("1.5.0"):
                 self._backend_args["maxtasksperchild"] = maxtasksperchild  # pylint: disable=E1101
             else:
                 self._backend_kwargs["maxtasksperchild"] = maxtasksperchild  # pylint: disable=E1101

--- a/tests/misc/test_paral.py
+++ b/tests/misc/test_paral.py
@@ -1,0 +1,10 @@
+import qlib.utils.paral as paral_mod
+from qlib.utils.paral import ParallelExt
+
+
+def test_parallel_ext_uses_semantic_joblib_version(monkeypatch):
+    monkeypatch.setattr(paral_mod.joblib, "__version__", "1.10.0")
+
+    parallel = ParallelExt(n_jobs=2, backend="multiprocessing", maxtasksperchild=3)
+
+    assert parallel._backend_kwargs["maxtasksperchild"] == 3


### PR DESCRIPTION
﻿## Summary
- compare `joblib.__version__` with `packaging.version.parse()` instead of raw strings
- add a regression test covering a future-style `1.10.0` joblib version string

## Why
`ParallelExt` selects between joblib's old `_backend_args` and newer `_backend_kwargs` attributes based on the joblib version. A raw string comparison treats `"1.10.0"` as lower than `"1.5.0"`, which would send newer joblib releases down the removed `_backend_args` path.

## Tests
- `python -m py_compile qlib\\utils\\paral.py tests\\misc\\test_paral.py`
- `python -m pytest tests\\misc\\test_paral.py -q`
- `git diff --check`
