### PR TITLE
fix(ops): make PairRolling input assert actually check its inputs

### DIFF
--- a/qlib/data/ops.py
+++ b/qlib/data/ops.py
@@ -1413,8 +1413,8 @@ class PairRolling(ExpressionOps):
         return "{}({},{},{})".format(type(self).__name__, self.feature_left, self.feature_right, self.N)
 
     def _load_internal(self, instrument, start_index, end_index, *args):
-        assert any(
-            [isinstance(self.feature_left, Expression), self.feature_right, Expression]
+        assert isinstance(self.feature_left, Expression) or isinstance(
+            self.feature_right, Expression
         ), "at least one of two inputs is Expression instance"
 
         if isinstance(self.feature_left, Expression):

--- a/tests/ops/test_pair_rolling_inputs.py
+++ b/tests/ops/test_pair_rolling_inputs.py
@@ -1,0 +1,50 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from qlib.data.base import Expression
+from qlib.data.ops import Cov
+
+
+class StubFeature(Expression):
+    """Minimal expression returning a fixed series, so operators can be tested without a data provider."""
+
+    def __init__(self, values, name):
+        self._values = list(values)
+        self._name = name
+
+    def __str__(self):
+        # unique per stub: Expression.load caches series keyed on str(self)
+        return self._name
+
+    def _load_internal(self, instrument, start_index, end_index, *args):
+        return pd.Series(self._values, dtype=float)
+
+    def get_longest_back_rolling(self):
+        return 0
+
+    def get_extended_window_size(self):
+        return 0, 0
+
+
+class TestPairRollingInputCheck(unittest.TestCase):
+    """PairRolling must reject two non-Expression inputs instead of failing later with AttributeError."""
+
+    def test_two_numeric_inputs_rejected(self):
+        with self.assertRaises(AssertionError):
+            Cov(1.0, 2.0, 3).load("inst", 0, 4, "day")
+
+    def test_expression_inputs_accepted(self):
+        left = [1.0, 2.0, 3.0, 4.0, 5.0]
+        right = [2.0, 1.0, 4.0, 3.0, 6.0]
+        res = Cov(StubFeature(left, "cov_l"), StubFeature(right, "cov_r"), 3).load("inst", 0, 4, "day")
+        expected = pd.Series(left).rolling(3, min_periods=1).cov(pd.Series(right))
+        np.testing.assert_allclose(res.values, expected.values)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

The input-validation assert in `PairRolling._load_internal` (`qlib/data/ops.py`) can never fail:

```python
assert any(
    [isinstance(self.feature_left, Expression), self.feature_right, Expression]
), "at least one of two inputs is Expression instance"
```

The second element is the raw `feature_right` value and the third is the `Expression` **class object**, which is always truthy — so `any(...)` is always `True`. The intended check was clearly "at least one of the two inputs is an `Expression` instance" (per the message). As a result, `Cov(1.0, 2.0, 3)` sails past the assert and later fails with an unrelated `AttributeError: 'float' object has no attribute 'rolling'`.

This PR replaces it with the intended check:

```python
assert isinstance(self.feature_left, Expression) or isinstance(
    self.feature_right, Expression
), "at least one of two inputs is Expression instance"
```

## Motivation and Context

Invalid `PairRolling` inputs (e.g. `Corr`/`Cov` built with two constants) should fail fast with the intended message instead of surfacing a confusing `AttributeError` deep in pandas. No valid usage changes behavior: any call with at least one `Expression` input passes the assert exactly as before.

## How Has This Been Tested?
- [x] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [x] If you are adding a new feature, test on your own test scripts.

Added `tests/ops/test_pair_rolling_inputs.py` (no data download needed — uses a stub `Expression`):
- two non-Expression inputs now raise `AssertionError` (previously: passed the assert, crashed later with `AttributeError`)
- `Cov` of two expressions still matches `pandas.Series.rolling().cov()`

## Screenshots of Test Results (if appropriate):
1. Pipeline test (run with `MLFLOW_ALLOW_FILE_STORE=true`, since mlflow 3.14 gates the `./mlruns` file store behind that flag independently of this change):
```
tests/test_all_pipeline.py::TestAllFlow::test_0_train PASSED
tests/test_all_pipeline.py::TestAllFlow::test_1_backtest PASSED
tests/test_all_pipeline.py::TestAllFlow::test_2_expmanager PASSED
================ 3 passed, 1351 warnings in 247.62s (0:04:07) =================
```
2. Your own tests:
```
tests/ops/test_pair_rolling_inputs.py::TestPairRollingInputCheck::test_expression_inputs_accepted PASSED
tests/ops/test_pair_rolling_inputs.py::TestPairRollingInputCheck::test_two_numeric_inputs_rejected PASSED
============================== 2 passed in 1.95s ==============================
```
Without the fix, `test_two_numeric_inputs_rejected` fails with `AttributeError: 'float' object has no attribute 'rolling'` at `qlib/data/ops.py:1432`.

## Types of changes
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
