### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Also, users can install the latest dev version ``Qlib`` by the source code accor
 * Clone the repository and install ``Qlib`` as follows.
     ```bash
     git clone https://github.com/microsoft/qlib.git && cd qlib
-    pip install .  # `pip install -e .[dev]` is recommended for development. check details in docs/developer/code_standard_and_dev_guide.rst
+    pip install .  # `pip install -e '.[dev]'` is recommended for development. check details in docs/developer/code_standard_and_dev_guide.rst
     ```
 
 **Tips**: If you fail to install `Qlib` or run the examples in your environment,  comparing your steps and the [CI workflow](.github/workflows/test_qlib_from_source.yml) may help you find the problem.

--- a/docs/developer/code_standard_and_dev_guide.rst
+++ b/docs/developer/code_standard_and_dev_guide.rst
@@ -47,7 +47,7 @@ When you submit a PR request, you can check whether your code passes the CI test
 
 .. code-block:: bash
 
-    pip install -e .[dev]
+    pip install -e '.[dev]'
     pre-commit install
 
 


### PR DESCRIPTION
## Summary
- Quote `pip install` examples that include extras.

## Why
- Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

## Scope
- Files changed:
- `README.md`
- `docs/developer/code_standard_and_dev_guide.rst`
- This does not change dependencies or runtime behavior.

## Testing
- `git diff --check`

## Maintainer Fit
- Small install-command correctness fix.
- Duplicate PR search terms checked: `quote pip extras`, `quote optional dependency`, `zsh pip install extras`, `pip extras install examples`