### PR TITLE
fix: change assert tp_idx > 0 to tp_idx >= 0 in TimeAdjuster.truncate()

### DIFF
--- a/qlib/workflow/task/utils.py
+++ b/qlib/workflow/task/utils.py
@@ -226,7 +226,7 @@ class TimeAdjuster:
             new_seg = []
             for time_point in segment:
                 tp_idx = min(self.align_idx(time_point), test_idx - days)
-                assert tp_idx > 0
+                assert tp_idx >= 0
                 new_seg.append(self.get(tp_idx))
             return tuple(new_seg)
         else:


### PR DESCRIPTION
When setting `start_time` to a date that happens to be the first trading day in `day.txt`, the workflow crashes with `AssertionError` in `TimeAdjuster.truncate()`. The root cause is that `tp_idx` (the index from `calendar.searchsorted()`) is 0 for the first calendar entry, but the assertion checks `tp_idx > 0`. Index 0 is a perfectly valid position — the assertion should be `tp_idx >= 0`.

Would appreciate a review, thanks!