### PR TITLE
refactor(high_performance_ds): Use Parallel to process DataFrame sort…

### DIFF
--- a/qlib/backtest/high_performance_ds.py
+++ b/qlib/backtest/high_performance_ds.py
@@ -7,6 +7,7 @@ import inspect
 import logging
 from collections import OrderedDict
 from functools import lru_cache
+from joblib import delayed
 from typing import Any, Callable, Dict, Iterable, List, Optional, Text, Union, cast
 
 import numpy as np
@@ -14,10 +15,12 @@ import pandas as pd
 
 import qlib.utils.index_data as idd
 
+from ..config import C
 from ..log import get_module_logger
 from ..utils.index_data import IndexData, SingleData
 from ..utils.resam import resam_ts_data, ts_data_last
 from ..utils.time import Freq, is_single_value
+from ..utils.paral import ParallelExt
 
 
 class BaseQuote:
@@ -124,6 +127,10 @@ class PandasQuote(BaseQuote):
         else:
             raise ValueError(f"stock data from resam_ts_data must be a number, pd.Series or pd.DataFrame")
 
+def sort_index(stock_df: pd.DataFrame):
+    quote = idd.MultiData(stock_df.droplevel(level="instrument"))
+    quote.sort_index()
+    return quote
 
 class NumpyQuote(BaseQuote):
     def __init__(self, quote_df: pd.DataFrame, freq: str, region: str = "cn") -> None:
@@ -136,10 +143,22 @@ class NumpyQuote(BaseQuote):
         self.data : Dict(stock_id, IndexData.DataFrame)
         """
         super().__init__(quote_df=quote_df, freq=freq)
-        quote_dict = {}
-        for stock_id, stock_val in quote_df.groupby(level="instrument", group_keys=False):
-            quote_dict[stock_id] = idd.MultiData(stock_val.droplevel(level="instrument"))
-            quote_dict[stock_id].sort_index()  # To support more flexible slicing, we must sort data first
+        workers = max(min(C.get_kernels(freq), len(quote_df)), 1)
+        inst_l = []
+        task_l = []
+        for stock_id, stock_val in quote_df.groupby(level="instrument"):
+            inst_l.append(stock_id)
+            task_l.append(
+                delayed(sort_index)(
+                    stock_val
+                )
+            )
+        quote_dict = dict(
+            zip(
+                inst_l,
+                ParallelExt(n_jobs=workers, backend=C.joblib_backend, maxtasksperchild=C.maxtasksperchild)(task_l),
+            )
+        )
         self.data = quote_dict
 
         n, unit = Freq.parse(freq)


### PR DESCRIPTION
…ing in parallel

<!--- Thank you for submitting a Pull Request! In order to make our work smoother. -->
<!--- please make sure your Pull Request meets the following requirements: -->
<!---   1. Provide a general summary of your changes in the Title above; -->
<!---   2. Add appropriate prefixes to titles, such as `build:`, `chore:`, `ci:`, `docs:`, `feat:`, `fix:`, `perf:`, `refactor:`, `revert:`, `style:`, `test:`(Ref: https://www.conventionalcommits.org/). -->
<!--- Category: -->
<!--- Patch Updates: `fix:` -->
<!---   Example: fix(auth): correct login validation issue -->
<!--- minor update (introduces new functionality): `feat` -->
<!---   Example: feature(parser): add ability to parse arrays -->
<!--- major update(destructive update): Include BREAKING CHANGE in the commit message footer, or add `! ` in the commit footer to indicate that there is a destructive update. -->
<!---   Example: feat(auth)! : remove support for old authentication method -->
<!--- Other updates: `build:`, `chore:`, `ci:`, `docs:`, `perf:`, `refactor:`, `revert:`, `style:`, `test:`. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
NumpyQuote processes all data in a single thread, which requires a long execution time when dealing with very large data volumes. use parallel fix

### The Fix
Original code (qlib/backtest/high_performance_ds.py):

```
quote_dict = {}
for stock_id, stock_val in quote_df.groupby(level="instrument", group_keys=False):
    quote_dict[stock_id] = idd.MultiData(stock_val.droplevel(level="instrument"))
    quote_dict[stock_id].sort_index()  # To support more flexible slicing, we must sort data first
```

### Fixed code:
```
from joblib import delayed
from ..config import C
from ..utils.paral import ParallelExt

def sort_index(stock_df: pd.DataFrame):
    quote = idd.MultiData(stock_df.droplevel(level="instrument"))
    quote.sort_index()
    return quote

```

class NumpyQuote in ***__init__***
```
workers = max(min(C.get_kernels(freq), len(quote_df)), 1)
inst_l = []
task_l = []
for stock_id, stock_val in quote_df.groupby(level="instrument"):
    inst_l.append(stock_id)
    task_l.append(
        delayed(sort_index)(
            stock_val
        )
    )
quote_dict = dict(
    zip(
        inst_l,
        ParallelExt(n_jobs=workers, backend=C.joblib_backend, maxtasksperchild=C.maxtasksperchild)(task_l),
    )
)

```

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!---  Put an `x` in all the boxes that apply: --->
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ Y ] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
