### PR TITLE
feat: add incremental inference helper

### DIFF
--- a/docs/component/online.rst
+++ b/docs/component/online.rst
@@ -51,6 +51,29 @@ Online Tool
 Updater
 =======
 
+Lightweight Incremental Prediction
+----------------------------------
+
+If you update the local qlib data by yourself and only need predictions for
+newly available dates, you can reuse an existing ``DatasetH`` without running
+the full online serving workflow.
+
+``prepare_incremental_inference_dataset`` configures the handler loading window
+with enough historical warmup rows while keeping the ``test`` segment limited
+to the dates that need new scores. For ``TSDatasetH``, the warmup length is
+inferred from ``step_len - 1`` unless ``hist_ref`` is provided explicitly.
+
+.. code-block:: python
+
+    from qlib.workflow.online.update import prepare_incremental_inference_dataset
+
+    dataset = prepare_incremental_inference_dataset(
+        dataset,
+        start_time="2024-01-03",
+        end_time="2024-01-05",
+    )
+    pred = model.predict(dataset)
+
 .. automodule:: qlib.workflow.online.update
     :members:
     :noindex:

--- a/qlib/workflow/online/update.py
+++ b/qlib/workflow/online/update.py
@@ -5,7 +5,7 @@ Updater is a module to update artifacts such as predictions when the stock data 
 """
 
 from abc import ABCMeta, abstractmethod
-from typing import Optional
+from typing import Optional, Tuple
 
 import pandas as pd
 from qlib import get_module_logger
@@ -16,6 +16,88 @@ from qlib.model import Model
 from qlib.utils import get_date_by_shift
 from qlib.workflow.recorder import Recorder
 from qlib.workflow.record_temp import SignalRecord
+
+
+def get_inference_hist_ref(dataset: DatasetH, hist_ref: Optional[int] = None) -> int:
+    """
+    Return the number of historical trading days required for inference.
+
+    If ``hist_ref`` is not provided, time-series datasets use ``step_len - 1``.
+    Regular tabular datasets do not require historical warmup rows.
+    """
+    if hist_ref is not None:
+        if hist_ref < 0:
+            raise ValueError("hist_ref must be non-negative.")
+        return hist_ref
+    if isinstance(dataset, TSDatasetH):
+        return dataset.step_len - 1
+    return 0
+
+
+def get_incremental_inference_config(
+    start_time,
+    end_time,
+    hist_ref: int = 0,
+    freq: str = "day",
+    segment_name: str = "test",
+) -> Tuple[pd.Timestamp, dict]:
+    """
+    Build the data loading window and prediction segment for incremental inference.
+
+    ``start_time`` and ``end_time`` describe the dates that should receive new
+    predictions. ``hist_ref`` extends only the handler loading window so models
+    that need historical bars have enough warmup data. The returned segment is
+    still limited to the incremental prediction window.
+    """
+    if hist_ref < 0:
+        raise ValueError("hist_ref must be non-negative.")
+    if not segment_name:
+        raise ValueError("segment_name must be a non-empty string.")
+
+    start_time = pd.Timestamp(start_time)
+    end_time = pd.Timestamp(end_time)
+    if start_time > end_time:
+        raise ValueError("start_time must be no later than end_time.")
+
+    data_start_time = (
+        start_time
+        if hist_ref == 0
+        else get_date_by_shift(start_time, -hist_ref, clip_shift=False, freq=freq)
+    )
+    return data_start_time, {segment_name: (start_time, end_time)}
+
+
+def prepare_incremental_inference_dataset(
+    dataset: DatasetH,
+    start_time,
+    end_time,
+    hist_ref: Optional[int] = None,
+    freq: str = "day",
+    segment_name: str = "test",
+    init_type=DataHandlerLP.IT_LS,
+) -> DatasetH:
+    """
+    Configure a DatasetH for lightweight incremental prediction.
+
+    This helper is useful when users update the local qlib data themselves and
+    only need scores for newly available dates. It reloads the handler from the
+    earliest required warmup date while keeping the prediction segment limited
+    to ``start_time`` through ``end_time``.
+    """
+    resolved_hist_ref = get_inference_hist_ref(dataset, hist_ref)
+    data_start_time, segments = get_incremental_inference_config(
+        start_time=start_time,
+        end_time=end_time,
+        hist_ref=resolved_hist_ref,
+        freq=freq,
+        segment_name=segment_name,
+    )
+    dataset.config(
+        handler_kwargs={"start_time": data_start_time, "end_time": pd.Timestamp(end_time)},
+        segments=segments,
+    )
+    dataset.setup_data(handler_kwargs={"init_type": init_type})
+    return dataset
 
 
 class RMDLoader:
@@ -199,13 +281,18 @@ class DSBasedUpdater(RecordUpdater, metaclass=ABCMeta):
         else:
             hist_ref = self.hist_ref
 
-        start_time_buffer = get_date_by_shift(
-            self.last_end, -hist_ref + 1, clip_shift=False, freq=self.freq  # pylint: disable=E1130
-        )
         start_time = get_date_by_shift(self.last_end, 1, freq=self.freq)
-        seg = {"test": (start_time, self.to_date)}
+        start_time_buffer, segments = get_incremental_inference_config(
+            start_time=start_time,
+            end_time=self.to_date,
+            hist_ref=hist_ref,
+            freq=self.freq,
+        )
         return self.rmdl.get_dataset(
-            start_time=start_time_buffer, end_time=self.to_date, segments=seg, unprepared_dataset=unprepared_dataset
+            start_time=start_time_buffer,
+            end_time=self.to_date,
+            segments=segments,
+            unprepared_dataset=unprepared_dataset,
         )
 
     def update(self, dataset: DatasetH = None, write: bool = True, ret_new: bool = False) -> Optional[object]:

--- a/tests/rolling_tests/test_incremental_inference.py
+++ b/tests/rolling_tests/test_incremental_inference.py
@@ -1,0 +1,116 @@
+import pandas as pd
+import pytest
+
+import qlib.workflow.online.update as update
+from qlib.data.dataset.handler import DataHandlerLP
+from qlib.workflow.online.update import (
+    get_incremental_inference_config,
+    prepare_incremental_inference_dataset,
+)
+
+
+class DummyDataset:
+    def __init__(self):
+        self.config_kwargs = None
+        self.setup_kwargs = None
+
+    def config(self, **kwargs):
+        self.config_kwargs = kwargs
+
+    def setup_data(self, **kwargs):
+        self.setup_kwargs = kwargs
+
+
+def test_get_incremental_inference_config_extends_only_loading_window(monkeypatch):
+    def fake_get_date_by_shift(trading_date, shift, clip_shift=True, freq="day"):
+        assert pd.Timestamp(trading_date) == pd.Timestamp("2020-01-03")
+        assert shift == -2
+        assert clip_shift is False
+        assert freq == "day"
+        return pd.Timestamp("2020-01-01")
+
+    monkeypatch.setattr(update, "get_date_by_shift", fake_get_date_by_shift)
+
+    data_start_time, segments = get_incremental_inference_config(
+        start_time="2020-01-03",
+        end_time="2020-01-05",
+        hist_ref=2,
+    )
+
+    assert data_start_time == pd.Timestamp("2020-01-01")
+    assert segments == {
+        "test": (pd.Timestamp("2020-01-03"), pd.Timestamp("2020-01-05"))
+    }
+
+
+def test_prepare_incremental_inference_dataset_configures_dataset(monkeypatch):
+    monkeypatch.setattr(
+        update,
+        "get_date_by_shift",
+        lambda trading_date, shift, clip_shift=True, freq="day": pd.Timestamp(
+            "2020-01-01"
+        ),
+    )
+    dataset = DummyDataset()
+
+    result = prepare_incremental_inference_dataset(
+        dataset,
+        start_time="2020-01-03",
+        end_time="2020-01-05",
+        hist_ref=2,
+    )
+
+    assert result is dataset
+    assert dataset.config_kwargs == {
+        "handler_kwargs": {
+            "start_time": pd.Timestamp("2020-01-01"),
+            "end_time": pd.Timestamp("2020-01-05"),
+        },
+        "segments": {
+            "test": (pd.Timestamp("2020-01-03"), pd.Timestamp("2020-01-05"))
+        },
+    }
+    assert dataset.setup_kwargs == {"handler_kwargs": {"init_type": DataHandlerLP.IT_LS}}
+
+
+def test_prepare_incremental_inference_dataset_infers_ts_hist_ref(monkeypatch):
+    class FakeTSDatasetH(DummyDataset):
+        step_len = 4
+
+    def fake_get_date_by_shift(trading_date, shift, clip_shift=True, freq="day"):
+        assert shift == -3
+        return pd.Timestamp("2020-01-01")
+
+    monkeypatch.setattr(update, "TSDatasetH", FakeTSDatasetH)
+    monkeypatch.setattr(update, "get_date_by_shift", fake_get_date_by_shift)
+    dataset = FakeTSDatasetH()
+
+    prepare_incremental_inference_dataset(
+        dataset,
+        start_time="2020-01-04",
+        end_time="2020-01-05",
+    )
+
+    assert dataset.config_kwargs["handler_kwargs"]["start_time"] == pd.Timestamp(
+        "2020-01-01"
+    )
+    assert dataset.config_kwargs["segments"] == {
+        "test": (pd.Timestamp("2020-01-04"), pd.Timestamp("2020-01-05"))
+    }
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"start_time": "2020-01-05", "end_time": "2020-01-03"},
+        {"start_time": "2020-01-03", "end_time": "2020-01-05", "hist_ref": -1},
+        {
+            "start_time": "2020-01-03",
+            "end_time": "2020-01-05",
+            "segment_name": "",
+        },
+    ],
+)
+def test_get_incremental_inference_config_validates_inputs(kwargs):
+    with pytest.raises(ValueError):
+        get_incremental_inference_config(**kwargs)


### PR DESCRIPTION
## Summary

Adds a lightweight helper for users who update their local qlib data themselves and only need predictions for newly available dates.

The new helper configures an existing `DatasetH` so the handler loading window includes the required historical warmup rows while the prediction segment stays limited to the incremental date range. For `TSDatasetH`, the warmup length is inferred from `step_len - 1` unless `hist_ref` is provided explicitly.

Fixes #2073.

## Changes

- Add `get_inference_hist_ref`, `get_incremental_inference_config`, and `prepare_incremental_inference_dataset` in `qlib.workflow.online.update`.
- Reuse the same incremental window helper inside `DSBasedUpdater.prepare_data` to keep the existing online updater behavior aligned with the public helper.
- Document the lightweight incremental prediction workflow in the online component docs.
- Add regression coverage for warmup-window calculation, dataset configuration, `TSDatasetH` warmup inference, and validation errors.

## Validation

- `python -m py_compile qlib\workflow\online\update.py tests\rolling_tests\test_incremental_inference.py`
- `git diff --check`

I also attempted `python -m pytest tests\rolling_tests\test_incremental_inference.py -q` locally on Windows. Collection is blocked before the new tests run because the source checkout does not have the compiled qlib Cython extension (`qlib.data._libs.rolling`), and building it requires Microsoft Visual C++ Build Tools in this environment.