### PR TITLE
fix: correct model objective in High-Freq Tree Alpha158 workflow config

### DIFF
--- a/examples/highfreq/workflow_config_High_Freq_Tree_Alpha158.yaml
+++ b/examples/highfreq/workflow_config_High_Freq_Tree_Alpha158.yaml
@@ -35,8 +35,8 @@ task:
         class: "HFLGBModel"
         module_path: "qlib.contrib.model.highfreq_gdbt_model"
         kwargs:
-            objective: 'binary'
-            metric: ['binary_logloss','auc']
+            objective: 'l2'
+            metric: ['mae','mse','rmse']
             verbosity: -1
             learning_rate: 0.01
             max_depth: 8


### PR DESCRIPTION
The high-frequency Alpha158 example config `workflow_config_High_Freq_Tree_Alpha158.yaml` has a mismatch between the label and the model objective. The label `Ref($close, -2) / Ref($close, -1) - 1` produces continuous regression values (e.g., 0.023, -0.015), but the model was set to `"binary"` — so LightGBM silently trains a classifier on regression targets. I checked the other example configs for reference: the daily-frequency counterpart `workflow_config_lightgbm_Alpha158.yaml` uses `loss: "l2"` with the same label pattern, confirming regression is the intended behavior.

Changed the objective from `"binary"` to `"l2"` and updated metrics from `binary_logloss/auc` to `mae/mse/rmse`.

Would appreciate a review, thanks!