### PR TITLE
Fix workflow CWD safety for file locks and git diff logging

### DIFF
--- a/qlib/workflow/expm.py
+++ b/qlib/workflow/expm.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 from urllib.parse import urlparse
+from urllib.request import url2pathname
 import mlflow
 from filelock import FileLock
 from mlflow.exceptions import MlflowException, RESOURCE_ALREADY_EXISTS, ErrorCode
@@ -17,6 +18,19 @@ from ..log import get_module_logger
 from ..utils.exceptions import ExpAlreadyExistError
 
 logger = get_module_logger("workflow")
+
+
+def _file_uri_to_path(uri: Text) -> Path:
+    pr = urlparse(uri)
+    if pr.scheme != "file":
+        return Path(uri)
+
+    path = url2pathname(pr.path)
+    if os.name == "nt" and len(path) >= 3 and path[0] == "/" and path[2] == ":":
+        path = path[1:]
+    if pr.netloc and pr.netloc != "localhost":
+        path = f"//{pr.netloc}{path}"
+    return Path(path)
 
 
 class ExpManager:
@@ -233,7 +247,7 @@ class ExpManager:
             # So we supported it in the interface wrapper
             pr = urlparse(self.uri)
             if pr.scheme == "file":
-                with FileLock(Path(os.path.join(pr.netloc, pr.path.lstrip("/"), "filelock"))):  # pylint: disable=E0110
+                with FileLock(_file_uri_to_path(self.uri) / "filelock"):  # pylint: disable=E0110
                     return self.create_exp(experiment_name), True
             # NOTE: for other schemes like http, we double check to avoid create exp conflicts
             try:

--- a/qlib/workflow/recorder.py
+++ b/qlib/workflow/recorder.py
@@ -25,6 +25,16 @@ logger = get_module_logger("workflow")
 mlflow.utils.validation.MAX_PARAM_VAL_LENGTH = 1000
 
 
+def _is_git_work_tree() -> bool:
+    result = subprocess.run(
+        ["git", "rev-parse", "--is-inside-work-tree"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    return result.returncode == 0 and result.stdout.decode().strip() == "true"
+
+
 class Recorder:
     """
     This is the `Recorder` class for logging the experiments. The API is designed similar to mlflow.
@@ -366,16 +376,20 @@ class MLflowRecorder(Recorder):
         """
         # TODO: the sub-directories maybe git repos.
         # So it will be better if we can walk the sub-directories and log the uncommitted changes.
+        if not _is_git_work_tree():
+            logger.debug(f"Skip logging the uncommitted code of $CWD({os.getcwd()}) because it is not a git work tree.")
+            return
+
         for cmd, fname in [
-            ("git diff", "code_diff.txt"),
-            ("git status", "code_status.txt"),
-            ("git diff --cached", "code_cached.txt"),
+            (["git", "diff"], "code_diff.txt"),
+            (["git", "status"], "code_status.txt"),
+            (["git", "diff", "--cached"], "code_cached.txt"),
         ]:
             try:
-                out = subprocess.check_output(cmd, shell=True)
-                self.client.log_text(self.id, out.decode(), fname)  # this behaves same as above
+                out = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+                self.client.log_text(self.id, out.stdout.decode(), fname)  # this behaves same as above
             except subprocess.CalledProcessError:
-                logger.info(f"Fail to log the uncommitted code of $CWD({os.getcwd()}) when run {cmd}.")
+                logger.debug(f"Fail to log the uncommitted code of $CWD({os.getcwd()}) when run {' '.join(cmd)}.")
 
     def end_run(self, status: str = Recorder.STATUS_S):
         assert status in [

--- a/tests/test_workflow_cwd_safety.py
+++ b/tests/test_workflow_cwd_safety.py
@@ -1,0 +1,64 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import subprocess
+from unittest.mock import MagicMock
+
+from qlib.workflow.expm import _file_uri_to_path
+from qlib.workflow.recorder import MLflowRecorder
+
+
+def test_file_uri_path_remains_absolute_from_other_cwd(tmp_path, monkeypatch):
+    target = tmp_path / "mlruns"
+    other_cwd = tmp_path / "elsewhere"
+    other_cwd.mkdir()
+    monkeypatch.chdir(other_cwd)
+
+    file_uri = target.resolve().as_uri()
+
+    assert _file_uri_to_path(file_uri) == target.resolve()
+    assert _file_uri_to_path(file_uri).is_absolute()
+
+
+def test_log_uncommitted_code_skips_non_git_cwd(monkeypatch, tmp_path):
+    recorder = MLflowRecorder.__new__(MLflowRecorder)
+    recorder.client = MagicMock()
+    recorder.id = "run-id"
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("qlib.workflow.recorder._is_git_work_tree", lambda: False)
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("git diff commands should not run outside a git work tree")
+
+    monkeypatch.setattr(subprocess, "run", fail_if_called)
+
+    recorder._log_uncommitted_code()
+
+    recorder.client.log_text.assert_not_called()
+
+
+def test_log_uncommitted_code_captures_git_output_without_shell(monkeypatch):
+    recorder = MLflowRecorder.__new__(MLflowRecorder)
+    recorder.client = MagicMock()
+    recorder.id = "run-id"
+    monkeypatch.setattr("qlib.workflow.recorder._is_git_work_tree", lambda: True)
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0, stdout=b"captured", stderr=b"")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    recorder._log_uncommitted_code()
+
+    assert [cmd for cmd, _ in calls] == [
+        ["git", "diff"],
+        ["git", "status"],
+        ["git", "diff", "--cached"],
+    ]
+    for _, kwargs in calls:
+        assert kwargs["check"] is True
+        assert kwargs["stdout"] is subprocess.PIPE
+        assert kwargs["stderr"] is subprocess.PIPE
+    assert recorder.client.log_text.call_count == 3


### PR DESCRIPTION
## Summary
- resolve `file://` tracking URIs to local absolute paths before creating the workflow file lock
- skip uncommitted-code logging when the current directory is not a git work tree
- run git diff/status commands without `shell=True` and capture stderr to avoid noisy startup output
- add focused regression tests for the CWD-sensitive path and git logging behavior

Fixes #2252.

## Tests
- `.\.venv\Scripts\python -m pytest tests\test_workflow_cwd_safety.py -q`

Attempted:
- `.\.venv\Scripts\python -m pytest tests\test_workflow.py tests\test_workflow_cwd_safety.py -q`
  - blocked during collection because this local shallow clone/test env does not have compiled `qlib.data._libs.rolling`