### PR TITLE
fix: correct import order in gbdt.py (pylint C0411)

### DIFF
--- a/qlib/contrib/model/gbdt.py
+++ b/qlib/contrib/model/gbdt.py
@@ -1,16 +1,18 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+from typing import List, Text, Tuple, Union
+
 import numpy as np
 import pandas as pd
 import lightgbm as lgb
-from typing import List, Text, Tuple, Union
+
+from qlib.workflow import R
 from ...model.base import ModelFT
 from ...data.dataset import DatasetH
 from ...data.dataset.handler import DataHandlerLP
 from ...model.interpret.base import LightGBMFInt
 from ...data.dataset.weight import Reweighter
-from qlib.workflow import R
 
 
 class LGBModel(ModelFT, LightGBMFInt):


### PR DESCRIPTION
## Summary
Partial contribution toward #1007 (refine code style reported by pylint/flake8).

Reorders imports in `qlib/contrib/model/gbdt.py` to follow standard grouping (stdlib → third-party → first-party), resolving the `wrong-import-order` (C0411) pylint warning for this file.

## Verification
Ran pylint locally with only `wrong-import-order` enabled, before/after:
- Before: 1 violation (C0411) at import block
- After: 0 violations, `10.00/10` for that check

## Test plan
- [x] `pylint --disable=all --enable=wrong-import-order qlib/contrib/model/gbdt.py` passes clean
- [x] No functional code changed — import ordering only