### PR TITLE
fix: resolve pylint issues R1705, R1725, R1735

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,10 +123,8 @@ black:
 # 	C0103: invalid-name
 # 	C0209: consider-using-f-string
 # 	R0402: consider-using-from-import
-# 	R1705: no-else-return
 # 	R1710: inconsistent-return-statements
-# 	R1725: super-with-arguments
-# 	R1735: use-dict-literal
+# 	R1730: consider-using-ternary
 # 	W0102: dangerous-default-value
 # 	W0212: protected-access
 # 	W0221: arguments-differ
@@ -148,8 +146,8 @@ black:
 # We use sys.setrecursionlimit(2000) to make the recursion depth larger to ensure that pylint works properly (the default recursion depth is 1000).
 # References for parameters: https://github.com/PyCQA/pylint/issues/4577#issuecomment-1000245962
 pylint:
-	pylint --disable=C0104,C0114,C0115,C0116,C0301,C0302,C0411,C0413,C1802,R0401,R0801,R0902,R0903,R0911,R0912,R0913,R0914,R0915,R0917,R1720,W0105,W0123,W0201,W0511,W0613,W1113,W1514,W4904,E0401,E1121,C0103,C0209,R0402,R1705,R1710,R1725,R1730,R1735,W0102,W0212,W0221,W0223,W0231,W0237,W0612,W0621,W0622,W0703,W1309,E1102,E1136 --const-rgx='[a-z_][a-z0-9_]{2,30}' qlib --init-hook="import astroid; astroid.context.InferenceContext.max_inferred = 500; import sys; sys.setrecursionlimit(2000)"
-	pylint --disable=C0104,C0114,C0115,C0116,C0301,C0302,C0411,C0413,C1802,R0401,R0801,R0902,R0903,R0911,R0912,R0913,R0914,R0915,R0917,R1720,W0105,W0123,W0201,W0511,W0613,W1113,W1514,E0401,E1121,E1123,C0103,C0209,R0402,R1705,R1710,R1725,R1735,W0102,W0212,W0221,W0223,W0231,W0237,W0246,W0612,W0621,W0622,W0703,W1309,E1102,E1136 --const-rgx='[a-z_][a-z0-9_]{2,30}' scripts --init-hook="import astroid; astroid.context.InferenceContext.max_inferred = 500; import sys; sys.setrecursionlimit(2000)"
+	pylint --disable=C0104,C0114,C0115,C0116,C0301,C0302,C0411,C0413,C1802,R0401,R0801,R0902,R0903,R0911,R0912,R0913,R0914,R0915,R0917,R1720,W0105,W0123,W0201,W0511,W0613,W1113,W1514,W4904,E0401,E1121,C0103,C0209,R0402,R1710,R1730,W0102,W0212,W0221,W0223,W0231,W0237,W0612,W0621,W0622,W0703,W1309,E1102,E1136 --const-rgx='[a-z_][a-z0-9_]{2,30}' qlib --init-hook="import astroid; astroid.context.InferenceContext.max_inferred = 500; import sys; sys.setrecursionlimit(2000)"
+	pylint --disable=C0104,C0114,C0115,C0116,C0301,C0302,C0411,C0413,C1802,R0401,R0801,R0902,R0903,R0911,R0912,R0913,R0914,R0915,R0917,R1720,W0105,W0123,W0201,W0511,W0613,W1113,W1514,E0401,E1121,E1123,C0103,C0209,R0402,R1710,R1730,W0102,W0212,W0221,W0223,W0231,W0237,W0246,W0612,W0621,W0622,W0703,W1309,E1102,E1136 --const-rgx='[a-z_][a-z0-9_]{2,30}' scripts --init-hook="import astroid; astroid.context.InferenceContext.max_inferred = 500; import sys; sys.setrecursionlimit(2000)"
 
 # Check code with flake8.
 # The following flake8 error codes were ignored:

--- a/qlib/backtest/__init__.py
+++ b/qlib/backtest/__init__.py
@@ -106,8 +106,7 @@ def get_exchange(
             **kwargs,
         )
         return exchange
