### PR TITLE
Fix issue 2098: Add opt-in structured logging, metrics, and tracing

### DIFF
--- a/qlib/config.py
+++ b/qlib/config.py
@@ -111,6 +111,7 @@ class Config:
     @staticmethod
     def register_from_C(config, skip_register=True):
         from .utils import set_log_with_config  # pylint: disable=C0415
+        from .metrics import configure_metrics  # pylint: disable=C0415
 
         if C.registered and skip_register:
             return
@@ -118,6 +119,7 @@ class Config:
         C.set_conf_from_C(config)
         if C.logging_config:
             set_log_with_config(C.logging_config)
+        configure_metrics(C.get("metrics_config", {}))
         C.register()
 
 
@@ -183,6 +185,10 @@ _default_config = {
     "redis_password": None,
     # This value can be reset via qlib.init
     "logging_level": logging.INFO,
+    # Optional process-local observability metrics. Disabled by default.
+    "metrics_config": {
+        "enabled": False,
+    },
     # Global configuration of qlib log
     # logging_level can control the logging level more finely
     "logging_config": {
@@ -440,6 +446,7 @@ class QlibConfig(Config):
             the default config template chosen by user: "server", "client"
         """
         from .utils import set_log_with_config, get_module_logger, can_use_cache  # pylint: disable=C0415
+        from .metrics import configure_metrics  # pylint: disable=C0415
 
         self.reset()
 
@@ -459,6 +466,8 @@ class QlibConfig(Config):
             if k not in self:
                 logger.warning("Unrecognized config %s" % k)
             self[k] = v
+
+        configure_metrics(self.get("metrics_config", {}))
 
         self.resolve_path()
 

--- a/qlib/config.py
+++ b/qlib/config.py
@@ -112,6 +112,7 @@ class Config:
     def register_from_C(config, skip_register=True):
         from .utils import set_log_with_config  # pylint: disable=C0415
         from .metrics import configure_metrics  # pylint: disable=C0415
+        from .trace import configure_tracing  # pylint: disable=C0415
 
         if C.registered and skip_register:
             return
@@ -120,6 +121,7 @@ class Config:
         if C.logging_config:
             set_log_with_config(C.logging_config)
         configure_metrics(C.get("metrics_config", {}))
+        configure_tracing(C.get("tracing_config", {}))
         C.register()
 
 
@@ -187,6 +189,10 @@ _default_config = {
     "logging_level": logging.INFO,
     # Optional process-local observability metrics. Disabled by default.
     "metrics_config": {
+        "enabled": False,
+    },
+    # Optional lightweight workflow tracing. Disabled by default.
+    "tracing_config": {
         "enabled": False,
     },
     # Global configuration of qlib log
@@ -447,6 +453,7 @@ class QlibConfig(Config):
         """
         from .utils import set_log_with_config, get_module_logger, can_use_cache  # pylint: disable=C0415
         from .metrics import configure_metrics  # pylint: disable=C0415
+        from .trace import configure_tracing  # pylint: disable=C0415
 
         self.reset()
 
@@ -468,6 +475,7 @@ class QlibConfig(Config):
             self[k] = v
 
         configure_metrics(self.get("metrics_config", {}))
+        configure_tracing(self.get("tracing_config", {}))
 
         self.resolve_path()
 

--- a/qlib/data/cache.py
+++ b/qlib/data/cache.py
@@ -34,6 +34,7 @@ from ..utils.pickle_utils import restricted_pickle_load
 
 from ..log import get_module_logger
 from ..metrics import get_metrics_recorder
+from ..trace import trace_span
 from .base import Feature
 from .ops import Operators  # pylint: disable=W0611  # noqa: F401
 
@@ -1088,10 +1089,11 @@ class SimpleDatasetCache(DatasetCache):
     ):
         metrics = get_metrics_recorder()
         metric_tags = {"cache": "simple", "freq": freq}
-        with metrics.timer("qlib.cache.dataset.load_seconds", tags=metric_tags):
-            return self._dataset_with_metrics(
-                instruments, fields, start_time, end_time, freq, disk_cache, inst_processors, metrics, metric_tags
-            )
+        with trace_span("cache.dataset"):
+            with metrics.timer("qlib.cache.dataset.load_seconds", tags=metric_tags):
+                return self._dataset_with_metrics(
+                    instruments, fields, start_time, end_time, freq, disk_cache, inst_processors, metrics, metric_tags
+                )
 
     def _dataset_with_metrics(
         self, instruments, fields, start_time, end_time, freq, disk_cache, inst_processors, metrics, metric_tags
@@ -1199,17 +1201,18 @@ class MemoryCalendarCache(CalendarCache):
         metrics = get_metrics_recorder()
         metric_tags = {"cache": "memory", "freq": freq}
         uri = self._uri(start_time, end_time, freq, future)
-        with metrics.timer("qlib.cache.calendar.load_seconds", tags=metric_tags):
-            result, expire = MemCacheExpire.get_cache(H["c"], uri)
-            if result is None or expire:
-                metrics.increment("qlib.cache.calendar.miss", tags=metric_tags)
-                result = self.provider.calendar(start_time, end_time, freq, future)
-                MemCacheExpire.set_cache(H["c"], uri, result)
+        with trace_span("cache.calendar"):
+            with metrics.timer("qlib.cache.calendar.load_seconds", tags=metric_tags):
+                result, expire = MemCacheExpire.get_cache(H["c"], uri)
+                if result is None or expire:
+                    metrics.increment("qlib.cache.calendar.miss", tags=metric_tags)
+                    result = self.provider.calendar(start_time, end_time, freq, future)
+                    MemCacheExpire.set_cache(H["c"], uri, result)
 
-                get_module_logger("data").debug(f"get calendar from {C.calendar_provider}")
-            else:
-                metrics.increment("qlib.cache.calendar.hit", tags=metric_tags)
-                get_module_logger("data").debug("get calendar from local cache")
+                    get_module_logger("data").debug(f"get calendar from {C.calendar_provider}")
+                else:
+                    metrics.increment("qlib.cache.calendar.hit", tags=metric_tags)
+                    get_module_logger("data").debug("get calendar from local cache")
 
         return result
 

--- a/qlib/data/cache.py
+++ b/qlib/data/cache.py
@@ -33,6 +33,7 @@ from ..utils import (
 from ..utils.pickle_utils import restricted_pickle_load
 
 from ..log import get_module_logger
+from ..metrics import get_metrics_recorder
 from .base import Feature
 from .ops import Operators  # pylint: disable=W0611  # noqa: F401
 
@@ -1085,6 +1086,16 @@ class SimpleDatasetCache(DatasetCache):
     def _dataset(
         self, instruments, fields, start_time=None, end_time=None, freq="day", disk_cache=1, inst_processors=[]
     ):
+        metrics = get_metrics_recorder()
+        metric_tags = {"cache": "simple", "freq": freq}
+        with metrics.timer("qlib.cache.dataset.load_seconds", tags=metric_tags):
+            return self._dataset_with_metrics(
+                instruments, fields, start_time, end_time, freq, disk_cache, inst_processors, metrics, metric_tags
+            )
+
+    def _dataset_with_metrics(
+        self, instruments, fields, start_time, end_time, freq, disk_cache, inst_processors, metrics, metric_tags
+    ):
         if disk_cache == 0:
             # In this case, data_set cache is configured but will not be used.
             return self.provider.dataset(instruments, fields, start_time, end_time, freq)
@@ -1099,6 +1110,7 @@ class SimpleDatasetCache(DatasetCache):
         if cache_file.exists():
             if disk_cache == 1:
                 # use cache
+                metrics.increment("qlib.cache.dataset.hit", tags=metric_tags)
                 df = pd.read_pickle(cache_file)
                 return self.cache_to_origin_data(df, fields)
             elif disk_cache == 2:
@@ -1108,6 +1120,7 @@ class SimpleDatasetCache(DatasetCache):
             gen_flag = True
 
         if gen_flag:
+            metrics.increment("qlib.cache.dataset.miss", tags=metric_tags)
             data = self.provider.dataset(
                 instruments, normalize_cache_fields(fields), start_time, end_time, freq, inst_processors=inst_processors
             )
@@ -1183,15 +1196,20 @@ class CalendarCache(BaseProviderCache):
 
 class MemoryCalendarCache(CalendarCache):
     def calendar(self, start_time=None, end_time=None, freq="day", future=False):
+        metrics = get_metrics_recorder()
+        metric_tags = {"cache": "memory", "freq": freq}
         uri = self._uri(start_time, end_time, freq, future)
-        result, expire = MemCacheExpire.get_cache(H["c"], uri)
-        if result is None or expire:
-            result = self.provider.calendar(start_time, end_time, freq, future)
-            MemCacheExpire.set_cache(H["c"], uri, result)
+        with metrics.timer("qlib.cache.calendar.load_seconds", tags=metric_tags):
+            result, expire = MemCacheExpire.get_cache(H["c"], uri)
+            if result is None or expire:
+                metrics.increment("qlib.cache.calendar.miss", tags=metric_tags)
+                result = self.provider.calendar(start_time, end_time, freq, future)
+                MemCacheExpire.set_cache(H["c"], uri, result)
 
-            get_module_logger("data").debug(f"get calendar from {C.calendar_provider}")
-        else:
-            get_module_logger("data").debug("get calendar from local cache")
+                get_module_logger("data").debug(f"get calendar from {C.calendar_provider}")
+            else:
+                metrics.increment("qlib.cache.calendar.hit", tags=metric_tags)
+                get_module_logger("data").debug("get calendar from local cache")
 
         return result
 

--- a/qlib/log.py
+++ b/qlib/log.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 
+import json
 import logging
 from typing import Optional, Text, Dict, Any
 import re
@@ -10,6 +11,33 @@ from time import time
 from contextlib import contextmanager
 
 from .config import C
+
+
+_LOG_RECORD_ATTRIBUTES = frozenset(logging.makeLogRecord({}).__dict__)
+
+
+class JSONFormatter(logging.Formatter):
+    """Format log records as JSON, including fields supplied through ``extra``."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        log_data = {
+            "timestamp": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        log_data.update(
+            {
+                key: value
+                for key, value in record.__dict__.items()
+                if key not in _LOG_RECORD_ATTRIBUTES and key not in log_data
+            }
+        )
+
+        if record.exc_info:
+            log_data["exception"] = self.formatException(record.exc_info)
+
+        return json.dumps(log_data, default=str)
 
 
 class MetaLogger(type):

--- a/qlib/log.py
+++ b/qlib/log.py
@@ -75,7 +75,8 @@ def _normalize_logging_config(log_config: Dict[Text, Any]) -> Dict[Text, Any]:
     if log_format != _STRUCTURED_LOGGING_FORMAT:
         raise ValueError(f"Unsupported structured logging format: {log_format}")
 
-    normalized_config = copy.deepcopy(log_config if is_dict_config else C.logging_config)
+    default_logging_config = C.__dict__["_default_config"]["logging_config"]
+    normalized_config = copy.deepcopy(log_config if is_dict_config else default_logging_config)
     normalized_config.pop("structured", None)
     normalized_config.pop("format", None)
 

--- a/qlib/log.py
+++ b/qlib/log.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 
+import copy
 import json
 import logging
 from typing import Optional, Text, Dict, Any
@@ -14,6 +15,7 @@ from .config import C
 
 
 _LOG_RECORD_ATTRIBUTES = frozenset(logging.makeLogRecord({}).__dict__)
+_STRUCTURED_LOGGING_FORMAT = "json"
 
 
 class JSONFormatter(logging.Formatter):
@@ -38,6 +40,43 @@ class JSONFormatter(logging.Formatter):
             log_data["exception"] = self.formatException(record.exc_info)
 
         return json.dumps(log_data, default=str)
+
+
+def _normalize_logging_config(log_config: Dict[Text, Any]) -> Dict[Text, Any]:
+    """Normalize Qlib's logging config before passing it to ``dictConfig``.
+
+    Qlib continues to accept a standard ``logging.config.dictConfig`` mapping.
+    In addition, users can opt into structured JSON logs with a compact config:
+
+    .. code-block:: python
+
+        qlib.init(logging_config={"structured": True, "format": "json"})
+
+    The compact config reuses Qlib's default handlers and only swaps their
+    formatter to :class:`JSONFormatter`.
+    """
+    if not isinstance(log_config, dict):
+        return log_config
+
+    is_dict_config = "version" in log_config
+    structured = bool(log_config.get("structured", False))
+
+    if not structured:
+        return copy.deepcopy(log_config)
+
+    log_format = log_config.get("format", _STRUCTURED_LOGGING_FORMAT)
+    if log_format != _STRUCTURED_LOGGING_FORMAT:
+        raise ValueError(f"Unsupported structured logging format: {log_format}")
+
+    normalized_config = copy.deepcopy(log_config if is_dict_config else C.logging_config)
+    normalized_config.pop("structured", None)
+    normalized_config.pop("format", None)
+
+    normalized_config.setdefault("formatters", {})[_STRUCTURED_LOGGING_FORMAT] = {"()": "qlib.log.JSONFormatter"}
+    for handler_config in normalized_config.get("handlers", {}).values():
+        handler_config["formatter"] = _STRUCTURED_LOGGING_FORMAT
+
+    return normalized_config
 
 
 class MetaLogger(type):
@@ -183,6 +222,7 @@ def set_log_with_config(log_config: Dict[Text, Any]):
     :param log_config:
     :return:
     """
+    log_config = _normalize_logging_config(log_config)
     logging_config.dictConfig(log_config)
 
 

--- a/qlib/log.py
+++ b/qlib/log.py
@@ -28,6 +28,13 @@ class JSONFormatter(logging.Formatter):
             "logger": record.name,
             "message": record.getMessage(),
         }
+        try:
+            from .trace import get_current_trace_context  # pylint: disable=C0415
+
+            log_data.update(get_current_trace_context())
+        except Exception:
+            pass
+
         log_data.update(
             {
                 key: value

--- a/qlib/metrics.py
+++ b/qlib/metrics.py
@@ -1,0 +1,134 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+from contextlib import contextmanager
+from threading import RLock
+from typing import Any, Dict, Iterator, Optional
+
+
+class NoOpMetricsRecorder:
+    """Metrics recorder used when observability metrics are disabled."""
+
+    enabled = False
+
+    def increment(self, name: str, value: float = 1, tags: Optional[Dict[str, Any]] = None) -> None:
+        return None
+
+    def gauge(self, name: str, value: float, tags: Optional[Dict[str, Any]] = None) -> None:
+        return None
+
+    def timing(self, name: str, value: float, tags: Optional[Dict[str, Any]] = None) -> None:
+        return None
+
+    @contextmanager
+    def timer(self, name: str, tags: Optional[Dict[str, Any]] = None) -> Iterator[None]:
+        yield None
+
+    def snapshot(self) -> Dict[str, Dict[str, Any]]:
+        return {"counters": {}, "gauges": {}, "timings": {}}
+
+    def reset(self) -> None:
+        return None
+
+
+class InMemoryMetricsRecorder:
+    """Small in-memory metrics recorder for lightweight Qlib observability.
+
+    This recorder intentionally has no external service dependency. It gives
+    Qlib a testable metrics foundation that can later be exported to logs,
+    experiment recorders, or monitoring backends.
+    """
+
+    enabled = True
+
+    def __init__(self) -> None:
+        self._lock = RLock()
+        self._counters = defaultdict(float)
+        self._gauges = {}
+        self._timings = {}
+
+    @staticmethod
+    def _metric_key(name: str, tags: Optional[Dict[str, Any]] = None) -> str:
+        if not tags:
+            return name
+        tag_str = ",".join(f"{key}={tags[key]}" for key in sorted(tags))
+        return f"{name}{{{tag_str}}}"
+
+    def increment(self, name: str, value: float = 1, tags: Optional[Dict[str, Any]] = None) -> None:
+        key = self._metric_key(name, tags)
+        with self._lock:
+            self._counters[key] += value
+
+    def gauge(self, name: str, value: float, tags: Optional[Dict[str, Any]] = None) -> None:
+        key = self._metric_key(name, tags)
+        with self._lock:
+            self._gauges[key] = value
+
+    def timing(self, name: str, value: float, tags: Optional[Dict[str, Any]] = None) -> None:
+        key = self._metric_key(name, tags)
+        with self._lock:
+            stats = self._timings.setdefault(
+                key,
+                {
+                    "count": 0,
+                    "total": 0.0,
+                    "last": None,
+                    "min": None,
+                    "max": None,
+                },
+            )
+            stats["count"] += 1
+            stats["total"] += value
+            stats["last"] = value
+            stats["min"] = value if stats["min"] is None else min(stats["min"], value)
+            stats["max"] = value if stats["max"] is None else max(stats["max"], value)
+
+    @contextmanager
+    def timer(self, name: str, tags: Optional[Dict[str, Any]] = None) -> Iterator[None]:
+        start = time.perf_counter()
+        try:
+            yield None
+        finally:
+            self.timing(name, time.perf_counter() - start, tags=tags)
+
+    def snapshot(self) -> Dict[str, Dict[str, Any]]:
+        with self._lock:
+            return {
+                "counters": dict(self._counters),
+                "gauges": dict(self._gauges),
+                "timings": {name: dict(stats) for name, stats in self._timings.items()},
+            }
+
+    def reset(self) -> None:
+        with self._lock:
+            self._counters.clear()
+            self._gauges.clear()
+            self._timings.clear()
+
+
+_NOOP_RECORDER = NoOpMetricsRecorder()
+_METRICS_RECORDER = _NOOP_RECORDER
+
+
+def configure_metrics(metrics_config: Optional[Dict[str, Any]] = None) -> None:
+    """Configure Qlib's process-local metrics recorder.
+
+    Metrics are disabled by default. Passing ``{"enabled": True}`` enables an
+    in-memory recorder that can be inspected through ``snapshot()``.
+    """
+    global _METRICS_RECORDER
+
+    metrics_config = metrics_config or {}
+    if metrics_config.get("enabled", False):
+        _METRICS_RECORDER = InMemoryMetricsRecorder()
+    else:
+        _METRICS_RECORDER = _NOOP_RECORDER
+
+
+def get_metrics_recorder():
+    """Return the active metrics recorder."""
+    return _METRICS_RECORDER

--- a/qlib/metrics.py
+++ b/qlib/metrics.py
@@ -7,7 +7,7 @@ import time
 from collections import defaultdict
 from contextlib import contextmanager
 from threading import RLock
-from typing import Any, Dict, Iterator, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 
 class NoOpMetricsRecorder:
@@ -30,6 +30,15 @@ class NoOpMetricsRecorder:
 
     def snapshot(self) -> Dict[str, Dict[str, Any]]:
         return {"counters": {}, "gauges": {}, "timings": {}}
+
+    def export(self) -> Dict[str, Dict[str, Any]]:
+        return self.snapshot()
+
+    def summary(self) -> List[str]:
+        return []
+
+    def log_summary(self, logger=None) -> None:
+        return None
 
     def reset(self) -> None:
         return None
@@ -102,6 +111,42 @@ class InMemoryMetricsRecorder:
                 "gauges": dict(self._gauges),
                 "timings": {name: dict(stats) for name, stats in self._timings.items()},
             }
+
+    def export(self) -> Dict[str, Dict[str, Any]]:
+        """Export collected metrics as a plain dictionary."""
+        return self.snapshot()
+
+    def summary(self) -> List[str]:
+        """Return a human-readable metrics summary."""
+        snapshot = self.snapshot()
+        lines = []
+
+        for name, value in sorted(snapshot["counters"].items()):
+            lines.append(f"counter {name}={value:g}")
+
+        for name, value in sorted(snapshot["gauges"].items()):
+            lines.append(f"gauge {name}={value:g}")
+
+        for name, stats in sorted(snapshot["timings"].items()):
+            count = stats["count"]
+            avg = stats["total"] / count if count else 0
+            lines.append(
+                "timing "
+                f"{name} count={count} total={stats['total']:.6f}s avg={avg:.6f}s "
+                f"min={stats['min']:.6f}s max={stats['max']:.6f}s last={stats['last']:.6f}s"
+            )
+
+        return lines
+
+    def log_summary(self, logger=None) -> None:
+        """Log a human-readable metrics summary."""
+        if logger is None:
+            from qlib.log import get_module_logger  # pylint: disable=C0415
+
+            logger = get_module_logger("metrics")
+
+        for line in self.summary():
+            logger.info(line)
 
     def reset(self) -> None:
         with self._lock:

--- a/qlib/trace.py
+++ b/qlib/trace.py
@@ -1,0 +1,88 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from __future__ import annotations
+
+import uuid
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any, Dict, Iterator, Optional
+
+
+@dataclass(frozen=True)
+class TraceSpan:
+    """A lightweight trace span used to connect related Qlib logs."""
+
+    name: str
+    trace_id: str
+    span_id: str
+    parent_span_id: Optional[str] = None
+
+    def to_log_fields(self) -> Dict[str, str]:
+        fields = {
+            "trace_id": self.trace_id,
+            "span_id": self.span_id,
+            "span_name": self.name,
+        }
+        if self.parent_span_id is not None:
+            fields["parent_span_id"] = self.parent_span_id
+        return fields
+
+
+_TRACING_ENABLED = False
+_CURRENT_SPAN: ContextVar[Optional[TraceSpan]] = ContextVar("qlib_current_trace_span", default=None)
+
+
+def configure_tracing(tracing_config: Optional[Dict[str, Any]] = None) -> None:
+    """Configure lightweight Qlib tracing.
+
+    Tracing is disabled by default. Passing ``{"enabled": True}`` enables span
+    creation through :func:`trace_span`.
+    """
+    global _TRACING_ENABLED
+
+    tracing_config = tracing_config or {}
+    _TRACING_ENABLED = bool(tracing_config.get("enabled", False))
+    if not _TRACING_ENABLED:
+        _CURRENT_SPAN.set(None)
+
+
+def is_tracing_enabled() -> bool:
+    return _TRACING_ENABLED
+
+
+def get_current_span() -> Optional[TraceSpan]:
+    if not _TRACING_ENABLED:
+        return None
+    return _CURRENT_SPAN.get()
+
+
+def get_current_trace_context() -> Dict[str, str]:
+    span = get_current_span()
+    return {} if span is None else span.to_log_fields()
+
+
+@contextmanager
+def trace_span(name: str, trace_id: Optional[str] = None) -> Iterator[Optional[TraceSpan]]:
+    """Create a lightweight trace span when tracing is enabled.
+
+    When tracing is disabled, this context manager yields ``None`` and has no
+    logging side effects.
+    """
+    if not _TRACING_ENABLED:
+        yield None
+        return
+
+    parent_span = _CURRENT_SPAN.get()
+    span = TraceSpan(
+        name=name,
+        trace_id=trace_id or (parent_span.trace_id if parent_span is not None else uuid.uuid4().hex),
+        span_id=uuid.uuid4().hex,
+        parent_span_id=parent_span.span_id if parent_span is not None else None,
+    )
+    token = _CURRENT_SPAN.set(span)
+    try:
+        yield span
+    finally:
+        _CURRENT_SPAN.reset(token)

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,8 +1,11 @@
 import io
 import json
 import logging
+import logging.config
 from contextlib import contextmanager
+from unittest.mock import patch
 
+from qlib.config import C
 from qlib.log import JSONFormatter, get_module_logger, set_log_with_config
 from qlib.trace import configure_tracing, trace_span
 
@@ -86,6 +89,23 @@ def test_structured_logging_can_be_enabled_with_compact_config(capsys):
         qlib_logger.handlers = original_handlers
         qlib_logger.setLevel(original_level)
         qlib_logger.propagate = original_propagate
+
+
+def test_compact_structured_logging_config_expands_when_stored_on_global_config():
+    original_logging_config = C.logging_config
+    compact_config = {"structured": True, "format": "json"}
+
+    try:
+        C.logging_config = compact_config
+        with patch.object(logging.config, "dictConfig") as dict_config:
+            set_log_with_config(compact_config)
+
+        normalized_config = dict_config.call_args.args[0]
+        assert normalized_config["version"] == 1
+        assert normalized_config["formatters"]["json"] == {"()": "qlib.log.JSONFormatter"}
+        assert normalized_config["handlers"]["console"]["formatter"] == "json"
+    finally:
+        C.logging_config = original_logging_config
 
 
 def test_json_formatter_includes_trace_context_when_enabled():

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,0 +1,48 @@
+import io
+import json
+import logging
+from contextlib import contextmanager
+
+from qlib.log import JSONFormatter, get_module_logger
+
+
+@contextmanager
+def _logger_with_handler(name, formatter):
+    logger = get_module_logger(name, level=logging.INFO)
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(formatter)
+    logger.logger.handlers = [handler]
+    logger.logger.propagate = False
+    try:
+        yield logger, stream
+    finally:
+        logger.logger.handlers = []
+
+
+def test_default_logging_remains_plain_text():
+    formatter = logging.Formatter("%(levelname)s: %(message)s")
+    with _logger_with_handler("test.default_logging", formatter) as (logger, stream):
+        logger.info("Dataset loaded")
+
+        assert stream.getvalue().strip() == "INFO: Dataset loaded"
+
+
+def test_json_formatter_produces_structured_output():
+    with _logger_with_handler("test.structured_logging", JSONFormatter()) as (logger, stream):
+        logger.info("Dataset loaded")
+
+        output = json.loads(stream.getvalue())
+        assert output["level"] == "INFO"
+        assert output["logger"] == "qlib.test.structured_logging"
+        assert output["message"] == "Dataset loaded"
+        assert "timestamp" in output
+
+
+def test_json_formatter_includes_extra_fields():
+    with _logger_with_handler("test.structured_extra", JSONFormatter()) as (logger, stream):
+        logger.info("Dataset loaded", extra={"dataset_size": 100, "cache_hit": True})
+
+        output = json.loads(stream.getvalue())
+        assert output["dataset_size"] == 100
+        assert output["cache_hit"] is True

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -4,6 +4,7 @@ import logging
 from contextlib import contextmanager
 
 from qlib.log import JSONFormatter, get_module_logger, set_log_with_config
+from qlib.trace import configure_tracing, trace_span
 
 
 @contextmanager
@@ -18,6 +19,7 @@ def _logger_with_handler(name, formatter):
         yield logger, stream
     finally:
         logger.logger.handlers = []
+        configure_tracing({"enabled": False})
 
 
 def test_default_logging_remains_plain_text():
@@ -84,3 +86,29 @@ def test_structured_logging_can_be_enabled_with_compact_config(capsys):
         qlib_logger.handlers = original_handlers
         qlib_logger.setLevel(original_level)
         qlib_logger.propagate = original_propagate
+
+
+def test_json_formatter_includes_trace_context_when_enabled():
+    configure_tracing({"enabled": True})
+
+    with _logger_with_handler("test.structured_trace", JSONFormatter()) as (logger, stream):
+        with trace_span("dataset.prepare", trace_id="trace-1") as span:
+            logger.info("Preparing dataset")
+
+        output = json.loads(stream.getvalue())
+        assert output["trace_id"] == "trace-1"
+        assert output["span_id"] == span.span_id
+        assert output["span_name"] == "dataset.prepare"
+
+
+def test_json_formatter_omits_trace_context_when_disabled():
+    configure_tracing({"enabled": False})
+
+    with _logger_with_handler("test.no_trace", JSONFormatter()) as (logger, stream):
+        with trace_span("dataset.prepare"):
+            logger.info("Preparing dataset")
+
+        output = json.loads(stream.getvalue())
+        assert "trace_id" not in output
+        assert "span_id" not in output
+        assert "span_name" not in output

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -3,7 +3,7 @@ import json
 import logging
 from contextlib import contextmanager
 
-from qlib.log import JSONFormatter, get_module_logger
+from qlib.log import JSONFormatter, get_module_logger, set_log_with_config
 
 
 @contextmanager
@@ -46,3 +46,41 @@ def test_json_formatter_includes_extra_fields():
         output = json.loads(stream.getvalue())
         assert output["dataset_size"] == 100
         assert output["cache_hit"] is True
+
+
+def test_json_formatter_includes_exception_details():
+    with _logger_with_handler("test.structured_exception", JSONFormatter()) as (logger, stream):
+        try:
+            raise ValueError("bad dataset")
+        except ValueError:
+            logger.exception("Dataset load failed")
+
+        output = json.loads(stream.getvalue())
+        assert output["level"] == "ERROR"
+        assert output["message"] == "Dataset load failed"
+        assert "ValueError: bad dataset" in output["exception"]
+
+
+def test_structured_logging_can_be_enabled_with_compact_config(capsys):
+    qlib_logger = logging.getLogger("qlib")
+    original_handlers = qlib_logger.handlers[:]
+    original_level = qlib_logger.level
+    original_propagate = qlib_logger.propagate
+
+    try:
+        set_log_with_config({"structured": True, "format": "json"})
+        logger = get_module_logger("test.configured_structured", level=logging.INFO)
+        logger.info("Configured JSON logging", extra={"run_id": "abc123"})
+
+        captured = capsys.readouterr()
+        output = captured.err.strip() or captured.out.strip()
+        log_data = json.loads(output.splitlines()[-1])
+
+        assert log_data["level"] == "INFO"
+        assert log_data["logger"] == "qlib.test.configured_structured"
+        assert log_data["message"] == "Configured JSON logging"
+        assert log_data["run_id"] == "abc123"
+    finally:
+        qlib_logger.handlers = original_handlers
+        qlib_logger.setLevel(original_level)
+        qlib_logger.propagate = original_propagate

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,73 @@
+from qlib.config import C
+from qlib.metrics import configure_metrics, get_metrics_recorder
+
+
+def teardown_function():
+    configure_metrics({"enabled": False})
+    C.reset()
+
+
+def test_metrics_are_disabled_by_default():
+    configure_metrics({"enabled": False})
+
+    metrics = get_metrics_recorder()
+    metrics.increment("qlib.cache.hit")
+    metrics.gauge("qlib.memory.usage_mb", 128)
+    metrics.timing("qlib.data.load_seconds", 0.25)
+
+    assert metrics.enabled is False
+    assert metrics.snapshot() == {"counters": {}, "gauges": {}, "timings": {}}
+
+
+def test_enabled_metrics_record_counters_gauges_and_timings():
+    configure_metrics({"enabled": True})
+
+    metrics = get_metrics_recorder()
+    metrics.increment("qlib.cache.hit")
+    metrics.increment("qlib.cache.hit", 2)
+    metrics.gauge("qlib.memory.usage_mb", 128)
+    metrics.timing("qlib.data.load_seconds", 0.25)
+    metrics.timing("qlib.data.load_seconds", 0.75)
+
+    snapshot = metrics.snapshot()
+    assert snapshot["counters"]["qlib.cache.hit"] == 3
+    assert snapshot["gauges"]["qlib.memory.usage_mb"] == 128
+    assert snapshot["timings"]["qlib.data.load_seconds"] == {
+        "count": 2,
+        "total": 1.0,
+        "last": 0.75,
+        "min": 0.25,
+        "max": 0.75,
+    }
+
+
+def test_metrics_support_tags():
+    configure_metrics({"enabled": True})
+
+    metrics = get_metrics_recorder()
+    metrics.increment("qlib.cache.hit", tags={"provider": "local", "freq": "day"})
+
+    assert metrics.snapshot()["counters"]["qlib.cache.hit{freq=day,provider=local}"] == 1
+
+
+def test_metrics_timer_context_records_elapsed_time():
+    configure_metrics({"enabled": True})
+
+    metrics = get_metrics_recorder()
+    with metrics.timer("qlib.workflow.step_seconds"):
+        pass
+
+    timing = metrics.snapshot()["timings"]["qlib.workflow.step_seconds"]
+    assert timing["count"] == 1
+    assert timing["total"] >= 0
+    assert timing["last"] >= 0
+
+
+def test_metrics_can_be_enabled_from_qlib_config():
+    C.set(metrics_config={"enabled": True})
+
+    metrics = get_metrics_recorder()
+    metrics.increment("qlib.config.enabled")
+
+    assert metrics.enabled is True
+    assert metrics.snapshot()["counters"]["qlib.config.enabled"] == 1

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,10 +1,39 @@
+import pandas as pd
+
 from qlib.config import C
+from qlib.data.cache import H, MemoryCalendarCache, SimpleDatasetCache
 from qlib.metrics import configure_metrics, get_metrics_recorder
 
 
 def teardown_function():
     configure_metrics({"enabled": False})
+    H.clear()
     C.reset()
+
+
+class FakeDatasetProvider:
+    def __init__(self):
+        self.calls = 0
+
+    def dataset(self, instruments, fields, start_time=None, end_time=None, freq="day", inst_processors=[]):
+        self.calls += 1
+        index = pd.MultiIndex.from_product(
+            [["SH600000"], [pd.Timestamp("2020-01-01")]], names=["instrument", "datetime"]
+        )
+        return pd.DataFrame([[1.0]], index=index, columns=fields)
+
+
+class FakeCalendarProvider:
+    def __init__(self):
+        self.calls = 0
+
+    @staticmethod
+    def _uri(start_time=None, end_time=None, freq="day", future=False):
+        return f"{start_time}:{end_time}:{freq}:{future}"
+
+    def calendar(self, start_time=None, end_time=None, freq="day", future=False):
+        self.calls += 1
+        return [pd.Timestamp("2020-01-01")]
 
 
 def test_metrics_are_disabled_by_default():
@@ -71,3 +100,34 @@ def test_metrics_can_be_enabled_from_qlib_config():
 
     assert metrics.enabled is True
     assert metrics.snapshot()["counters"]["qlib.config.enabled"] == 1
+
+
+def test_simple_dataset_cache_emits_hit_miss_and_timing_metrics(tmp_path):
+    C["local_cache_path"] = str(tmp_path)
+    configure_metrics({"enabled": True})
+    provider = FakeDatasetProvider()
+    cache = SimpleDatasetCache(provider)
+
+    cache.dataset(["SH600000"], ["close"], freq="day")
+    cache.dataset(["SH600000"], ["close"], freq="day")
+
+    snapshot = get_metrics_recorder().snapshot()
+    assert provider.calls == 1
+    assert snapshot["counters"]["qlib.cache.dataset.miss{cache=simple,freq=day}"] == 1
+    assert snapshot["counters"]["qlib.cache.dataset.hit{cache=simple,freq=day}"] == 1
+    assert snapshot["timings"]["qlib.cache.dataset.load_seconds{cache=simple,freq=day}"]["count"] == 2
+
+
+def test_memory_calendar_cache_emits_hit_miss_and_timing_metrics():
+    configure_metrics({"enabled": True})
+    provider = FakeCalendarProvider()
+    cache = MemoryCalendarCache(provider)
+
+    cache.calendar(freq="day")
+    cache.calendar(freq="day")
+
+    snapshot = get_metrics_recorder().snapshot()
+    assert provider.calls == 1
+    assert snapshot["counters"]["qlib.cache.calendar.miss{cache=memory,freq=day}"] == 1
+    assert snapshot["counters"]["qlib.cache.calendar.hit{cache=memory,freq=day}"] == 1
+    assert snapshot["timings"]["qlib.cache.calendar.load_seconds{cache=memory,freq=day}"]["count"] == 2

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -3,10 +3,12 @@ import pandas as pd
 from qlib.config import C
 from qlib.data.cache import H, MemoryCalendarCache, SimpleDatasetCache
 from qlib.metrics import configure_metrics, get_metrics_recorder
+from qlib.trace import configure_tracing, get_current_trace_context
 
 
 def teardown_function():
     configure_metrics({"enabled": False})
+    configure_tracing({"enabled": False})
     H.clear()
     C.reset()
 
@@ -14,9 +16,11 @@ def teardown_function():
 class FakeDatasetProvider:
     def __init__(self):
         self.calls = 0
+        self.trace_contexts = []
 
     def dataset(self, instruments, fields, start_time=None, end_time=None, freq="day", inst_processors=[]):
         self.calls += 1
+        self.trace_contexts.append(get_current_trace_context())
         index = pd.MultiIndex.from_product(
             [["SH600000"], [pd.Timestamp("2020-01-01")]], names=["instrument", "datetime"]
         )
@@ -26,6 +30,7 @@ class FakeDatasetProvider:
 class FakeCalendarProvider:
     def __init__(self):
         self.calls = 0
+        self.trace_contexts = []
 
     @staticmethod
     def _uri(start_time=None, end_time=None, freq="day", future=False):
@@ -33,6 +38,7 @@ class FakeCalendarProvider:
 
     def calendar(self, start_time=None, end_time=None, freq="day", future=False):
         self.calls += 1
+        self.trace_contexts.append(get_current_trace_context())
         return [pd.Timestamp("2020-01-01")]
 
 
@@ -164,6 +170,19 @@ def test_simple_dataset_cache_emits_hit_miss_and_timing_metrics(tmp_path):
     assert snapshot["timings"]["qlib.cache.dataset.load_seconds{cache=simple,freq=day}"]["count"] == 2
 
 
+def test_simple_dataset_cache_executes_provider_inside_trace_span(tmp_path):
+    C["local_cache_path"] = str(tmp_path)
+    configure_tracing({"enabled": True})
+    provider = FakeDatasetProvider()
+    cache = SimpleDatasetCache(provider)
+
+    cache.dataset(["SH600000"], ["close"], freq="day")
+
+    assert provider.trace_contexts[0]["span_name"] == "cache.dataset"
+    assert "trace_id" in provider.trace_contexts[0]
+    assert "span_id" in provider.trace_contexts[0]
+
+
 def test_memory_calendar_cache_emits_hit_miss_and_timing_metrics():
     configure_metrics({"enabled": True})
     provider = FakeCalendarProvider()
@@ -177,3 +196,15 @@ def test_memory_calendar_cache_emits_hit_miss_and_timing_metrics():
     assert snapshot["counters"]["qlib.cache.calendar.miss{cache=memory,freq=day}"] == 1
     assert snapshot["counters"]["qlib.cache.calendar.hit{cache=memory,freq=day}"] == 1
     assert snapshot["timings"]["qlib.cache.calendar.load_seconds{cache=memory,freq=day}"]["count"] == 2
+
+
+def test_memory_calendar_cache_executes_provider_inside_trace_span():
+    configure_tracing({"enabled": True})
+    provider = FakeCalendarProvider()
+    cache = MemoryCalendarCache(provider)
+
+    cache.calendar(freq="day")
+
+    assert provider.trace_contexts[0]["span_name"] == "cache.calendar"
+    assert "trace_id" in provider.trace_contexts[0]
+    assert "span_id" in provider.trace_contexts[0]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -36,6 +36,14 @@ class FakeCalendarProvider:
         return [pd.Timestamp("2020-01-01")]
 
 
+class FakeLogger:
+    def __init__(self):
+        self.messages = []
+
+    def info(self, message):
+        self.messages.append(message)
+
+
 def test_metrics_are_disabled_by_default():
     configure_metrics({"enabled": False})
 
@@ -100,6 +108,44 @@ def test_metrics_can_be_enabled_from_qlib_config():
 
     assert metrics.enabled is True
     assert metrics.snapshot()["counters"]["qlib.config.enabled"] == 1
+
+
+def test_metrics_export_returns_snapshot():
+    configure_metrics({"enabled": True})
+
+    metrics = get_metrics_recorder()
+    metrics.increment("qlib.cache.hit")
+    metrics.gauge("qlib.memory.usage_mb", 128)
+    metrics.timing("qlib.data.load_seconds", 0.25)
+
+    assert metrics.export() == metrics.snapshot()
+
+
+def test_metrics_summary_formats_collected_metrics():
+    configure_metrics({"enabled": True})
+
+    metrics = get_metrics_recorder()
+    metrics.increment("qlib.cache.hit", 2)
+    metrics.gauge("qlib.memory.usage_mb", 128)
+    metrics.timing("qlib.data.load_seconds", 0.25)
+    metrics.timing("qlib.data.load_seconds", 0.75)
+
+    assert metrics.summary() == [
+        "counter qlib.cache.hit=2",
+        "gauge qlib.memory.usage_mb=128",
+        "timing qlib.data.load_seconds count=2 total=1.000000s avg=0.500000s min=0.250000s max=0.750000s last=0.750000s",
+    ]
+
+
+def test_metrics_log_summary_writes_to_logger():
+    configure_metrics({"enabled": True})
+
+    metrics = get_metrics_recorder()
+    metrics.increment("qlib.cache.hit")
+    logger = FakeLogger()
+    metrics.log_summary(logger)
+
+    assert logger.messages == ["counter qlib.cache.hit=1"]
 
 
 def test_simple_dataset_cache_emits_hit_miss_and_timing_metrics(tmp_path):

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -1,0 +1,53 @@
+from qlib.config import C
+from qlib.trace import configure_tracing, get_current_span, get_current_trace_context, is_tracing_enabled, trace_span
+
+
+def teardown_function():
+    configure_tracing({"enabled": False})
+    C.reset()
+
+
+def test_trace_span_is_noop_when_tracing_disabled():
+    configure_tracing({"enabled": False})
+
+    with trace_span("dataset.prepare") as span:
+        assert span is None
+        assert get_current_span() is None
+        assert get_current_trace_context() == {}
+
+
+def test_trace_span_creates_context_when_enabled():
+    configure_tracing({"enabled": True})
+
+    with trace_span("dataset.prepare", trace_id="trace-1") as span:
+        assert span is not None
+        assert span.name == "dataset.prepare"
+        assert span.trace_id == "trace-1"
+        assert get_current_span() == span
+        assert get_current_trace_context() == {
+            "trace_id": span.trace_id,
+            "span_id": span.span_id,
+            "span_name": "dataset.prepare",
+        }
+
+    assert get_current_span() is None
+
+
+def test_nested_trace_spans_share_trace_id_and_set_parent():
+    configure_tracing({"enabled": True})
+
+    with trace_span("workflow") as parent:
+        with trace_span("dataset.prepare") as child:
+            assert child.trace_id == parent.trace_id
+            assert child.parent_span_id == parent.span_id
+            assert get_current_trace_context()["parent_span_id"] == parent.span_id
+
+        assert get_current_span() == parent
+
+
+def test_tracing_can_be_enabled_from_qlib_config():
+    C.set(tracing_config={"enabled": True})
+
+    assert is_tracing_enabled() is True
+    with trace_span("model.fit") as span:
+        assert span is not None


### PR DESCRIPTION
# feat(observability): add opt-in structured logging, metrics, and tracing

## Description

This PR adds an opt-in observability foundation for Qlib.

It introduces structured JSON logging, lightweight metrics collection, metrics export/reporting, and basic trace/span support while preserving Qlib's existing default logging behavior.

Main changes:

- Added `JSONFormatter` for structured JSON logs.
- Added compact structured logging config support:

```python
qlib.init(logging_config={"structured": True, "format": "json"})
```

- Added lightweight metrics support:

```python
qlib.init(metrics_config={"enabled": True})
```

- Added counters, gauges, timings, timer context manager, export, and summary reporting.
- Added cache instrumentation for dataset/calendar cache hit, miss, and load duration metrics.
- Added lightweight tracing support:

```python
qlib.init(tracing_config={"enabled": True})
```

- Added `trace_span(...)` context manager.
- Added trace fields to structured logs when tracing is enabled.
- Added trace spans around cache dataset/calendar operations.

## Motivation and Context

Related to #2098.

Qlib currently has plain-text logging and some isolated timing/experiment metrics, but it does not have a unified opt-in observability layer for structured logs, runtime metrics, and trace context.

This PR keeps observability disabled by default and does not introduce mandatory external monitoring dependencies such as Prometheus or OpenTelemetry.

## How Has This Been Tested?

- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [x] If you are adding a new feature, test on your own test scripts.

Focused tests run:

```bash
python -m pytest tests/test_log.py tests/test_metrics.py tests/test_trace.py -q
```

Result:

```text
24 passed
```

Also manually tested with a real-data Qlib notebook using `D.features(...)` to verify structured logs, metrics export/summary, and trace spans.

## Screenshots of Test Results (if appropriate)

1. Pipeline test: Not run.
2. Your own tests:

```text
24 passed
```

## Types of changes

- [ ] Fix bugs
- [x] Add new feature
- [ ] Update documentation
