### PR TITLE
fix: reuse filtered instruments across field groups

### DIFF
--- a/qlib/data/dataset/loader.py
+++ b/qlib/data/dataset/loader.py
@@ -199,6 +199,11 @@ class QlibDataLoader(DLWParser):
                     self.inst_processors
                 ), f"freq(={self.freq}), inst_processors(={self.inst_processors}) cannot be None/empty"
 
+    def load(self, instruments=None, start_time=None, end_time=None) -> pd.DataFrame:
+        if self.is_group and isinstance(instruments, str):
+            instruments = D.instruments(instruments, filter_pipe=self.filter_pipe)
+        return super().load(instruments, start_time, end_time)
+
     def load_group_df(
         self,
         instruments,
@@ -213,7 +218,7 @@ class QlibDataLoader(DLWParser):
             instruments = "all"
         if isinstance(instruments, str):
             instruments = D.instruments(instruments, filter_pipe=self.filter_pipe)
-        elif self.filter_pipe is not None:
+        elif self.filter_pipe is not None and not isinstance(instruments, dict):
             warnings.warn("`filter_pipe` is not None, but it will not be used with `instruments` as list")
 
         freq = self.freq[gp_name] if isinstance(self.freq, dict) else self.freq

--- a/qlib/data/dataset/loader.py
+++ b/qlib/data/dataset/loader.py
@@ -200,9 +200,42 @@ class QlibDataLoader(DLWParser):
                 ), f"freq(={self.freq}), inst_processors(={self.inst_processors}) cannot be None/empty"
 
     def load(self, instruments=None, start_time=None, end_time=None) -> pd.DataFrame:
-        if self.is_group and isinstance(instruments, str):
-            instruments = D.instruments(instruments, filter_pipe=self.filter_pipe)
+        if self.is_group:
+            if instruments is None:
+                warnings.warn("`instruments` is not set, will load all stocks")
+                instruments = "all"
+            elif self.filter_pipe is not None and not isinstance(instruments, (dict, str)):
+                warnings.warn("`filter_pipe` is not None, but it will not be used with `instruments` as list")
+
+            if isinstance(instruments, str):
+                instruments = D.instruments(instruments, filter_pipe=self.filter_pipe)
+            resolved = {}
+            df = pd.concat(
+                {
+                    grp: self.load_group_df(
+                        self._resolve_group_instruments(instruments, gp_name=grp, resolved=resolved),
+                        exprs,
+                        names,
+                        start_time,
+                        end_time,
+                        grp,
+                    )
+                    for grp, (exprs, names) in self.fields.items()
+                },
+                axis=1,
+            )
+            return df
         return super().load(instruments, start_time, end_time)
+
+    def _resolve_group_instruments(self, instruments, gp_name: str, resolved: dict):
+        if not (isinstance(instruments, dict) and "market" in instruments and instruments.get("filter_pipe")):
+            return instruments
+
+        freq = self.freq[gp_name] if isinstance(self.freq, dict) else self.freq
+        cache_key = repr(freq)
+        if cache_key not in resolved:
+            resolved[cache_key] = D.list_instruments(instruments, freq=freq, as_list=False)
+        return resolved[cache_key]
 
     def load_group_df(
         self,

--- a/tests/data_mid_layer_tests/test_dataloader.py
+++ b/tests/data_mid_layer_tests/test_dataloader.py
@@ -96,13 +96,14 @@ class TestDataLoader(unittest.TestCase):
             filter_pipe=[{"filter_type": "SeriesDFilter"}],
         )
         instruments_config = {"market": "csi300", "filter_pipe": loader.filter_pipe}
+        filtered_instruments = {"SH600000": [(pd.Timestamp("2020-01-01"), pd.Timestamp("2020-01-02"))]}
         index = pd.MultiIndex.from_tuples(
             [("SH600000", pd.Timestamp("2020-01-01"))],
             names=["instrument", "datetime"],
         )
 
         def fake_features(instruments, exprs, start_time, end_time, freq="day", inst_processors=None):
-            self.assertIs(instruments, instruments_config)
+            self.assertIs(instruments, filtered_instruments)
             return pd.DataFrame([[1.0] * len(exprs)], index=index, columns=exprs)
 
         with (
@@ -111,24 +112,31 @@ class TestDataLoader(unittest.TestCase):
                 return_value=instruments_config,
                 create=True,
             ) as instruments_mock,
+            patch(
+                "qlib.data.dataset.loader.D.list_instruments",
+                return_value=filtered_instruments,
+                create=True,
+            ) as list_instruments_mock,
             patch("qlib.data.dataset.loader.D.features", side_effect=fake_features, create=True) as features_mock,
         ):
             df = loader.load("csi300", start_time="2020-01-01", end_time="2020-01-02")
 
         instruments_mock.assert_called_once_with("csi300", filter_pipe=loader.filter_pipe)
+        list_instruments_mock.assert_called_once_with(instruments_config, freq="day", as_list=False)
         self.assertEqual(features_mock.call_count, 2)
         self.assertEqual({"feature", "label"}, set(df.columns.get_level_values(0)))
 
     def test_alpha158_handler_applies_filter_pipe_once(self):
         filter_pipe = [{"filter_type": "SeriesDFilter"}]
         instruments_config = {"market": "csi300", "filter_pipe": filter_pipe}
+        filtered_instruments = {"SH600000": [(pd.Timestamp("2020-01-01"), pd.Timestamp("2020-01-02"))]}
         index = pd.MultiIndex.from_tuples(
             [("SH600000", pd.Timestamp("2020-01-01"))],
             names=["instrument", "datetime"],
         )
 
         def fake_features(instruments, exprs, start_time, end_time, freq="day", inst_processors=None):