-    else:
-        return init_instance_by_config(exchange, accept_types=Exchange)
+    return init_instance_by_config(exchange, accept_types=Exchange)
 
 
 def create_account_instance(

--- a/qlib/backtest/account.py
+++ b/qlib/backtest/account.py
@@ -409,8 +409,7 @@ class Account:
             _portfolio_metrics = self.portfolio_metrics.generate_portfolio_metrics_dataframe()
             _positions = self.get_hist_positions()
             return _portfolio_metrics, _positions
-        else:
-            raise ValueError("generate_portfolio_metrics should be True if you want to generate portfolio_metrics")
+        raise ValueError("generate_portfolio_metrics should be True if you want to generate portfolio_metrics")
 
     def get_trade_indicator(self) -> Indicator:
         """get the trade indicator instance, which has pa/pos/ffr info."""

--- a/qlib/backtest/decision.py
+++ b/qlib/backtest/decision.py
@@ -117,23 +117,21 @@ class Order:
     def parse_dir(direction: Union[str, int, np.integer, OrderDir, np.ndarray]) -> Union[OrderDir, np.ndarray]:
         if isinstance(direction, OrderDir):
             return direction
-        elif isinstance(direction, (int, float, np.integer, np.floating)):
+        if isinstance(direction, (int, float, np.integer, np.floating)):
             return Order.BUY if direction > 0 else Order.SELL
-        elif isinstance(direction, str):
+        if isinstance(direction, str):
             dl = direction.lower().strip()
             if dl == "sell":
                 return OrderDir.SELL
-            elif dl == "buy":
+            if dl == "buy":
                 return OrderDir.BUY
-            else:
-                raise NotImplementedError(f"This type of input is not supported")
-        elif isinstance(direction, np.ndarray):
+            raise NotImplementedError(f"This type of input is not supported")
+        if isinstance(direction, np.ndarray):
             direction_array = direction.copy()
             direction_array[direction_array > 0] = Order.BUY
             direction_array[direction_array <= 0] = Order.SELL
             return direction_array
-        else:
-            raise NotImplementedError(f"This type of input is not supported")
+        raise NotImplementedError(f"This type of input is not supported")
 
     @property
     def key_by_day(self) -> tuple:
@@ -385,8 +383,7 @@ class BaseTradeDecision(Generic[DecisionType]):
     def _get_range_limit(self, **kwargs: Any) -> Tuple[int, int]:
         if self.trade_range is not None:
             return self.trade_range(trade_calendar=cast(TradeCalendarManager, kwargs.get("inner_calendar")))
-        else:
-            raise NotImplementedError("The decision didn't provide an index range")
+        raise NotImplementedError("The decision didn't provide an index range")
 
     def get_range_limit(self, **kwargs: Any) -> Tuple[int, int]:
         """
@@ -432,9 +429,8 @@ class BaseTradeDecision(Generic[DecisionType]):
         except NotImplementedError as e:
             if "default_value" in kwargs:
                 return kwargs["default_value"]
-            else:
-                # Default to get full index
-                raise NotImplementedError(f"The decision didn't provide an index range") from e
+            # Default to get full index
+            raise NotImplementedError(f"The decision didn't provide an index range") from e
 
         # clip index
         if getattr(self, "total_step", None) is not None:

--- a/qlib/backtest/exchange.py
+++ b/qlib/backtest/exchange.py
@@ -263,12 +263,11 @@ class Exchange:
         """get limit type"""
         if isinstance(limit_threshold, tuple):
             return self.LT_TP_EXP
-        elif isinstance(limit_threshold, float):
+        if isinstance(limit_threshold, float):
             return self.LT_FLT
-        elif limit_threshold is None:
+        if limit_threshold is None:
             return self.LT_NONE
-        else:
-            raise NotImplementedError(f"This type of `limit_threshold` is not supported")
+        raise NotImplementedError(f"This type of `limit_threshold` is not supported")
 
     def _update_limit(self, limit_threshold: Union[Tuple, float, None]) -> None:
         # $close may contain NaN, the nan indicates that the stock is not tradable at that timestamp
@@ -368,12 +367,11 @@ class Exchange:
             buy_limit = self.quote.get_data(stock_id, start_time, end_time, field="limit_buy", method="all")
             sell_limit = self.quote.get_data(stock_id, start_time, end_time, field="limit_sell", method="all")
             return bool(buy_limit or sell_limit)
-        elif direction == Order.BUY:
+        if direction == Order.BUY:
             return cast(bool, self.quote.get_data(stock_id, start_time, end_time, field="limit_buy", method="all"))
-        elif direction == Order.SELL:
+        if direction == Order.SELL:
             return cast(bool, self.quote.get_data(stock_id, start_time, end_time, field="limit_sell", method="all"))
-        else:
-            raise ValueError(f"direction {direction} is not supported!")
+        raise ValueError(f"direction {direction} is not supported!")
 
     def check_stock_suspended(
         self,
@@ -596,17 +594,15 @@ class Exchange:
         """
         if current_amount == target_amount:
             return 0
-        elif current_amount < target_amount:
+        if current_amount < target_amount:
             deal_amount = target_amount - current_amount
             deal_amount = self.round_amount_by_trade_unit(deal_amount, factor)
             return deal_amount
-        else:
-            if target_amount == 0:
-                return -current_amount
-            else:
-                deal_amount = current_amount - target_amount
-                deal_amount = self.round_amount_by_trade_unit(deal_amount, factor)
-                return -deal_amount
+        if target_amount == 0:
+            return -current_amount
+        deal_amount = current_amount - target_amount
+        deal_amount = self.round_amount_by_trade_unit(deal_amount, factor)
+        return -deal_amount
 
     def generate_order_for_target_amount_position(
         self,
@@ -755,8 +751,7 @@ class Exchange:
                 end_time=end_time,
             )
             return self.trade_unit / factor
-        else:
-            return None
+        return None
 
     def round_amount_by_trade_unit(
         self,

--- a/qlib/backtest/executor.py
+++ b/qlib/backtest/executor.py
@@ -360,7 +360,7 @@ class NestedExecutor(BaseExecutor):
         self._skip_empty_decision = skip_empty_decision
         self._align_range_limit = align_range_limit
 
-        super(NestedExecutor, self).__init__(
+        super().__init__(
             time_per_step=time_per_step,
             start_time=start_time,
             end_time=end_time,
@@ -380,7 +380,7 @@ class NestedExecutor(BaseExecutor):
         # NOTE: please refer to the docs of BaseExecutor.reset_common_infra for the meaning of `copy_trade_account`
 
         # The first level follow the `copy_trade_account` from the upper level
-        super(NestedExecutor, self).reset_common_infra(common_infra, copy_trade_account=copy_trade_account)
+        super().reset_common_infra(common_infra, copy_trade_account=copy_trade_account)
 
         # The lower level have to copy the trade_account
         self.inner_executor.reset_common_infra(common_infra, copy_trade_account=True)
@@ -544,7 +544,7 @@ class SimulatorExecutor(BaseExecutor):
         trade_type: str
             please refer to the doc of `TT_SERIAL` & `TT_PARAL`
         """
-        super(SimulatorExecutor, self).__init__(
+        super().__init__(
             time_per_step=time_per_step,
             start_time=start_time,
             end_time=end_time,

--- a/qlib/backtest/high_performance_ds.py
+++ b/qlib/backtest/high_performance_ds.py
@@ -117,12 +117,11 @@ class PandasQuote(BaseQuote):
         stock_data = resam_ts_data(self.data[stock_id][field], start_time, end_time, method=method)
         if stock_data is None:
             return None
-        elif isinstance(stock_data, (bool, np.bool_, int, float, np.number)):
+        if isinstance(stock_data, (bool, np.bool_, int, float, np.number)):
             return stock_data
-        elif isinstance(stock_data, pd.Series):
+        if isinstance(stock_data, pd.Series):
             return idd.SingleData(stock_data)
-        else:
-            raise ValueError(f"stock data from resam_ts_data must be a number, pd.Series or pd.DataFrame")
+        raise ValueError(f"stock data from resam_ts_data must be a number, pd.Series or pd.DataFrame")
 
 
 class NumpyQuote(BaseQuote):
@@ -561,7 +560,7 @@ class PandasOrderIndicator(BaseOrderIndicator):
     """
 
     def __init__(self) -> None:
-        super(PandasOrderIndicator, self).__init__()
+        super().__init__()
         self.data: Dict[str, PandasSingleMetric] = OrderedDict()
 
     def assign(self, col: str, metric: Union[dict, pd.Series]) -> None:
@@ -609,7 +608,7 @@ class NumpyOrderIndicator(BaseOrderIndicator):
     """
 
     def __init__(self) -> None:
-        super(NumpyOrderIndicator, self).__init__()
+        super().__init__()
         self.data: Dict[str, SingleData] = OrderedDict()
 
     def assign(self, col: str, metric: dict) -> None:

--- a/qlib/backtest/position.py
+++ b/qlib/backtest/position.py
@@ -433,8 +433,7 @@ class Position(BasePosition):
         """the days the account has been hold, it may be used in some special strategies"""
         if f"count_{bar}" in self.position[code]:
             return self.position[code][f"count_{bar}"]
-        else:
-            return 0
+        return 0
 
     def get_stock_weight(self, code: str) -> float:
         return self.position[code]["weight"]

--- a/qlib/backtest/report.py
+++ b/qlib/backtest/report.py
@@ -299,13 +299,13 @@ class Indicator:
         self.trade_indicator_his[trade_start_time] = self.get_trade_indicator()
 
     def _update_order_trade_info(self, trade_info: List[Tuple[Order, float, float, float]]) -> None:
-        amount = dict()
-        deal_amount = dict()
-        trade_price = dict()
-        trade_value = dict()
-        trade_cost = dict()
-        trade_dir = dict()
-        pa = dict()
+        amount = {}
+        deal_amount = {}
+        trade_price = {}
+        trade_value = {}
+        trade_cost = {}
+        trade_dir = {}
+        pa = {}
 
         for order, _trade_val, _trade_cost, _trade_price in trade_info:
             amount[order.stock_id] = order.amount_delta

--- a/qlib/backtest/report.py
+++ b/qlib/backtest/report.py
@@ -103,22 +103,21 @@ class PortfolioMetrics:
 
         if isinstance(benchmark, pd.Series):
             return benchmark
-        else:
-            start_time = benchmark_config.get("start_time", None)
-            end_time = benchmark_config.get("end_time", None)
+        start_time = benchmark_config.get("start_time", None)
+        end_time = benchmark_config.get("end_time", None)
 
-            if freq is None:
-                raise ValueError("benchmark freq can't be None!")
-            _codes = benchmark if isinstance(benchmark, (list, dict)) else [benchmark]
-            fields = ["$close/Ref($close,1)-1"]
-            _temp_result, _ = get_higher_eq_freq_feature(_codes, fields, start_time, end_time, freq=freq)
-            if len(_temp_result) == 0:
-                raise ValueError(f"The benchmark {_codes} does not exist. Please provide the right benchmark")
-            return (
-                _temp_result.groupby(level="datetime", group_keys=False)[_temp_result.columns.tolist()[0]]
-                .mean()
-                .fillna(0)
-            )
+        if freq is None:
+            raise ValueError("benchmark freq can't be None!")
+        _codes = benchmark if isinstance(benchmark, (list, dict)) else [benchmark]
+        fields = ["$close/Ref($close,1)-1"]
+        _temp_result, _ = get_higher_eq_freq_feature(_codes, fields, start_time, end_time, freq=freq)
+        if len(_temp_result) == 0:
+            raise ValueError(f"The benchmark {_codes} does not exist. Please provide the right benchmark")
+        return (
+            _temp_result.groupby(level="datetime", group_keys=False)[_temp_result.columns.tolist()[0]]
+            .mean()
+            .fillna(0)
+        )
 
     def _sample_benchmark(
         self,
@@ -556,30 +555,28 @@ class Indicator:
             return self.order_indicator.transfer(
                 lambda ffr: ffr.mean(),
             )
-        elif method == "amount_weighted":
+        if method == "amount_weighted":
             return self.order_indicator.transfer(
                 lambda ffr, deal_amount: (ffr * deal_amount.abs()).sum() / (deal_amount.abs().sum()),
             )
-        elif method == "value_weighted":
+        if method == "value_weighted":
             return self.order_indicator.transfer(
                 lambda ffr, trade_value: (ffr * trade_value.abs()).sum() / (trade_value.abs().sum()),
             )
-        else:
-            raise ValueError(f"method {method} is not supported!")
+        raise ValueError(f"method {method} is not supported!")
 
     def _cal_trade_price_advantage(self, method: str = "mean") -> Optional[BaseSingleMetric]:
         if method == "mean":
             return self.order_indicator.transfer(lambda pa: pa.mean())
-        elif method == "amount_weighted":
+        if method == "amount_weighted":
             return self.order_indicator.transfer(
                 lambda pa, deal_amount: (pa * deal_amount.abs()).sum() / (deal_amount.abs().sum()),
             )
-        elif method == "value_weighted":
+        if method == "value_weighted":
             return self.order_indicator.transfer(
                 lambda pa, trade_value: (pa * trade_value.abs()).sum() / (trade_value.abs().sum()),
             )
-        else:
-            raise ValueError(f"method {method} is not supported!")
+        raise ValueError(f"method {method} is not supported!")
 
     def _cal_trade_positive_rate(self) -> Optional[BaseSingleMetric]:
         def func(pa):

--- a/qlib/config.py
+++ b/qlib/config.py
@@ -361,8 +361,7 @@ class QlibConfig(Config):
 
             if is_nfs_or_win and not is_win:
                 return QlibConfig.NFS_URI
-            else:
-                return QlibConfig.LOCAL_URI
+            return QlibConfig.LOCAL_URI
 
         def get_data_uri(self, freq: Optional[Union[str, Freq]] = None) -> Path:
             """
@@ -375,14 +374,13 @@ class QlibConfig(Config):
             _provider_uri = self.provider_uri[freq]
             if self.get_uri_type(_provider_uri) == QlibConfig.LOCAL_URI:
                 return Path(_provider_uri)
-            elif self.get_uri_type(_provider_uri) == QlibConfig.NFS_URI:
+            if self.get_uri_type(_provider_uri) == QlibConfig.NFS_URI:
                 if "win" in platform.system().lower():
                     # windows, mount_path is the drive
                     _path = str(self.mount_path[freq])
                     return Path(f"{_path}:\\") if ":" not in _path else Path(_path)
                 return Path(self.mount_path[freq])
-            else:
-                raise NotImplementedError(f"This type of uri is not supported")
+            raise NotImplementedError(f"This type of uri is not supported")
 
     def set_mode(self, mode):
         # raise KeyError

--- a/qlib/contrib/model/catboost_model.py
+++ b/qlib/contrib/model/catboost_model.py
@@ -31,7 +31,7 @@ class CatBoostModel(Model, FeatureInt):
         num_boost_round=1000,
         early_stopping_rounds=50,
         verbose_eval=20,
-        evals_result=dict(),
+        evals_result={},
         reweighter=None,
         **kwargs,
     ):

--- a/qlib/contrib/model/double_ensemble.py
+++ b/qlib/contrib/model/double_ensemble.py
@@ -104,7 +104,7 @@ class DEnsembleModel(Model, FeatureInt):
 
     def train_submodel(self, df_train, df_valid, weights, features):
         dtrain, dvalid = self._prepare_data_gbm(df_train, df_valid, weights, features)
-        evals_result = dict()
+        evals_result = {}
 
         callbacks = [lgb.log_evaluation(20), lgb.record_evaluation(evals_result)]
         if self.early_stopping_rounds:

--- a/qlib/contrib/model/highfreq_gdbt_model.py
+++ b/qlib/contrib/model/highfreq_gdbt_model.py
@@ -122,7 +122,7 @@ class HFLGBModel(ModelFT, LightGBMFInt):
         evals_result=None,
     ):
         if evals_result is None:
-            evals_result = dict()
+            evals_result = {}
         dtrain, dvalid = self._prepare_data(dataset)
         early_stopping_callback = lgb.early_stopping(early_stopping_rounds)
         verbose_eval_callback = lgb.log_evaluation(period=verbose_eval)

--- a/qlib/contrib/model/pytorch_adarnn.py
+++ b/qlib/contrib/model/pytorch_adarnn.py
@@ -242,7 +242,7 @@ class ADARNN(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result={},
         save_path=None,
     ):
         df_train, df_valid = dataset.prepare(
@@ -387,7 +387,7 @@ class AdaRNN(nn.Module):
         trans_loss="mmd",
         GPU=0,
     ):
-        super(AdaRNN, self).__init__()
+        super().__init__()
         self.use_bottleneck = use_bottleneck
         self.n_input = n_input
         self.num_layers = len(n_hiddens)
@@ -618,7 +618,7 @@ class ReverseLayerF(Function):
 
 class Discriminator(nn.Module):
     def __init__(self, input_dim=256, hidden_dim=256):
-        super(Discriminator, self).__init__()
+        super().__init__()
         self.input_dim = input_dim
         self.hidden_dim = hidden_dim
         self.dis1 = nn.Linear(input_dim, hidden_dim)
@@ -668,7 +668,7 @@ def CORAL(source, target, device):
 
 class MMD_loss(nn.Module):
     def __init__(self, kernel_type="linear", kernel_mul=2.0, kernel_num=5):
-        super(MMD_loss, self).__init__()
+        super().__init__()
         self.kernel_num = kernel_num
         self.kernel_mul = kernel_mul
         self.fix_sigma = None
@@ -715,7 +715,7 @@ class MMD_loss(nn.Module):
 
 class Mine_estimator(nn.Module):
     def __init__(self, input_dim=2048, hidden_dim=512):
-        super(Mine_estimator, self).__init__()
+        super().__init__()
         self.mine_model = Mine(input_dim, hidden_dim)
 
     def forward(self, X, Y):
@@ -729,7 +729,7 @@ class Mine_estimator(nn.Module):
 
 class Mine(nn.Module):
     def __init__(self, input_dim=2048, hidden_dim=512):
-        super(Mine, self).__init__()
+        super().__init__()
         self.fc1_x = nn.Linear(input_dim, hidden_dim)
         self.fc1_y = nn.Linear(input_dim, hidden_dim)
         self.fc2 = nn.Linear(hidden_dim, 1)

--- a/qlib/contrib/model/pytorch_add.py
+++ b/qlib/contrib/model/pytorch_add.py
@@ -363,7 +363,7 @@ class ADD(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result={},
         save_path=None,
     ):
         label_train, label_valid = dataset.prepare(

--- a/qlib/contrib/model/pytorch_alstm.py
+++ b/qlib/contrib/model/pytorch_alstm.py
@@ -209,7 +209,7 @@ class ALSTM(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result={},
         save_path=None,
     ):
         df_train, df_valid, df_test = dataset.prepare(

--- a/qlib/contrib/model/pytorch_alstm_ts.py
+++ b/qlib/contrib/model/pytorch_alstm_ts.py
@@ -206,7 +206,7 @@ class ALSTM(Model):
     def fit(
         self,
         dataset,
-        evals_result=dict(),
+        evals_result={},
         save_path=None,
         reweighter=None,
     ):

--- a/qlib/contrib/model/pytorch_gats.py
+++ b/qlib/contrib/model/pytorch_gats.py
@@ -224,7 +224,7 @@ class GATs(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result={},
         save_path=None,
     ):
         df_train, df_valid, df_test = dataset.prepare(

--- a/qlib/contrib/model/pytorch_gats_ts.py
+++ b/qlib/contrib/model/pytorch_gats_ts.py
@@ -233,7 +233,7 @@ class GATs(Model):
     def fit(
         self,
         dataset,
-        evals_result=dict(),
+        evals_result={},
         save_path=None,
     ):
         dl_train = dataset.prepare("train", col_set=["feature", "label"], data_key=DataHandlerLP.DK_L)

--- a/qlib/contrib/model/pytorch_general_nn.py
+++ b/qlib/contrib/model/pytorch_general_nn.py
@@ -235,7 +235,7 @@ class GeneralPTNN(Model):
     def fit(
         self,
         dataset: Union[DatasetH, TSDatasetH],
-        evals_result=dict(),
+        evals_result={},
         save_path=None,
         reweighter=None,
     ):

--- a/qlib/contrib/model/pytorch_gru.py
+++ b/qlib/contrib/model/pytorch_gru.py
@@ -209,7 +209,7 @@ class GRU(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result={},
         save_path=None,
     ):
         # prepare training and validation data

--- a/qlib/contrib/model/pytorch_gru_ts.py
+++ b/qlib/contrib/model/pytorch_gru_ts.py
@@ -200,7 +200,7 @@ class GRU(Model):
     def fit(
         self,
         dataset,
-        evals_result=dict(),
+        evals_result={},
         save_path=None,
         reweighter=None,
     ):

--- a/qlib/contrib/model/pytorch_hist.py
+++ b/qlib/contrib/model/pytorch_hist.py
@@ -244,7 +244,7 @@ class HIST(Model):
     def fit(
         self,
         dataset: DatasetH,
-        evals_result=dict(),
+        evals_result={},
         save_path=None,
     ):
         df_train, df_valid, df_test = dataset.prepare(

--- a/qlib/contrib/model/pytorch_localformer.py
+++ b/qlib/contrib/model/pytorch_localformer.py
@@ -242,7 +242,7 @@ class LocalformerModel(Model):
 
 class PositionalEncoding(nn.Module):
     def __init__(self, d_model, max_len=1000):
-        super(PositionalEncoding, self).__init__()
+        super().__init__()
         pe = torch.zeros(max_len, d_model)
         position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)
         div_term = torch.exp(torch.arange(0, d_model, 2).float() * (-math.log(10000.0) / d_model))
@@ -264,7 +264,7 @@ class LocalformerEncoder(nn.Module):
     __constants__ = ["norm"]
 
     def __init__(self, encoder_layer, num_layers, d_model):
-        super(LocalformerEncoder, self).__init__()
+        super().__init__()
         self.layers = _get_clones(encoder_layer, num_layers)
         self.conv = _get_clones(nn.Conv1d(d_model, d_model, 3, 1, 1), num_layers)
         self.num_layers = num_layers
@@ -285,7 +285,7 @@ class LocalformerEncoder(nn.Module):
 
 class Transformer(nn.Module):
     def __init__(self, d_feat=6, d_model=8, nhead=4, num_layers=2, dropout=0.5, device=None):
-        super(Transformer, self).__init__()
+        super().__init__()
         self.rnn = nn.GRU(
             input_size=d_model,
             hidden_size=d_model,

--- a/qlib/contrib/model/pytorch_localformer_ts.py
+++ b/qlib/contrib/model/pytorch_localformer_ts.py
@@ -223,7 +223,7 @@ class LocalformerModel(Model):
 
 class PositionalEncoding(nn.Module):
     def __init__(self, d_model, max_len=1000):
-        super(PositionalEncoding, self).__init__()
+        super().__init__()
         pe = torch.zeros(max_len, d_model)
         position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)
         div_term = torch.exp(torch.arange(0, d_model, 2).float() * (-math.log(10000.0) / d_model))
@@ -245,7 +245,7 @@ class LocalformerEncoder(nn.Module):
     __constants__ = ["norm"]
 
     def __init__(self, encoder_layer, num_layers, d_model):
-        super(LocalformerEncoder, self).__init__()
+        super().__init__()
         self.layers = _get_clones(encoder_layer, num_layers)
         self.conv = _get_clones(nn.Conv1d(d_model, d_model, 3, 1, 1), num_layers)
         self.num_layers = num_layers
@@ -266,7 +266,7 @@ class LocalformerEncoder(nn.Module):
 
 class Transformer(nn.Module):
     def __init__(self, d_feat=6, d_model=8, nhead=4, num_layers=2, dropout=0.5, device=None):
-        super(Transformer, self).__init__()
+        super().__init__()
         self.rnn = nn.GRU(
             input_size=d_model,
             hidden_size=d_model,

--- a/qlib/contrib/model/pytorch_nn.py
+++ b/qlib/contrib/model/pytorch_nn.py
@@ -425,7 +425,7 @@ class AverageMeter:
 
 class Net(nn.Module):
     def __init__(self, input_dim, output_dim=1, layers=(256,), act="LeakyReLU"):
-        super(Net, self).__init__()
+        super().__init__()
 
         layers = [input_dim] + list(layers)
         dnn_layers = []

--- a/qlib/contrib/model/pytorch_tra.py
+++ b/qlib/contrib/model/pytorch_tra.py
@@ -583,7 +583,7 @@ class RNN(nn.Module):
 class PositionalEncoding(nn.Module):
     # reference: https://pytorch.org/tutorials/beginner/transformer_tutorial.html
     def __init__(self, d_model, dropout=0.1, max_len=5000):
-        super(PositionalEncoding, self).__init__()
+        super().__init__()
         self.dropout = nn.Dropout(p=dropout)
 
         pe = torch.zeros(max_len, d_model)

--- a/qlib/contrib/model/pytorch_transformer.py
+++ b/qlib/contrib/model/pytorch_transformer.py
@@ -241,7 +241,7 @@ class TransformerModel(Model):
 
 class PositionalEncoding(nn.Module):
     def __init__(self, d_model, max_len=1000):
-        super(PositionalEncoding, self).__init__()
+        super().__init__()
         pe = torch.zeros(max_len, d_model)
         position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)
         div_term = torch.exp(torch.arange(0, d_model, 2).float() * (-math.log(10000.0) / d_model))
@@ -257,7 +257,7 @@ class PositionalEncoding(nn.Module):
 
 class Transformer(nn.Module):
     def __init__(self, d_feat=6, d_model=8, nhead=4, num_layers=2, dropout=0.5, device=None):
-        super(Transformer, self).__init__()
+        super().__init__()
         self.feature_layer = nn.Linear(d_feat, d_model)
         self.pos_encoder = PositionalEncoding(d_model)
         self.encoder_layer = nn.TransformerEncoderLayer(d_model=d_model, nhead=nhead, dropout=dropout)

--- a/qlib/contrib/model/pytorch_transformer_ts.py
+++ b/qlib/contrib/model/pytorch_transformer_ts.py
@@ -221,7 +221,7 @@ class TransformerModel(Model):
 
 class PositionalEncoding(nn.Module):
     def __init__(self, d_model, max_len=1000):
-        super(PositionalEncoding, self).__init__()
+        super().__init__()
         pe = torch.zeros(max_len, d_model)
         position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)
         div_term = torch.exp(torch.arange(0, d_model, 2).float() * (-math.log(10000.0) / d_model))
@@ -237,7 +237,7 @@ class PositionalEncoding(nn.Module):
 
 class Transformer(nn.Module):
     def __init__(self, d_feat=6, d_model=8, nhead=4, num_layers=2, dropout=0.5, device=None):
-        super(Transformer, self).__init__()
+        super().__init__()
         self.feature_layer = nn.Linear(d_feat, d_model)
         self.pos_encoder = PositionalEncoding(d_model)
         self.encoder_layer = nn.TransformerEncoderLayer(d_model=d_model, nhead=nhead, dropout=dropout)

--- a/qlib/contrib/model/tcn.py
+++ b/qlib/contrib/model/tcn.py
@@ -6,7 +6,7 @@ from torch.nn.utils import weight_norm
 
 class Chomp1d(nn.Module):
     def __init__(self, chomp_size):
-        super(Chomp1d, self).__init__()
+        super().__init__()
         self.chomp_size = chomp_size
 
     def forward(self, x):
@@ -15,7 +15,7 @@ class Chomp1d(nn.Module):
 
 class TemporalBlock(nn.Module):
     def __init__(self, n_inputs, n_outputs, kernel_size, stride, dilation, padding, dropout=0.2):
-        super(TemporalBlock, self).__init__()
+        super().__init__()
         self.conv1 = weight_norm(
             nn.Conv1d(n_inputs, n_outputs, kernel_size, stride=stride, padding=padding, dilation=dilation)
         )
@@ -51,7 +51,7 @@ class TemporalBlock(nn.Module):
 
 class TemporalConvNet(nn.Module):
     def __init__(self, num_inputs, num_channels, kernel_size=2, dropout=0.2):
-        super(TemporalConvNet, self).__init__()
+        super().__init__()
         layers = []
         num_levels = len(num_channels)
         for i in range(num_levels):

--- a/qlib/contrib/ops/high_freq.py
+++ b/qlib/contrib/ops/high_freq.py
@@ -262,7 +262,7 @@ class Cut(ElemOperator):
         if (self.left is not None and self.left <= 0) or (self.right is not None and self.right >= 0):
             raise ValueError("Cut operator l shoud > 0 and r should < 0")
 
-        super(Cut, self).__init__(feature)
+        super().__init__(feature)
 
     def _load_internal(self, instrument, start_index, end_index, freq):
         series = self.feature.load(instrument, start_index, end_index, freq)

--- a/qlib/contrib/strategy/cost_control.py
+++ b/qlib/contrib/strategy/cost_control.py
@@ -32,7 +32,7 @@ class SoftTopkStrategy(WeightStrategyBase):
         risk_degree : float
             The target percentage of total value to be invested.
         """
-        super(SoftTopkStrategy, self).__init__(
+        super().__init__(
             model=model, dataset=dataset, order_generator_cls_or_obj=order_generator_cls_or_obj, **kwargs
         )
 

--- a/qlib/contrib/strategy/rule_strategy.py
+++ b/qlib/contrib/strategy/rule_strategy.py
@@ -34,7 +34,7 @@ class TWAPStrategy(BaseStrategy):
         outer_trade_decision : BaseTradeDecision, optional
         """
 
-        super(TWAPStrategy, self).reset(outer_trade_decision=outer_trade_decision, **kwargs)
+        super().reset(outer_trade_decision=outer_trade_decision, **kwargs)
         if outer_trade_decision is not None:
             self.trade_amount_remain = {}
             for order in outer_trade_decision.get_decision():
@@ -142,7 +142,7 @@ class SBBStrategyBase(BaseStrategy):
         ----------
         outer_trade_decision : BaseTradeDecision, optional
         """
-        super(SBBStrategyBase, self).reset(outer_trade_decision=outer_trade_decision, **kwargs)
+        super().reset(outer_trade_decision=outer_trade_decision, **kwargs)
         if outer_trade_decision is not None:
             self.trade_trend = {}
             self.trade_amount = {}
@@ -331,7 +331,7 @@ class SBBStrategyEMA(SBBStrategyBase):
         elif isinstance(instruments, List):
             self.instruments = instruments
         self.freq = freq
-        super(SBBStrategyEMA, self).__init__(
+        super().__init__(
             outer_trade_decision, level_infra, common_infra, trade_exchange=trade_exchange, **kwargs
         )
 
@@ -416,7 +416,7 @@ class ACStrategy(BaseStrategy):
         if isinstance(instruments, str):
             self.instruments = D.instruments(instruments)
         self.freq = freq
-        super(ACStrategy, self).__init__(
+        super().__init__(
             outer_trade_decision, level_infra, common_infra, trade_exchange=trade_exchange, **kwargs
         )
 
@@ -451,7 +451,7 @@ class ACStrategy(BaseStrategy):
         ----------
         outer_trade_decision : BaseTradeDecision, optional
         """
-        super(ACStrategy, self).reset(outer_trade_decision=outer_trade_decision, **kwargs)
+        super().reset(outer_trade_decision=outer_trade_decision, **kwargs)
         if outer_trade_decision is not None:
             self.trade_amount = {}
             # init the trade amount of order and  predicted trade trend

--- a/qlib/data/cache.py
+++ b/qlib/data/cache.py
@@ -491,13 +491,13 @@ class DiskExpressionCache(ExpressionCache):
     """Prepared cache mechanism for server."""
 
     def __init__(self, provider, **kwargs):
-        super(DiskExpressionCache, self).__init__(provider)
+        super().__init__(provider)
         self.r = get_redis_connection()
         # remote==True means client is using this module, writing behaviour will not be allowed.
         self.remote = kwargs.get("remote", False)
 
     def get_cache_dir(self, freq: str = None) -> Path:
-        return super(DiskExpressionCache, self).get_cache_dir(C.features_cache_dir_name, freq)
+        return super().get_cache_dir(C.features_cache_dir_name, freq)
 
     def _uri(self, instrument, field, start_time, end_time, freq):
         field = remove_fields_space(field)

--- a/qlib/data/storage/file_storage.py
+++ b/qlib/data/storage/file_storage.py
@@ -75,7 +75,7 @@ class FileStorageMixin:
 
 class FileCalendarStorage(FileStorageMixin, CalendarStorage):
     def __init__(self, freq: str, future: bool, provider_uri: dict = None, **kwargs):
-        super(FileCalendarStorage, self).__init__(freq, future, **kwargs)
+        super().__init__(freq, future, **kwargs)
         self.future = future
         self._provider_uri = None if provider_uri is None else C.DataPathManager.format_provider_uri(provider_uri)
         self.enable_read_cache = True  # TODO: make it configurable
@@ -196,7 +196,7 @@ class FileInstrumentStorage(FileStorageMixin, InstrumentStorage):
     SYMBOL_FIELD_NAME = "instrument"
 
     def __init__(self, market: str, freq: str, provider_uri: dict = None, **kwargs):
-        super(FileInstrumentStorage, self).__init__(market, freq, **kwargs)
+        super().__init__(market, freq, **kwargs)
         self._provider_uri = None if provider_uri is None else C.DataPathManager.format_provider_uri(provider_uri)
         self.file_name = f"{market.lower()}.txt"
 
@@ -204,7 +204,7 @@ class FileInstrumentStorage(FileStorageMixin, InstrumentStorage):
         if not self.uri.exists():
             self._write_instrument()
 
-        _instruments = dict()
+        _instruments = {}
         df = pd.read_csv(
             self.uri,
             sep="\t",
@@ -284,7 +284,7 @@ class FileInstrumentStorage(FileStorageMixin, InstrumentStorage):
 
 class FileFeatureStorage(FileStorageMixin, FeatureStorage):
     def __init__(self, instrument: str, field: str, freq: str, provider_uri: dict = None, **kwargs):
-        super(FileFeatureStorage, self).__init__(instrument, field, freq, **kwargs)
+        super().__init__(instrument, field, freq, **kwargs)
         self._provider_uri = None if provider_uri is None else C.DataPathManager.format_provider_uri(provider_uri)
         self.file_name = f"{instrument.lower()}/{field.lower()}.{freq.lower()}.bin"
 

--- a/qlib/data/storage/file_storage.py
+++ b/qlib/data/storage/file_storage.py
@@ -347,10 +347,9 @@ class FileFeatureStorage(FileStorageMixin, FeatureStorage):
         if not self.uri.exists():
             if isinstance(i, int):
                 return None, None
-            elif isinstance(i, slice):
+            if isinstance(i, slice):
                 return pd.Series(dtype=np.float32)
-            else:
-                raise TypeError(f"type(i) = {type(i)}")
+            raise TypeError(f"type(i) = {type(i)}")
 
         storage_start_index = self.start_index
         storage_end_index = self.end_index
@@ -360,7 +359,7 @@ class FileFeatureStorage(FileStorageMixin, FeatureStorage):
                     raise IndexError(f"{i}: start index is {storage_start_index}")
                 fp.seek(4 * (i - storage_start_index) + 4)
                 return i, struct.unpack("f", fp.read(4))[0]
-            elif isinstance(i, slice):
+            if isinstance(i, slice):
                 start_index = storage_start_index if i.start is None else i.start
                 end_index = storage_end_index if i.stop is None else i.stop - 1
                 si = max(start_index, storage_start_index)
@@ -371,8 +370,7 @@ class FileFeatureStorage(FileStorageMixin, FeatureStorage):
                 count = end_index - si + 1
                 data = np.frombuffer(fp.read(4 * count), dtype="<f")
                 return pd.Series(data, index=pd.RangeIndex(si, si + len(data)))
-            else:
-                raise TypeError(f"type(i) = {type(i)}")
+            raise TypeError(f"type(i) = {type(i)}")
 
     def __len__(self) -> int:
         self.check()


### PR DESCRIPTION

This PR resolves pylint issues R1705, R1725, and R1735 as requested in Issue #1007.

## Changes
- R1725: Use Python 3 style super() without arguments
- R1735: Use dict literal {} instead of dict() call
- R1705: Remove unnecessary else/elif after return statements
- Makefile: Removed fixed error codes from disabled list

## Files Modified
- 35 files across backtest, contrib, data, and config modules

Fixes #1007
@microsoft-github-policy-service agree