### PR TITLE
Handle backtest calendar right boundary

### DIFF
--- a/qlib/backtest/utils.py
+++ b/qlib/backtest/utils.py
@@ -8,7 +8,7 @@ from typing import Any, Set, Tuple, TYPE_CHECKING, Union
 
 import numpy as np
 
-from qlib.utils.time import epsilon_change
+from qlib.utils.time import Freq, epsilon_change
 
 if TYPE_CHECKING:
     from qlib.backtest.decision import BaseTradeDecision
@@ -86,7 +86,7 @@ class TradeCalendarManager:
 
     def step(self) -> None:
         if self.finished():
-            raise RuntimeError(f"The calendar is finished, please reset it if you want to call it!")
+            raise RuntimeError("The calendar is finished, please reset it if you want to call it!")
         self.trade_step += 1
 
     def get_freq(self) -> str:
@@ -128,7 +128,13 @@ class TradeCalendarManager:
         if trade_step is None:
             trade_step = self.get_trade_step()
         calendar_index = self.start_index + trade_step - shift
-        return self._calendar[calendar_index], epsilon_change(self._calendar[calendar_index + 1])
+        step_start = pd.Timestamp(self._calendar[calendar_index])
+        if calendar_index + 1 < len(self._calendar):
+            step_end = self._calendar[calendar_index + 1]
+        else:
+            freq = Freq(self.freq)
+            step_end = step_start + Freq.get_timedelta(freq.count, freq.base)
+        return step_start, epsilon_change(pd.Timestamp(step_end))
 
     def get_data_cal_range(self, rtype: str = "full") -> Tuple[int, int]:
         """

--- a/tests/backtest/test_trade_calendar_manager.py
+++ b/tests/backtest/test_trade_calendar_manager.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pandas as pd
+
+from qlib.backtest.utils import TradeCalendarManager
+
+
+def _make_calendar_manager():
+    trade_calendar = TradeCalendarManager.__new__(TradeCalendarManager)
+    trade_calendar.freq = "day"
+    trade_calendar.start_index = 0
+    trade_calendar.end_index = 1
+    trade_calendar.trade_len = 2
+    trade_calendar.trade_step = 1
+    trade_calendar._calendar = np.array(
+        [pd.Timestamp("2020-01-01"), pd.Timestamp("2020-01-02")]
+    )
+    return trade_calendar
+
+
+def test_get_step_time_uses_next_calendar_when_available():
+    trade_calendar = _make_calendar_manager()
+
+    start_time, end_time = trade_calendar.get_step_time(trade_step=0)
+
+    assert start_time == pd.Timestamp("2020-01-01")
+    assert end_time == pd.Timestamp("2020-01-01 23:59:59")
+
+
+def test_get_step_time_infers_right_boundary_for_last_calendar_bar():
+    trade_calendar = _make_calendar_manager()
+
+    start_time, end_time = trade_calendar.get_step_time()
+
+    assert start_time == pd.Timestamp("2020-01-02")
+    assert end_time == pd.Timestamp("2020-01-02 23:59:59")


### PR DESCRIPTION
## Summary

Fixes #2278.

`TradeCalendarManager.get_step_time()` forms each step interval as `[calendar[i], epsilon_change(calendar[i + 1])]`. When a provider has no future calendar extension and a backtest ends on the final available calendar bar, the last step has no `calendar[i + 1]` and raises an opaque `IndexError`.

This PR keeps the normal next-calendar path unchanged, but when the next calendar bar is unavailable it infers the right endpoint from the manager frequency (`calendar[i] + freq`) and then applies the existing `epsilon_change` closed-interval convention. For a daily final bar, the last interval becomes `2020-01-02 00:00:00` through `2020-01-02 23:59:59` instead of crashing.

## Tests

- `PYTHONPYCACHEPREFIX=/private/tmp/qlib-pycache /usr/bin/python3 -m py_compile qlib/backtest/utils.py tests/backtest/test_trade_calendar_manager.py`
- `git diff --check`
- `/opt/homebrew/bin/python3.11 -m ruff check tests/backtest/test_trade_calendar_manager.py`
- isolated harness that stubs package-level Qlib imports, loads `qlib/backtest/utils.py`, and verifies both the normal next-calendar path and the final-calendar fallback

Note: direct local `pytest -q tests/backtest/test_trade_calendar_manager.py` is blocked in this unbuilt source checkout by missing compiled extensions (`qlib.data._libs.rolling`). The added test is a normal repository test and should run after CI builds the extension.