### PR TITLE
Fix no-op sort_index() in SeriesDFilter._toTimestamp

### DIFF
--- a/qlib/data/filter.py
+++ b/qlib/data/filter.py
@@ -160,7 +160,7 @@ class SeriesDFilter(BaseDFilter):
             the list of tuple (timestamp, timestamp).
         """
         # sort the timestamp_series according to the timestamps
-        timestamp_series.sort_index()
+        timestamp_series = timestamp_series.sort_index()
         timestamp = []
         _lbool = None
         _ltime = None


### PR DESCRIPTION
Fix no-op sort_index() in SeriesDFilter._toTimestamp