### PR TITLE
fix: compute WMA as weighted sum

### DIFF
--- a/qlib/data/ops.py
+++ b/qlib/data/ops.py
@@ -1337,7 +1337,7 @@ class WMA(Rolling):
         def weighted_mean(x):
             w = np.arange(len(x)) + 1
             w = w / w.sum()
-            return np.nanmean(w * x)
+            return np.nansum(w * x)
 
         if self.N == 0:
             series = series.expanding(min_periods=1).apply(weighted_mean, raw=True)

--- a/tests/ops/test_rolling_ops.py
+++ b/tests/ops/test_rolling_ops.py
@@ -1,0 +1,20 @@
+import numpy as np
+import pandas as pd
+
+from qlib.data.ops import WMA
+
+
+class _Feature:
+    def __init__(self, series):
+        self.series = series
+
+    def load(self, *args):
+        return self.series
+
+
+def test_wma_uses_weighted_sum():
+    series = pd.Series([1.0, 2.0, 3.0])
+
+    result = WMA(_Feature(series), 3)._load_internal("SH600000", 0, 2)
+
+    np.testing.assert_allclose(result.to_numpy(), [1.0, 5.0 / 3.0, 14.0 / 6.0])


### PR DESCRIPTION
## Summary

Fixes #1993.

`WMA` already normalizes the rolling weights so they sum to 1, but then calls `np.nanmean(w * x)`. That divides the weighted values by the number of non-NaN entries again. For example, `[1, 2, 3]` with a 3-day window should be `(1 + 4 + 9) / 6 = 14/6`, while the current implementation returns `14/18`.

This changes the reducer to `np.nansum(w * x)`, matching the normalized-weight definition and the behavior used by the exponential weighted reducer nearby.

## Validation

```text
python setup.py build_ext --inplace

$env:PYTHONPATH=(Resolve-Path .).Path; python -m pytest tests\ops\test_rolling_ops.py -q
# 1 passed

$env:PYTHONPATH=(Resolve-Path .).Path; python -m pytest tests\ops\test_special_ops.py -q
# 2 passed

python -m py_compile qlib\data\ops.py tests\ops\test_rolling_ops.py
python -m ruff check qlib\data\ops.py tests\ops\test_rolling_ops.py
# All checks passed

git diff --check
```
