### PR TITLE
fix: keep workflow cwd-safe

### DIFF
--- a/qlib/workflow/expm.py
+++ b/qlib/workflow/expm.py
@@ -2,11 +2,11 @@
 # Licensed under the MIT License.
 
 from urllib.parse import urlparse
+from urllib.request import url2pathname
 import mlflow
 from filelock import FileLock
 from mlflow.exceptions import MlflowException, RESOURCE_ALREADY_EXISTS, ErrorCode
 from mlflow.entities import ViewType
-import os
 from typing import Optional, Text
 from pathlib import Path
 
@@ -17,6 +17,14 @@ from ..log import get_module_logger
 from ..utils.exceptions import ExpAlreadyExistError
 
 logger = get_module_logger("workflow")
+
+
+def _file_uri_to_path(uri: str) -> Path:
+    pr = urlparse(uri)
+    path = url2pathname(pr.path)
+    if pr.netloc and pr.netloc != "localhost":
+        path = f"//{pr.netloc}{path}"
+    return Path(path)
 
 
 class ExpManager:
@@ -233,7 +241,7 @@ class ExpManager:
             # So we supported it in the interface wrapper
             pr = urlparse(self.uri)
             if pr.scheme == "file":
-                with FileLock(Path(os.path.join(pr.netloc, pr.path.lstrip("/"), "filelock"))):  # pylint: disable=E0110
+                with FileLock(_file_uri_to_path(self.uri) / "filelock"):  # pylint: disable=E0110
                     return self.create_exp(experiment_name), True
             # NOTE: for other schemes like http, we double check to avoid create exp conflicts
             try:

--- a/qlib/workflow/recorder.py
+++ b/qlib/workflow/recorder.py
@@ -364,18 +364,33 @@ class MLflowRecorder(Recorder):
         Mlflow only log the commit id of the current repo. But usually, user will have a lot of uncommitted changes.
         So this tries to automatically to log them all.
         """
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "--is-inside-work-tree"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                check=True,
+            )
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            return
+
+        if result.stdout.decode().strip().lower() != "true":
+            return
+
         # TODO: the sub-directories maybe git repos.
         # So it will be better if we can walk the sub-directories and log the uncommitted changes.
         for cmd, fname in [
-            ("git diff", "code_diff.txt"),
-            ("git status", "code_status.txt"),
-            ("git diff --cached", "code_cached.txt"),
+            (["git", "diff"], "code_diff.txt"),
+            (["git", "status"], "code_status.txt"),
+            (["git", "diff", "--cached"], "code_cached.txt"),
         ]:
             try:
-                out = subprocess.check_output(cmd, shell=True)
+                out = subprocess.check_output(cmd, stderr=subprocess.DEVNULL)
                 self.client.log_text(self.id, out.decode(), fname)  # this behaves same as above
-            except subprocess.CalledProcessError:
-                logger.info(f"Fail to log the uncommitted code of $CWD({os.getcwd()}) when run {cmd}.")
+            except (subprocess.CalledProcessError, FileNotFoundError):
+                logger.debug(
+                    f"Fail to log the uncommitted code of $CWD({os.getcwd()}) when run {cmd}."
+                )
 
     def end_run(self, status: str = Recorder.STATUS_S):
         assert status in [

--- a/tests/test_workflow_cwd_safety.py
+++ b/tests/test_workflow_cwd_safety.py
@@ -1,0 +1,76 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import subprocess
+from pathlib import Path
+from unittest import mock
+
+from qlib.workflow.expm import _file_uri_to_path
+from qlib.workflow.recorder import MLflowRecorder
+
+
+def _make_recorder() -> MLflowRecorder:
+    recorder = MLflowRecorder.__new__(MLflowRecorder)
+    recorder.id = "run"
+    recorder.client = mock.Mock()
+    return recorder
+
+
+def test_file_uri_lock_path_stays_absolute(tmp_path: Path) -> None:
+    mlruns = (tmp_path / "mlruns").resolve()
+
+    assert _file_uri_to_path(mlruns.as_uri()) == mlruns
+    assert _file_uri_to_path("file:" + str(mlruns)) == mlruns
+
+
+def test_log_uncommitted_code_skips_non_git_cwd() -> None:
+    recorder = _make_recorder()
+    not_git = subprocess.CalledProcessError(128, ["git", "rev-parse"])
+
+    with (
+        mock.patch(
+            "qlib.workflow.recorder.subprocess.run",
+            side_effect=not_git,
+        ) as run,
+        mock.patch(
+            "qlib.workflow.recorder.subprocess.check_output"
+        ) as check_output,
+    ):
+        recorder._log_uncommitted_code()
+
+    run.assert_called_once_with(
+        ["git", "rev-parse", "--is-inside-work-tree"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        check=True,
+    )
+    check_output.assert_not_called()
+    recorder.client.log_text.assert_not_called()
+
+
+def test_log_uncommitted_code_uses_git_without_shell() -> None:
+    recorder = _make_recorder()
+    in_worktree = subprocess.CompletedProcess(["git"], 0, stdout=b"true\n")
+
+    with (
+        mock.patch(
+            "qlib.workflow.recorder.subprocess.run",
+            return_value=in_worktree,
+        ),
+        mock.patch(
+            "qlib.workflow.recorder.subprocess.check_output",
+            side_effect=[b"diff", b"status", b"cached"],
+        ) as check_output,
+    ):
+        recorder._log_uncommitted_code()
+
+    assert [call.args[0] for call in check_output.call_args_list] == [
+        ["git", "diff"],
+        ["git", "status"],
+        ["git", "diff", "--cached"],
+    ]
+    assert all(
+        call.kwargs == {"stderr": subprocess.DEVNULL}
+        for call in check_output.call_args_list
+    )
+    assert recorder.client.log_text.call_count == 3


### PR DESCRIPTION
## Description

Fixes two CWD-sensitive paths in `qlib.workflow`:

- resolve `file:` / `file://` experiment URIs to real filesystem paths before creating the qlib-side `FileLock`, so absolute tracking URIs do not turn into CWD-relative lock directories;
- make `_log_uncommitted_code()` skip quietly outside a git work tree, then run git without `shell=True` and with stderr suppressed for the optional diff/status artifacts.

I kept the change local to the workflow/recorder path and added a small regression file that does not need qlib market data.

## Motivation and Context

Fixes #2252.

The lock path bug can put `filelock` under whatever directory the process started from, which means two processes using the same absolute MLflow URI may not actually share the same lock. The git logging path is optional reproducibility metadata, so a non-git CWD should not leak git usage text to stderr or emit noisy INFO records on every run.

## How Has This Been Tested?

- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [x] If you are adding a new feature, test on your own test scripts.

Targeted checks run locally:

- `python -m pytest tests\test_workflow_cwd_safety.py -q`
- `python -m py_compile qlib\workflow\expm.py qlib\workflow\recorder.py tests\test_workflow_cwd_safety.py`
- `python -m flake8 tests\test_workflow_cwd_safety.py`
- `git diff --check`

Also attempted `python -m pytest tests\test_workflow.py -q`, but this Windows checkout has not built `qlib.data._libs.rolling`, so collection fails before the workflow tests run.

## Screenshots of Test Results (if appropriate):
1. Pipeline test: not run locally; see note above.
2. Your own tests: `tests\test_workflow_cwd_safety.py` passes (`3 passed`).

## Types of changes

- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
