### PR TITLE
fix: handle missing minute-level data in get_higher_eq_freq_feature

### DIFF
--- a/qlib/utils/resam.py
+++ b/qlib/utils/resam.py
@@ -92,8 +92,12 @@ def get_higher_eq_freq_feature(instruments, fields, start_time=None, end_time=No
                 _result = D.features(instruments, fields, start_time, end_time, freq="1min", disk_cache=disk_cache)
                 _freq = "1min"
         elif norm_freq == Freq.NORM_FREQ_MINUTE:
-            _result = D.features(instruments, fields, start_time, end_time, freq="1min", disk_cache=disk_cache)
-            _freq = "1min"
+            try:
+                _result = D.features(instruments, fields, start_time, end_time, freq="1min", disk_cache=disk_cache)
+                _freq = "1min"
+            except (ValueError, KeyError):
+                _result = D.features(instruments, fields, start_time, end_time, freq="day", disk_cache=disk_cache)
+                _freq = "day"
         else:
             raise ValueError(f"freq {freq} is not supported") from value_key_e
     return _result, _freq

--- a/qlib/utils/time.py
+++ b/qlib/utils/time.py
@@ -249,9 +249,9 @@ class Freq:
             if _min_delta < 0:
                 continue
             if min_freq is None:
-                min_freq = (_min_delta, str(_freq))
+                min_freq = (_min_delta, Freq(_freq))
                 continue
-            min_freq = min_freq if min_freq[0] <= _min_delta else (_min_delta, _freq)
+            min_freq = min_freq if min_freq[0] <= _min_delta else (_min_delta, Freq(_freq))
         return min_freq[1] if min_freq else None
 
 


### PR DESCRIPTION
This was the most involved fix of the three I worked on. #1854 causes a backtest crash when `time_per_step='30min'` is used — the error message says `ValueError: can't find a freq from [Freq(30min)] that can resample to 1min!`, which is confusing because the user never asked for 1min data.

I traced the crash from the backtest engine down through the call chain. `PortfolioMetrics._cal_benchmark()` calls `D.features()` with the 30min frequency. Since the CSI300 benchmark only has daily data, a ValueError is raised. The code then enters the minute-level fallback branch in `get_higher_eq_freq_feature()` (`qlib/utils/resam.py`), which hardcodes a retry with `freq='1min'` — but this fallback is **not wrapped in try/except**, unlike the day-level fallback earlier in the same function. When 1min data also doesn't exist, the raw exception propagates up as the misleading error above.

While reading the code, I also found a type inconsistency in `Freq.get_recent_freq()` (`qlib/utils/time.py`). The method builds a list of candidate frequencies — the first entry was stored as `str(_freq)` while subsequent entries kept the raw `_freq` (which could be either `str` or `Freq`). This made the return type unpredictable for callers like `FileCalendarStorage._freq_file`.

The fix spans two files:

1. **`qlib/utils/resam.py`** — Added a `try/except (ValueError, KeyError)` around the `1min` fallback inside `get_higher_eq_freq_feature()`, matching the pattern already used by the day/week/month branch a few lines above. If 1min also fails, it falls through to `day` as the ultimate fallback.

2. **`qlib/utils/time.py`** — Wrapped all candidates in `Freq.get_recent_freq()` consistently with `Freq(_freq)`, so the return type is always `Freq | None` regardless of which candidate wins.

Would appreciate a review, thanks!