### PR TITLE
fix: mask degenerate expanding Rsquare windows

### DIFF
--- a/qlib/data/ops.py
+++ b/qlib/data/ops.py
@@ -1277,6 +1277,7 @@ class Rsquare(Rolling):
         _series = self.feature.load(instrument, start_index, end_index, *args)
         if self.N == 0:
             series = pd.Series(expanding_rsquare(_series.values), index=_series.index)
+            series.loc[np.isclose(_series.expanding(min_periods=1).std(), 0, atol=2e-05)] = np.nan
         else:
             series = pd.Series(rolling_rsquare(_series.values, self.N), index=_series.index)
             series.loc[np.isclose(_series.rolling(self.N, min_periods=1).std(), 0, atol=2e-05)] = np.nan


### PR DESCRIPTION
This applies the same near-zero standard-deviation mask to the expanding `Rsquare` path that is already used by the rolling path. Constant and near-constant windows now produce `NaN` instead of leaking `inf` or unstable finite values.

Fixes #2297