### PR TITLE
fix: align the pre-commit black hook with the formatting CI enforces

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,9 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 23.7.0
+    # Keep this aligned with the black style CI enforces (`make black`): 23.x disagrees with
+    # the current repo formatting (e.g. qlib/model/riskmodel/shrink.py) and rewrites files the
+    # committer never touched. 24.8.0 matches CI's result and still supports Python 3.8.
+    rev: 24.8.0
     hooks:
     -   id: black
         args: ["qlib", "-l 120"]


### PR DESCRIPTION
CI checks formatting with the latest black (make black), but the
pre-commit config pinned black 23.7.0. The two disagree on
qlib/model/riskmodel/shrink.py, so on a clean checkout the documented
dev setup (pre-commit install) reformats a file the committer never
touched - the very first commit fails the hook or mutates unrelated
code.

* Bump the black hook rev to 24.8.0, which agrees with CI's black on
  all 336 repo files and still supports Python 3.8, qlib's floor.
* Comment the pin with the alignment constraint so it can't drift
  silently again.
* Leave the flake8 pin untouched - no misbehavior observed there.