### PR TITLE
Fix MLflow CWD-sensitive workflow paths

### DIFF
--- a/qlib/workflow/expm.py
+++ b/qlib/workflow/expm.py
@@ -2,11 +2,11 @@
 # Licensed under the MIT License.
 
 from urllib.parse import urlparse
+from urllib.request import url2pathname
 import mlflow
 from filelock import FileLock
 from mlflow.exceptions import MlflowException, RESOURCE_ALREADY_EXISTS, ErrorCode
 from mlflow.entities import ViewType
-import os
 from typing import Optional, Text
 from pathlib import Path
 
@@ -17,6 +17,14 @@ from ..log import get_module_logger
 from ..utils.exceptions import ExpAlreadyExistError
 
 logger = get_module_logger("workflow")
+
+
+def _file_uri_to_path(uri: Text) -> Path:
+    pr = urlparse(uri)
+    path = url2pathname(pr.path)
+    if pr.netloc and pr.netloc != "localhost":
+        path = f"//{pr.netloc}{path}"
+    return Path(path)
 
 
 class ExpManager:
@@ -233,7 +241,7 @@ class ExpManager:
             # So we supported it in the interface wrapper
             pr = urlparse(self.uri)
             if pr.scheme == "file":
-                with FileLock(Path(os.path.join(pr.netloc, pr.path.lstrip("/"), "filelock"))):  # pylint: disable=E0110
+                with FileLock(_file_uri_to_path(self.uri) / "filelock"):  # pylint: disable=E0110
                     return self.create_exp(experiment_name), True
             # NOTE: for other schemes like http, we double check to avoid create exp conflicts
             try:

--- a/qlib/workflow/recorder.py
+++ b/qlib/workflow/recorder.py
@@ -366,16 +366,30 @@ class MLflowRecorder(Recorder):
         """
         # TODO: the sub-directories maybe git repos.
         # So it will be better if we can walk the sub-directories and log the uncommitted changes.
+        try:
+            proc = subprocess.run(
+                ["git", "rev-parse", "--is-inside-work-tree"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=True,
+            )
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            logger.debug(f"Skip logging uncommitted code because $CWD({os.getcwd()}) is not a git work tree.")
+            return
+        if proc.stdout.decode().strip() != "true":
+            logger.debug(f"Skip logging uncommitted code because $CWD({os.getcwd()}) is not a git work tree.")
+            return
+
         for cmd, fname in [
-            ("git diff", "code_diff.txt"),
-            ("git status", "code_status.txt"),
-            ("git diff --cached", "code_cached.txt"),
+            (["git", "diff"], "code_diff.txt"),
+            (["git", "status"], "code_status.txt"),
+            (["git", "diff", "--cached"], "code_cached.txt"),
         ]:
             try:
-                out = subprocess.check_output(cmd, shell=True)
-                self.client.log_text(self.id, out.decode(), fname)  # this behaves same as above
-            except subprocess.CalledProcessError:
-                logger.info(f"Fail to log the uncommitted code of $CWD({os.getcwd()}) when run {cmd}.")
+                out = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+                self.client.log_text(self.id, out.stdout.decode(), fname)  # this behaves same as above
+            except (FileNotFoundError, subprocess.CalledProcessError):
+                logger.debug(f"Fail to log the uncommitted code of $CWD({os.getcwd()}) when run {' '.join(cmd)}.")
 
     def end_run(self, status: str = Recorder.STATUS_S):
         assert status in [

--- a/tests/dependency_tests/test_mlflow.py
+++ b/tests/dependency_tests/test_mlflow.py
@@ -2,10 +2,25 @@
 # Licensed under the MIT License.
 import unittest
 import platform
+import contextlib
+import io
 import mlflow
+import os
 import time
 from pathlib import Path
 import shutil
+import tempfile
+
+from qlib.workflow.expm import _file_uri_to_path
+from qlib.workflow.recorder import MLflowRecorder
+
+
+class DummyClient:
+    def __init__(self):
+        self.logged_text = []
+
+    def log_text(self, run_id, text, fname):
+        self.logged_text.append((run_id, text, fname))
 
 
 class MLflowTest(unittest.TestCase):
@@ -32,6 +47,28 @@ class MLflowTest(unittest.TestCase):
         else:
             self.assertLess(elapsed, 2e-2)
         print(elapsed)
+
+    def test_file_uri_to_path_keeps_absolute_paths(self):
+        self.assertEqual(_file_uri_to_path("file:///tmp/qlib/mlruns"), Path("/tmp/qlib/mlruns"))
+        self.assertEqual(_file_uri_to_path("file:/tmp/qlib/mlruns"), Path("/tmp/qlib/mlruns"))
+
+    def test_log_uncommitted_code_skips_non_git_cwd_quietly(self):
+        recorder = object.__new__(MLflowRecorder)
+        recorder.id = "run-id"
+        recorder.client = DummyClient()
+        stderr = io.StringIO()
+
+        old_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            try:
+                os.chdir(tmpdir)
+                with contextlib.redirect_stderr(stderr):
+                    recorder._log_uncommitted_code()
+            finally:
+                os.chdir(old_cwd)
+
+        self.assertEqual(stderr.getvalue(), "")
+        self.assertEqual(recorder.client.logged_text, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- resolve file:// MLflow tracking URIs with url2pathname before building the experiment FileLock path, so absolute tracking paths stay absolute regardless of the caller CWD
- skip optional uncommitted-code artifact logging when the process CWD is not a git work tree
- remove shell=True from the git diff/status calls and capture stderr so git diagnostics do not leak into caller stderr
- add regression coverage for absolute file URI lock paths and quiet non-git CWD handling

Fixes #2252.

## Test plan
- MLFLOW_ALLOW_FILE_STORE=true .venv/bin/python -m pytest tests/dependency_tests/test_mlflow.py -q
- .venv/bin/python -m black qlib/workflow/expm.py qlib/workflow/recorder.py tests/dependency_tests/test_mlflow.py -l 120 --check --diff
- .venv/bin/python -m pylint --disable=C0104,C0114,C0115,C0116,C0301,C0302,C0411,C0413,C1802,R0401,R0801,R0902,R0903,R0911,R0912,R0913,R0914,R0915,R0917,R1720,W0105,W0123,W0201,W0511,W0613,W1113,W1514,W4904,E0401,E1121,C0103,C0209,R0402,R1705,R1710,R1725,R1730,R1735,W0102,W0212,W0221,W0223,W0231,W0237,W0612,W0621,W0622,W0703,W1309,E1102,E1136 --const-rgx='[a-z_][a-z0-9_]{2,30}' qlib/workflow/expm.py qlib/workflow/recorder.py
- .venv/bin/python -m flake8 --ignore=E501,F541,E266,E402,W503,E731,E203 --per-file-ignores="__init__.py:F401,F403" qlib