### PR TITLE
fix: Make FileLock robust to the CWD (Fix #2252)

### DIFF
--- a/qlib/workflow/expm.py
+++ b/qlib/workflow/expm.py
@@ -231,9 +231,11 @@ class ExpManager:
 
             # NOTE: mlflow doesn't consider the lock for recording multiple runs
             # So we supported it in the interface wrapper
+            from urllib.request import url2pathname
             pr = urlparse(self.uri)
             if pr.scheme == "file":
-                with FileLock(Path(os.path.join(pr.netloc, pr.path.lstrip("/"), "filelock"))):  # pylint: disable=E0110
+                lock_path = Path(url2pathname(pr.path)) / "filelock"
+                with FileLock(lock_path):
                     return self.create_exp(experiment_name), True
             # NOTE: for other schemes like http, we double check to avoid create exp conflicts
             try:


### PR DESCRIPTION
## Description

This PR fixes Issue #2252 by making FileLock path handling robust to the Current Working Directory (CWD).

The previous implementation used `os.path.join`, which could incorrectly anchor absolute paths to the current working directory in certain scenarios. This change replaces that logic with `url2pathname`, ensuring that absolute paths are handled correctly and consistently.

## Motivation and Context

Fixes #2252.

This change prevents FileLock from incorrectly resolving lock file paths relative to the current working directory, improving reliability when working with absolute paths.

## How Has This Been Tested?

* [x] Verified that the modified code correctly handles absolute paths.
* [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py`
* [ ] If you are adding a new feature, test on your own test scripts.

## Screenshots of Test Results (if appropriate)

1. Pipeline test: Not run.
2. Your own tests: Verified path resolution behavior manually.

## Types of changes

* [x] Fix bugs
* [ ] Add new feature
* [ ] Update documentation