-            self.assertIs(instruments, instruments_config)
+            self.assertIs(instruments, filtered_instruments)
             return pd.DataFrame([[1.0] * len(exprs)], index=index, columns=exprs)
 
         with (
@@ -137,6 +145,11 @@ class TestDataLoader(unittest.TestCase):
                 return_value=instruments_config,
                 create=True,
             ) as instruments_mock,
+            patch(
+                "qlib.data.dataset.loader.D.list_instruments",
+                return_value=filtered_instruments,
+                create=True,
+            ) as list_instruments_mock,
             patch("qlib.data.dataset.loader.D.features", side_effect=fake_features, create=True) as features_mock,
         ):
             handler = Alpha158(
@@ -149,6 +162,7 @@ class TestDataLoader(unittest.TestCase):
             )
 
         instruments_mock.assert_called_once_with("csi300", filter_pipe=filter_pipe)
+        list_instruments_mock.assert_called_once_with(instruments_config, freq="day", as_list=False)
         self.assertEqual(features_mock.call_count, 2)
         self.assertEqual({"feature", "label"}, set(handler._data.columns.get_level_values(0)))
 

--- a/tests/data_mid_layer_tests/test_dataloader.py
+++ b/tests/data_mid_layer_tests/test_dataloader.py
@@ -4,11 +4,14 @@
 import sys
 import unittest
 import qlib
+import pandas as pd
 from pathlib import Path
+from unittest.mock import patch
 
 sys.path.append(str(Path(__file__).resolve().parent))
 from qlib.data.dataset.loader import NestedDataLoader, QlibDataLoader
 from qlib.data.dataset.handler import DataHandlerLP
+from qlib.contrib.data.handler import Alpha158
 from qlib.contrib.data.loader import Alpha158DL, Alpha360DL
 from qlib.data.dataset.processor import Fillna
 from qlib.data import D
@@ -83,6 +86,71 @@ class TestDataLoader(unittest.TestCase):
         data = data_handler.fetch()
         print(data)
         """
+
+    def test_grouped_loader_applies_filter_pipe_once(self):
+        loader = QlibDataLoader(
+            config={
+                "feature": (["$close"], ["close"]),
+                "label": (["Ref($close, -1)"], ["label"]),
+            },
+            filter_pipe=[{"filter_type": "SeriesDFilter"}],
+        )
+        instruments_config = {"market": "csi300", "filter_pipe": loader.filter_pipe}
+        index = pd.MultiIndex.from_tuples(
+            [("SH600000", pd.Timestamp("2020-01-01"))],
+            names=["instrument", "datetime"],
+        )
+
+        def fake_features(instruments, exprs, start_time, end_time, freq="day", inst_processors=None):
+            self.assertIs(instruments, instruments_config)
+            return pd.DataFrame([[1.0] * len(exprs)], index=index, columns=exprs)
+
+        with (
+            patch(
+                "qlib.data.dataset.loader.D.instruments",
+                return_value=instruments_config,
+                create=True,
+            ) as instruments_mock,
+            patch("qlib.data.dataset.loader.D.features", side_effect=fake_features, create=True) as features_mock,
+        ):
+            df = loader.load("csi300", start_time="2020-01-01", end_time="2020-01-02")
+
+        instruments_mock.assert_called_once_with("csi300", filter_pipe=loader.filter_pipe)
+        self.assertEqual(features_mock.call_count, 2)
+        self.assertEqual({"feature", "label"}, set(df.columns.get_level_values(0)))
+
+    def test_alpha158_handler_applies_filter_pipe_once(self):
+        filter_pipe = [{"filter_type": "SeriesDFilter"}]
+        instruments_config = {"market": "csi300", "filter_pipe": filter_pipe}
+        index = pd.MultiIndex.from_tuples(
+            [("SH600000", pd.Timestamp("2020-01-01"))],
+            names=["instrument", "datetime"],
+        )
+
+        def fake_features(instruments, exprs, start_time, end_time, freq="day", inst_processors=None):
+            self.assertIs(instruments, instruments_config)
+            return pd.DataFrame([[1.0] * len(exprs)], index=index, columns=exprs)
+
+        with (
+            patch(
+                "qlib.data.dataset.loader.D.instruments",
+                return_value=instruments_config,
+                create=True,
+            ) as instruments_mock,
+            patch("qlib.data.dataset.loader.D.features", side_effect=fake_features, create=True) as features_mock,
+        ):
+            handler = Alpha158(
+                instruments="csi300",
+                start_time="2020-01-01",
+                end_time="2020-01-02",
+                filter_pipe=filter_pipe,
+                infer_processors=[],
+                learn_processors=[],
+            )
+
+        instruments_mock.assert_called_once_with("csi300", filter_pipe=filter_pipe)
+        self.assertEqual(features_mock.call_count, 2)
+        self.assertEqual({"feature", "label"}, set(handler._data.columns.get_level_values(0)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
﻿Fixes #2236.

`QlibDataLoader` resolves `filter_pipe` inside `load_group_df()`. With grouped field configs, `load()` calls `load_group_df()` once per fields group, so the same market string runs through `D.instruments(..., filter_pipe=...)` repeatedly.

This resolves string instruments once at the grouped-loader entry point and reuses that instrument config for each group. Direct `load_group_df()` calls keep the old behavior, and explicit non-string instrument lists still warn that `filter_pipe` is ignored.

## To verify

- `python -m pytest tests\data_mid_layer_tests\test_dataloader.py -q -k grouped_loader`
- `python -m py_compile qlib\data\dataset\loader.py tests\data_mid_layer_tests\test_dataloader.py`
- `git diff --check`
