### PR TITLE
Fix typos in Qlib docs and comments

### DIFF
--- a/docs/component/workflow.rst
+++ b/docs/component/workflow.rst
@@ -127,8 +127,8 @@ Configuration File
 Let's get into details of ``qrun`` in this section.
 Before using ``qrun``, users need to prepare a configuration file. The following content shows how to prepare each part of the configuration file.
 
-The design logic of the configuration file is very simple. It predefines fixed workflows and provide this yaml interface to users to define how to initialize each component.
-It follow the design of `init_instance_by_config <https://github.com/microsoft/qlib/blob/2aee9e0145decc3e71def70909639b5e5a6f4b58/qlib/utils/__init__.py#L264>`_ .  It defines the initialization of each component of Qlib, which typically include the class and the initialization arguments.
+The design logic of the configuration file is very simple. It predefines fixed workflows and provides this YAML interface to users to define how to initialize each component.
+It follows the design of `init_instance_by_config <https://github.com/microsoft/qlib/blob/2aee9e0145decc3e71def70909639b5e5a6f4b58/qlib/utils/__init__.py#L264>`_ .  It defines the initialization of each component of Qlib, which typically includes the class and the initialization arguments.
 
 For example, the following yaml and code are equivalent.
 

--- a/docs/hidden/client.rst
+++ b/docs/hidden/client.rst
@@ -16,7 +16,7 @@ Client-Server is designed to solve following  problems
 Therefore, we designed the client-server framework to solve these problems.
 We will maintain a server and provide the data.
 
-You have to initialize you qlib with specific config for using the client-server framework.
+You have to initialize Qlib with a specific config for using the client-server framework.
 Here is a typical initialization process.
 
 qlib ``init`` commonly used parameters; ``nfs-common`` must be installed on the server where the client is located, execute: ``sudo apt install nfs-common``:

--- a/qlib/contrib/evaluate.py
+++ b/qlib/contrib/evaluate.py
@@ -154,7 +154,7 @@ def backtest_daily(
     exchange_kwargs: dict = None,
     pos_type: str = "Position",
 ):
-    """initialize the strategy and executor, then executor the backtest of daily frequency
+    """initialize the strategy and executor, then execute the backtest of daily frequency
 
     Parameters
     ----------

--- a/qlib/utils/__init__.py
+++ b/qlib/utils/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# TODO: this utils covers too much utilities, please seperat it into sub modules
+# TODO: this utils covers too many utilities, please separate it into submodules
 
 from __future__ import division
 from __future__ import print_function

--- a/qlib/utils/mod.py
+++ b/qlib/utils/mod.py
@@ -145,8 +145,8 @@ def init_instance_by_config(
         This will be passed into the second parameter of isinstance.
 
     try_kwargs: Dict
-        Try to pass in kwargs in `try_kwargs` when initialized the instance
-        If error occurred, it will fail back to initialization without try_kwargs.
+        Try to pass in kwargs in `try_kwargs` when initializing the instance
+        If an error occurs, it will fall back to initialization without try_kwargs.
 
     Returns
     -------


### PR DESCRIPTION
Summary
- Fixes several small typos and grammar issues in docs and comments.
- Keeps the changes limited to wording; no runtime logic is changed.

Testing
- Ran `git diff --check`.

Thanks for maintaining Qlib.