### PR TITLE
fix(utils): strip the _qlib_ prefix in fname_to_code, not characters

### DIFF
--- a/qlib/utils/__init__.py
+++ b/qlib/utils/__init__.py
@@ -932,7 +932,10 @@ def fname_to_code(fname: str):
 
     prefix = "_qlib_"
     if fname.startswith(prefix):
-        fname = fname.lstrip(prefix)
+        # NOTE: use slicing rather than ``lstrip(prefix)``; ``str.lstrip`` strips
+        # any leading characters contained in ``prefix`` (e.g. it would turn
+        # "_qlib_lpt1" into "pt1"), not the prefix as a whole.
+        fname = fname[len(prefix) :]
     return fname
 
 

--- a/tests/misc/test_utils.py
+++ b/tests/misc/test_utils.py
@@ -10,6 +10,7 @@ from qlib.log import TimeInspector
 from qlib.constant import REG_CN, REG_US, REG_TW
 from qlib.utils.time import cal_sam_minute as cal_sam_minute_new, get_min_cal, CN_TIME, US_TIME, TW_TIME
 from qlib.utils.data import guess_horizon
+from qlib.utils import code_to_fname, fname_to_code
 
 REG_MAP = {REG_CN: CN_TIME, REG_US: US_TIME, REG_TW: TW_TIME}
 
@@ -126,6 +127,22 @@ class DataUtils(TestCase):
         label = ["Ref($close, -5) / Ref($close, -1) - 1"]
         result = guess_horizon(label)
         assert result == 5
+
+
+class FileNameUtils(TestCase):
+    def test_fname_code_round_trip(self):
+        # code_to_fname only prefixes reserved Windows device names; fname_to_code
+        # must strip the whole "_qlib_" prefix, not individual characters.
+        # exists_qlib_data() lowercases the directory name before converting back,
+        # and "lpt*" begins with characters that are also in the prefix.
+        for code in ["CON", "PRN", "AUX", "NUL", "COM1", "LPT1", "LPT9"]:
+            fname = code_to_fname(code)
+            self.assertEqual(fname_to_code(fname.lower()), code.lower())
+
+        # a name whose body consists only of prefix characters must survive
+        self.assertEqual(fname_to_code("_qlib_lll"), "lll")
+        # plain codes pass through unchanged
+        self.assertEqual(fname_to_code("AAPL"), "AAPL")
 
         label = ["Ref($close, -1) / Ref($close, -1) - 1"]
         result = guess_horizon(label)


### PR DESCRIPTION
## Description

`fname_to_code()` is meant to reverse `code_to_fname()`, which prefixes reserved Windows device names (`CON`, `PRN`, `AUX`, `NUL`, `COM0`–`COM9`, `LPT0`–`LPT9`) with `_qlib_` so they can be used as directory names. The reverse used `fname.lstrip("_qlib_")`, but `str.lstrip` removes *any* leading characters contained in its argument, not the prefix as a whole.

`exists_qlib_data()` lowercases each feature directory name before calling `fname_to_code()`:

```python
code_names = set(map(lambda x: fname_to_code(x.name.lower()), features_dir.iterdir()))
```

So `LPT1` is stored as `_qlib_LPT1`, lowercased to `_qlib_lpt1`, and then `lstrip("_qlib_")` strips the leading `l` too (it is one of the prefix characters), yielding `pt1` instead of `lpt1`. The data-existence check then fails to match such a stock. Any name whose body begins with a character in `{_, q, l, i, b}` is corrupted (e.g. `fname_to_code("_qlib_lll")` returns `""`).

The fix removes the prefix by slicing, so the original code is recovered intact.

## Verification

Before:

```python
>>> fname_to_code("_qlib_lll")
''
>>> fname_to_code(code_to_fname("LPT1").lower())
'pt1'
```

After:

```python
>>> fname_to_code("_qlib_lll")
'lll'
>>> fname_to_code(code_to_fname("LPT1").lower())
'lpt1'
```

Added `FileNameUtils.test_fname_code_round_trip` in `tests/misc/test_utils.py`, covering the reserved device names (via the lowercased path `exists_qlib_data` uses), a prefix-only body, and a plain code. `black -l 120 --check` passes on the changed files.
