### PR TITLE
fix(cn_index): wrap literal HTML in StringIO for pd.read_html

### DIFF
--- a/scripts/data_collector/cn_index/collector.py
+++ b/scripts/data_collector/cn_index/collector.py
@@ -4,7 +4,7 @@
 import re
 import abc
 import sys
-from io import BytesIO
+from io import BytesIO, StringIO
 from typing import List, Iterable
 from pathlib import Path
 
@@ -182,7 +182,7 @@ class CSIIndex(IndexBase):
     def _parse_table(self, content: str, add_date: pd.DataFrame, remove_date: pd.DataFrame) -> pd.DataFrame:
         df = pd.DataFrame()
         _tmp_count = 0
-        for _df in pd.read_html(content):
+        for _df in pd.read_html(StringIO(content)):
             if _df.shape[-1] != 4 or _df.isnull().loc(0)[0][0]:
                 continue
             _tmp_count += 1


### PR DESCRIPTION
## Description

#2047 wrapped the literal HTML passed to `pd.read_html` in a `StringIO` for the `us_index` collector to silence pandas' `FutureWarning`:

> Passing literal html to 'read_html' is deprecated and will be removed in a future version. To read from a literal string, wrap it in a 'StringIO' object.

The parallel `cn_index` collector was missed. `_parse_table` passes the csindex response body (an HTML string, not a URL/path) straight to `pd.read_html(content)` at `scripts/data_collector/cn_index/collector.py:185`, so it still hits the same deprecation and will break once pandas drops literal-string support.

## Change

Import `StringIO` and wrap the content, matching what #2047 did for `us_index`. No behavior change on supported pandas versions; `StringIO` has always been accepted by `read_html`.

Reproduced locally on pandas 2.3.3:

```
>>> pd.read_html("<table>...</table>")        # FutureWarning: Passing literal html ...
>>> pd.read_html(StringIO("<table>...</table>"))  # no warning
```

## Note

I scoped this to the `read_html` fix to stay a clean parallel of #2047. The same file also calls `DataFrame.applymap` (line 174), which pandas 2.1 deprecates in favour of `DataFrame.map`, but `DataFrame.map` only exists from 2.1 onward while `setup.py` still supports `pandas>=1.1`, so swapping it would need version handling and is left out here.
