### PR TITLE
Add CausalWM357: a weight-free, discovered feature handler (357 features)

### DIFF
--- a/examples/benchmarks/LightGBM/workflow_config_lightgbm_CausalWM357.yaml
+++ b/examples/benchmarks/LightGBM/workflow_config_lightgbm_CausalWM357.yaml
@@ -1,0 +1,96 @@
+# LightGBM on CausalWM357, in the exact layout of
+# examples/benchmarks/LightGBM/workflow_config_lightgbm_Alpha158.yaml.
+#
+#   pip install causalwm      # optional dependency: the 111 feature programs
+#   qrun examples/benchmarks/LightGBM/workflow_config_lightgbm_CausalWM357.yaml
+#
+# Differences from the Alpha158 config, all forced by the handler and all
+# deliberate (see qlib/contrib/data/causalwm_handler.py):
+#   * rows are WEEKLY (W-FRI, Friday-stamped): the model trains and predicts
+#     once a week, so the backtest rebalances weekly, and SigAnaRecord's
+#     ann_scaler is 52 (weeks/year) instead of 252 (days/year);
+#   * the label is Alpha158's Ref($close, -2)/Ref($close, -1) - 1 read on the
+#     weekly grid (buy next week's close, sell the week after);
+#   * features are served RAW, so a fit-ranged RobustZScoreNorm is required
+#     (this is the handler default, spelled out here for visibility);
+#   * the handler over-fetches 420 calendar days before start_time for the
+#     encoder's 52-week window, so the segments below need no extra warm-up.
+qlib_init:
+    provider_uri: "~/.qlib/qlib_data/cn_data"
+    region: cn
+market: &market csi300
+benchmark: &benchmark SH000300
+data_handler_config: &data_handler_config
+    start_time: 2008-01-01
+    end_time: 2020-08-01
+    fit_start_time: 2008-01-01
+    fit_end_time: 2014-12-31
+    instruments: *market
+    infer_processors:
+        - class: RobustZScoreNorm
+          kwargs:
+              fields_group: feature
+              clip_outlier: true
+        - class: Fillna
+          kwargs:
+              fields_group: feature
+port_analysis_config: &port_analysis_config
+    strategy:
+        class: TopkDropoutStrategy
+        module_path: qlib.contrib.strategy
+        kwargs:
+            signal: <PRED>
+            topk: 50
+            n_drop: 5
+    backtest:
+        start_time: 2017-01-01
+        end_time: 2020-08-01
+        account: 100000000
+        benchmark: *benchmark
+        exchange_kwargs:
+            limit_threshold: 0.095
+            deal_price: close
+            open_cost: 0.0005
+            close_cost: 0.0015
+            min_cost: 5
+task:
+    model:
+        class: LGBModel
+        module_path: qlib.contrib.model.gbdt
+        kwargs:
+            loss: mse
+            colsample_bytree: 0.8879
+            learning_rate: 0.2
+            subsample: 0.8789
+            lambda_l1: 205.6999
+            lambda_l2: 580.9768
+            max_depth: 8
+            num_leaves: 210
+            num_threads: 20
+    dataset:
+        class: DatasetH
+        module_path: qlib.data.dataset
+        kwargs:
+            handler:
+                class: CausalWM357
+                module_path: qlib.contrib.data.causalwm_handler
+                kwargs: *data_handler_config
+            segments:
+                train: [2008-01-01, 2014-12-31]
+                valid: [2015-01-01, 2016-12-31]
+                test: [2017-01-01, 2020-08-01]
+    record:
+        - class: SignalRecord
+          module_path: qlib.workflow.record_temp
+          kwargs:
+            model: <MODEL>
+            dataset: <DATASET>
+        - class: SigAnaRecord
+          module_path: qlib.workflow.record_temp
+          kwargs:
+            ana_long_short: False
+            ann_scaler: 52
+        - class: PortAnaRecord
+          module_path: qlib.workflow.record_temp
+          kwargs:
+            config: *port_analysis_config

--- a/qlib/contrib/data/causalwm_handler.py
+++ b/qlib/contrib/data/causalwm_handler.py
@@ -1,0 +1,249 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""CausalWM357 — 357 weight-free, closed-form world-model features.
+
+``CausalWM357`` is an ``Alpha158``/``Alpha360`` sibling built on a *discovered*
+feature set: 111 closed-form programs producing 357 columns, found by an
+explanatory search (does the candidate improve prediction of the market's own
+next state?) rather than by fitting returns.  **There are no learned weights
+anywhere** — every column is a frozen closed form, so the handler re-executes
+rather than re-fits, and every column is auditable: ``ret_weighted_reversal_0``
+is produced by the function ``ret_weighted_reversal``, printable with
+``python -m causalwm --show ret_weighted_reversal``.
+
+The feature math lives in the optional ``causalwm`` package (pip installable,
+MIT, pure PyTorch used as an array library); this module is only the Qlib
+adapter, so qlib carries no new numerics::
+
+    pip install causalwm
+
+How it differs from Alpha158 / Alpha360
+---------------------------------------
+* **Weekly rows.**  Daily bars are pulled through Qlib's data API and
+  resampled internally to W-FRI weekly bars (first/max/min/last/sum); the
+  handler serves one row per instrument-week, indexed by the week-end date.
+  This makes no claim on qlib ``freq="week"`` stores.
+* **Cross-sectional.**  Alpha158's expressions are per-instrument.  These
+  features are built from per-week cross-sectional Gaussianized ranks over the
+  loaded universe, so a value depends on which instruments were loaded, and
+  ``inst_processors`` (per-instrument processing) is refused rather than
+  silently changing their meaning.
+* **Full-history universe.**  The encoder needs a gapless 52-week history per
+  instrument; instruments entering or leaving mid-span are dropped, with a
+  warning reporting the kept count.
+* **Two-week signal.**  This is a weekly mechanism, not a daily alpha; see the
+  PR description for measured numbers at both horizons.
+* **Not expressible in the Qlib DSL.**  Cross-sectional Gaussianized ranks and
+  the closed-form programs over 52-week windows have no operator-language
+  form, so the features are computed by a small Python ``DataLoader`` instead
+  of ``QlibDataLoader``.
+
+Causality and the availability lag
+----------------------------------
+The phi row computed from weekly bars through Friday *W* is stamped at Friday
+``W + availability_lag_weeks``.  The default lag is **1 week**: the row served
+at Friday *W* was already fully computable at the close of Friday *W-1*, so it
+needs no same-bar data to be traded on at *W*'s close.  ``0`` restores the
+source paper's protocol.  Either way ``feature[t]`` depends only on raw data at
+or before *t* — the channel constructions are strictly past-only (expanding
+demeans, trailing windows, contemporaneous cross-sectional ranks).  The lag
+counts weekly *bars*: a week in which the whole market was closed has no bar,
+so a lagged stamp can land more than seven calendar days later (never fewer).
+
+Label
+-----
+The default is Alpha158's convention, ``Ref($close, -2)/Ref($close, -1) - 1``,
+evaluated **on the weekly grid** (buy at next week's close, sell the week
+after).  Any ``Ref($close, -a)/Ref($close, -b) - 1`` is accepted (``$close``
+standing in for ``Ref($close, 0)``), so the two-week horizon the feature set
+was discovered at is ``label=(["Ref($close, -2)/$close - 1"], ["LABEL0"])``.
+Because this loader builds weekly bars in Python it does not run Qlib's
+expression engine; any other expression is rejected with an explanatory
+message rather than silently mis-evaluated.
+
+Features are served RAW; the default ``infer_processors`` normalize them with a
+fit-ranged ``RobustZScoreNorm`` (so ``fit_start_time``/``fit_end_time`` are
+required, as for ``Alpha360``).
+
+Example
+-------
+.. code-block:: yaml
+
+    handler:
+        class: CausalWM357
+        module_path: qlib.contrib.data.causalwm_handler
+        kwargs:
+            start_time: 2016-01-01
+            end_time: 2020-08-01
+            fit_start_time: 2017-01-01
+            fit_end_time: 2018-12-31
+            instruments: csi300
+"""
+import pandas as pd
+
+from qlib.data import D
+
+from .handler import check_transform_proc
+from ...data.dataset.handler import DataHandlerLP
+from ...data.dataset.loader import DataLoader
+
+_DEFAULT_LEARN_PROCESSORS = [
+    {"class": "DropnaLabel"},
+    {"class": "CSZScoreNorm", "kwargs": {"fields_group": "label"}},
+]
+_DEFAULT_INFER_PROCESSORS = [
+    {"class": "RobustZScoreNorm", "kwargs": {"fields_group": "feature", "clip_outlier": True}},
+    {"class": "Fillna", "kwargs": {"fields_group": "feature"}},
+]
+
+#: Alpha158's label convention, evaluated on the weekly grid.
+DEFAULT_LABEL = (["Ref($close, -2)/Ref($close, -1) - 1"], ["LABEL0"])
+
+_IMPORT_HINT = (
+    "CausalWM357 needs the optional `causalwm` package (which brings PyTorch; CPU is fine):\n"
+    "    pip install causalwm\n"
+    "It ships the 111 closed-form feature programs; they carry ZERO learned weights, "
+    "torch is used only as an array library for the forward pass."
+)
+
+
+def _causalwm():
+    """Import the optional dependency lazily, with an actionable message.
+
+    torch is not a qlib dependency (though 33 modules under ``qlib/contrib``
+    already import it), so nothing here is imported until features or feature
+    names are actually requested.
+    """
+    try:
+        from causalwm import qlib_handler as _impl
+    except ImportError as exc:
+        raise ImportError(_IMPORT_HINT) from exc
+    return _impl
+
+
+class CausalWM357DL(DataLoader):
+    """Compute the CausalWM357 feature group in Python.
+
+    Configured by dict so the owning handler stays picklable; holds no torch
+    state — the encoder is built inside :meth:`load` and dropped again.
+    """
+
+    def __init__(
+        self,
+        label=DEFAULT_LABEL,
+        freq: str = "day",
+        availability_lag_weeks: int = 1,
+        week_anchor: str = "W-FRI",
+        warmup_days: int = 420,
+        filter_pipe=None,
+    ):
+        self.label = label
+        self.freq = freq
+        self.availability_lag_weeks = availability_lag_weeks
+        self.week_anchor = week_anchor
+        self.warmup_days = warmup_days  # >= 52 weeks of window + holiday slack
+        self.filter_pipe = filter_pipe
+
+    def load(self, instruments=None, start_time=None, end_time=None) -> pd.DataFrame:
+        if self.freq != "day":
+            raise ValueError(
+                "CausalWM357DL reads daily bars and resamples them to weekly bars "
+                f"internally; freq={self.freq!r} is not supported"
+            )
+        impl = _causalwm()
+        if isinstance(instruments, str):
+            instruments = D.instruments(market=instruments, filter_pipe=self.filter_pipe)
+        ext_start = (
+            None
+            if start_time is None
+            else pd.Timestamp(start_time) - pd.Timedelta(days=self.warmup_days)
+        )
+        daily = D.features(
+            instruments,
+            ["$open", "$high", "$low", "$close", "$volume"],
+            start_time=ext_start,
+            end_time=end_time,
+            freq="day",
+        ).reset_index()
+        daily.columns = ["symbol", "timestamp", "open", "high", "low", "close", "volume"]
+        df = impl.compute_weekly_features(
+            daily,
+            label=self.label,
+            availability_lag_weeks=self.availability_lag_weeks,
+            week_anchor=self.week_anchor,
+            core_only=True,
+        )
+        return df.loc[pd.IndexSlice[slice(start_time, end_time), :], :]
+
+
+class CausalWM357(DataHandlerLP):
+    """357 discovered, weight-free, closed-form features (111 programs).
+
+    See the module docstring for the weekly grid, the causal availability lag,
+    the label convention and the cross-sectional caveats.
+    """
+
+    N_PROGRAMS = 111
+    N_FEATURES = 357
+
+    def __init__(
+        self,
+        instruments="csi300",
+        start_time=None,
+        end_time=None,
+        freq="day",
+        infer_processors=_DEFAULT_INFER_PROCESSORS,
+        learn_processors=_DEFAULT_LEARN_PROCESSORS,
+        fit_start_time=None,
+        fit_end_time=None,
+        process_type=DataHandlerLP.PTYPE_A,
+        filter_pipe=None,
+        inst_processors=None,
+        availability_lag_weeks=1,
+        week_anchor="W-FRI",
+        warmup_days=420,
+        **kwargs,
+    ):
+        if inst_processors:
+            raise NotImplementedError(
+                "CausalWM357 features are cross-sectional over the loaded universe, "
+                "so per-instrument processors would change their meaning; leave "
+                "inst_processors empty"
+            )
+        label = kwargs.pop("label", self.get_label_config())
+        if label is not None:  # fail fast, before any data is touched
+            for expr in label[0]:
+                _causalwm()._parse_close_ratio_label(expr)
+        infer_processors = check_transform_proc(infer_processors, fit_start_time, fit_end_time)
+        learn_processors = check_transform_proc(learn_processors, fit_start_time, fit_end_time)
+
+        data_loader = {
+            "class": "CausalWM357DL",
+            "module_path": __name__,
+            "kwargs": {
+                "label": label,
+                "freq": freq,
+                "availability_lag_weeks": availability_lag_weeks,
+                "week_anchor": week_anchor,
+                "warmup_days": warmup_days,
+                "filter_pipe": filter_pipe,
+            },
+        }
+        super().__init__(
+            instruments=instruments,
+            start_time=start_time,
+            end_time=end_time,
+            data_loader=data_loader,
+            infer_processors=infer_processors,
+            learn_processors=learn_processors,
+            process_type=process_type,
+            **kwargs,
+        )
+
+    @staticmethod
+    def get_feature_config():
+        """The 357 served column names, in phi order (``f"{program}_{k}"``)."""
+        return _causalwm().core_feature_names()
+
+    def get_label_config(self):
+        return DEFAULT_LABEL

--- a/tests/data_mid_layer_tests/test_causalwm_handler.py
+++ b/tests/data_mid_layer_tests/test_causalwm_handler.py
@@ -1,0 +1,190 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for ``qlib.contrib.data.causalwm_handler``.
+
+``causalwm`` is an OPTIONAL dependency, so the suite is split in two:
+
+* :class:`TestCausalWMOptionalDependency` always runs.  It checks that
+  importing the handler module never pulls in causalwm/torch and that, when
+  they are missing, the failure is an ``ImportError`` telling the user what to
+  install.
+* :class:`TestCausalWM357` needs the optional dependency and a data store; it
+  is skipped otherwise.  It exercises the handler end to end.
+
+Run with pytest (``pytest tests/data_mid_layer_tests/test_causalwm_handler.py``)
+or unittest (``python -m unittest tests.data_mid_layer_tests.test_causalwm_handler``).
+"""
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from qlib.contrib.data.causalwm_handler import CausalWM357
+from qlib.data import D
+from qlib.data.dataset.handler import DataHandler, DataHandlerLP
+from qlib.tests import TestAutoData
+
+try:  # the optional dependency, imported here only to decide what to skip
+    import causalwm  # noqa: F401
+    import torch  # noqa: F401
+
+    HAS_CAUSALWM = True
+except ImportError:
+    HAS_CAUSALWM = False
+
+_SKIP_REASON = "needs the optional `causalwm` package (pip install causalwm)"
+
+
+class TestCausalWMOptionalDependency(unittest.TestCase):
+    """Runs whether or not the optional dependency is installed."""
+
+    def test_module_imports_without_the_optional_dependency(self):
+        # The import at the top of this file already proves it; assert the
+        # public surface is there so the check cannot rot into a no-op.
+        self.assertTrue(issubclass(CausalWM357, DataHandlerLP))
+        self.assertEqual(CausalWM357.N_FEATURES, 357)
+        self.assertEqual(CausalWM357.N_PROGRAMS, 111)
+
+    @unittest.skipIf(HAS_CAUSALWM, "causalwm is installed, the error path cannot fire")
+    def test_missing_dependency_error_is_actionable(self):
+        with self.assertRaises(ImportError) as ctx:
+            CausalWM357.get_feature_config()
+        self.assertIn("pip install causalwm", str(ctx.exception))
+
+
+@unittest.skipUnless(HAS_CAUSALWM, _SKIP_REASON)
+class TestCausalWM357(TestAutoData):
+    """End-to-end checks against a data store."""
+
+    START = "2018-01-01"
+    END = "2020-12-31"
+    CUT = "2020-06-30"  # for the causal-lag test
+    N_INSTRUMENTS = 20
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        # An explicit instrument list, not a market name: the features are
+        # cross-sectional, so the two handlers below must see the same universe.
+        universe = D.list_instruments(
+            D.instruments("csi300"), start_time=cls.START, end_time=cls.END, as_list=True
+        )
+        cls.instruments = sorted(universe)[: cls.N_INSTRUMENTS]
+        cls.handler = CausalWM357(
+            instruments=cls.instruments,
+            start_time=cls.START,
+            end_time=cls.END,
+            infer_processors=[],
+            learn_processors=[],
+        )
+        cls.df = cls.handler.fetch(data_key=DataHandlerLP.DK_R, col_set=DataHandler.CS_RAW)
+
+    def test_columns_are_the_357_named_programs(self):
+        names = CausalWM357.get_feature_config()
+        self.assertEqual(len(names), 357)
+        self.assertEqual(len(set(names)), 357)
+        feature = self.df["feature"]
+        self.assertEqual(feature.shape[1], 357)
+        self.assertEqual(list(feature.columns), names)
+        # column names are program names, not opaque codes
+        self.assertTrue(all(n[-1].isdigit() and "_" in n for n in names))
+
+    def test_frame_contract(self):
+        self.assertEqual(list(self.df.index.names), ["datetime", "instrument"])
+        self.assertEqual(sorted(self.df.columns.get_level_values(0).unique()), ["feature", "label"])
+        self.assertIn("LABEL0", list(self.df["label"].columns))
+        self.assertTrue(self.df.index.is_monotonic_increasing)
+        self.assertGreater(len(self.df), 0)
+        got = set(self.df.index.get_level_values("instrument").unique())
+        self.assertTrue(got.issubset(set(self.instruments)))
+
+    def test_rows_are_weekly_friday_stamped(self):
+        dates = self.df.index.get_level_values("datetime")
+        self.assertTrue((dates.dayofweek == 4).all(), "rows must sit on the W-FRI grid")
+        # whole weeks with no trading day at all (holiday weeks) are absent from
+        # the grid, so gaps are multiples of a week rather than exactly one week
+        gaps = pd.Series(sorted(dates.unique())).diff().dropna().dt.days
+        self.assertTrue((gaps % 7 == 0).all(), "dates must sit on a weekly grid")
+        self.assertGreater((gaps == 7).mean(), 0.9, "most weeks should be consecutive")
+
+    def test_no_nan_explosion(self):
+        feature = self.df["feature"].to_numpy(dtype="float64")
+        self.assertLess(np.isnan(feature).mean(), 1e-3)
+        finite = feature[np.isfinite(feature)]
+        self.assertEqual(finite.size, feature.size, "features must not contain inf")
+        self.assertLess(np.abs(finite).max(), 1e6)
+        # a label is missing only where the future close does not exist yet
+        label = self.df["label"]["LABEL0"]
+        self.assertLess(label.isna().mean(), 0.05)
+
+    def test_features_at_t_use_only_data_up_to_t(self):
+        """Truncating the panel after CUT must not change any earlier row."""
+        truncated = CausalWM357(
+            instruments=self.instruments,
+            start_time=self.START,
+            end_time=self.CUT,
+            infer_processors=[],
+            learn_processors=[],
+        ).fetch(data_key=DataHandlerLP.DK_R, col_set=DataHandler.CS_RAW)["feature"]
+        full = self.df["feature"]
+        shared = full.index.intersection(truncated.index)
+        # stay clear of the truncation boundary: the 52-week window of a row
+        # near CUT is complete, but the weekly bar at CUT itself may be partial
+        shared = shared[shared.get_level_values("datetime") <= pd.Timestamp(self.CUT) - pd.Timedelta(weeks=8)]
+        self.assertGreater(len(shared), 100, "not enough overlap to test the property")
+        np.testing.assert_allclose(
+            full.loc[shared].to_numpy(dtype="float64"),
+            truncated.loc[shared].to_numpy(dtype="float64"),
+            rtol=0,
+            atol=1e-6,
+            err_msg="a feature value changed when future data was removed",
+        )
+
+    def test_availability_lag_shifts_the_stamp_by_one_bar(self):
+        unlagged = CausalWM357(
+            instruments=self.instruments,
+            start_time=self.START,
+            end_time=self.END,
+            availability_lag_weeks=0,
+            infer_processors=[],
+            learn_processors=[],
+        ).fetch(data_key=DataHandlerLP.DK_R, col_set=DataHandler.CS_RAW)["feature"]
+        lagged = self.df["feature"]
+        row = lagged.index[len(lagged) // 2]
+        # the previous date on the weekly grid, which a holiday week can put
+        # more than seven calendar days back
+        grid = pd.DatetimeIndex(sorted(unlagged.index.get_level_values("datetime").unique()))
+        earlier = (grid[grid.get_loc(row[0]) - 1], row[1])
+        self.assertIn(earlier, unlagged.index)
+        np.testing.assert_allclose(
+            lagged.loc[row].to_numpy(dtype="float64"),
+            unlagged.loc[earlier].to_numpy(dtype="float64"),
+            rtol=0,
+            atol=1e-6,
+        )
+
+    def test_unsupported_label_expression_is_rejected(self):
+        with self.assertRaises(NotImplementedError):
+            CausalWM357(
+                instruments=self.instruments,
+                start_time=self.START,
+                end_time=self.END,
+                label=(["Ref($vwap, -2)/Ref($vwap, -1) - 1"], ["LABEL0"]),
+                infer_processors=[],
+                learn_processors=[],
+            )
+
+    def test_inst_processors_are_refused(self):
+        with self.assertRaises(NotImplementedError):
+            CausalWM357(
+                instruments=self.instruments,
+                start_time=self.START,
+                end_time=self.END,
+                inst_processors=[{"class": "Resample1minProcessor"}],
+                infer_processors=[],
+                learn_processors=[],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Add `CausalWM357`: 357 weight-free, closed-form, discovered features

## What this adds

| File | Purpose |
|---|---|
| `qlib/contrib/data/causalwm_handler.py` | `CausalWM357(DataHandlerLP)` + `CausalWM357DL(DataLoader)` |
| `tests/data_mid_layer_tests/test_causalwm_handler.py` | optional-dependency guard, data-store construction, frame contract, no-NaN-explosion, causal-lag property |
| `examples/benchmarks/LightGBM/workflow_config_lightgbm_CausalWM357.yaml` | runnable benchmark config, structurally identical to the Alpha158 one |

`CausalWM357` is an `Alpha158`/`Alpha360` sibling — same constructor shape, same
`feature`/`label` contract — built on a feature set that was **discovered, not
hand-engineered**, and that carries **zero learned parameters**.

The name follows the existing convention of naming a handler after its feature
count: 111 closed-form programs producing 357 columns.

## Why

Qlib's built-in feature libraries are hand-written expression bags. This one was
produced by an *explanatory* search: a candidate program was admitted only if it
improved cross-validated prediction of the market's own **next state**, never by
fitting returns. What survives is a small set of frozen closed forms with three
properties that matter for a library feature set:

1. **Weight-free and reproducible.** Nothing is trained at load time. The
   handler re-executes fixed formulas; the same input always yields the same
   output, on CPU, with no checkpoint to ship or version.
2. **Auditable end to end.** Every column is named after the program that
   produced it — a feature-importance table reads as mechanisms, not as
   `KLEN`/`VSTD5` codes. `python -m causalwm --show ret_weighted_reversal`
   prints the exact source of any column's program.
3. **Slow, transferable structure.** The programs were discovered on a US
   universe and applied unchanged to CSI 300; the measurements below are all of
   that transferred feature set, with no re-discovery on the target market.

## How it differs from Alpha158 / Alpha360

| | Alpha158 / Alpha360 | CausalWM357 |
|---|---|---|
| Definition | expressions in the Qlib operator DSL | 111 Python closed-form programs (in the `causalwm` package) |
| Computation | `QlibDataLoader` | small custom `DataLoader` (the ops have no DSL form) |
| Row grid | daily | **weekly, W-FRI, Friday-stamped** (daily bars resampled internally) |
| Scope | per-instrument | **cross-sectional** over the loaded universe (per-week Gaussianized ranks) |
| Universe | any | **full-history only** — instruments entering/leaving mid-span are dropped, with a warning |
| Horizon | daily label | weekly label; the feature set was discovered at a **two-week** horizon |
| Dependencies | none beyond qlib | optional `causalwm` (brings torch, CPU is fine) |

Two design points worth reviewing explicitly:

* **Causal availability lag.** The phi row computed from weekly bars through
  Friday *W* is stamped at Friday `W + availability_lag_weeks`, default **1**:
  the row served at Friday *W* was already fully computable a week earlier, so
  it needs no same-bar data to be tradable at *W*'s close. `0` restores the
  source paper's protocol. Either way `feature[t]` depends only on raw data at
  or before *t*; there is a test for this that removes future data and asserts
  no earlier row changes.
* **Label.** The default is Alpha158's own convention,
  `Ref($close, -2)/Ref($close, -1) - 1`, read **on the weekly grid**. Any
  `Ref($close, -a)/Ref($close, -b) - 1` is accepted (so the paper's two-week
  horizon is `Ref($close, -2)/$close - 1`). Because the loader builds weekly
  bars in Python it does not run Qlib's expression engine, so any other
  expression is rejected with an explanatory `NotImplementedError` rather than
  silently mis-evaluated.

## The optional-dependency story

The feature math lives in a separate MIT-licensed pip package, `causalwm`
(PyTorch is used only as an array library for a weight-free forward pass).
**Qlib gains no new hard dependency and no new numerics to maintain** — the file
added here is a thin adapter.

* the module imports cleanly with neither `causalwm` nor `torch` installed;
* both are imported lazily, only when features (or feature names) are actually
  requested;
* the failure mode is an `ImportError` that names the fix:

```
CausalWM357 needs the optional `causalwm` package (which brings PyTorch; CPU is fine):
    pip install causalwm
It ships the 111 closed-form feature programs; they carry ZERO learned weights, torch is used only as an array library for the forward pass.
```

For precedent: 33 modules under `qlib/contrib/` already import torch in
0.9.7 — we still kept the import lazy, because a data handler should not be a
reason to install a deep-learning framework.

## How to run

```bash
pip install causalwm
qrun examples/benchmarks/LightGBM/workflow_config_lightgbm_CausalWM357.yaml
```

or in Python:

```python
from qlib.contrib.data.causalwm_handler import CausalWM357

h = CausalWM357(
    instruments="csi300",
    start_time="2017-01-01", end_time="2020-08-01",
    fit_start_time="2017-01-01", fit_end_time="2018-12-31",
)
df = h.fetch()          # (weekly rows) x (357 features + LABEL0)
```

Tests:

```bash
pytest tests/data_mid_layer_tests/test_causalwm_handler.py
```

Without `causalwm` installed, the data-store tests skip and the
optional-dependency tests still run and pass.

## Numbers we measured

These are **our** measurements, stated with their protocol. They are *not*
produced by the Qlib workflow above; they come from the harness of the paper
this feature set is from, which is stricter than a single held-out split.

**Protocol.** CSI 300, a fixed 225-name full-history universe, weekly bars,
two-week forward log-return Gaussianized cross-sectionally, 28-path
combinatorially-purged CPCV (8 blocks choose 2, 3-week embargo on both sides),
ridge readout as the only fitted object, refit per market. Every feature set
saw the **same universe, same folds, same readout**; Alpha158/Alpha360 were
extracted from Qlib and evaluated at each set's own best in-fold configuration.

| Feature set | mean rank IC (28 paths) | worst path | paths > 0 |
|---|---|---|---|
| Alpha360 (300 cols) | +0.014 | −0.011 | 24/28 |
| Alpha158 (157 cols) | +0.045 | +0.021 | 28/28 |
| **CausalWM357 (357 cols, transferred)** | +0.0385 | −0.015 | 27/28 |
| **CausalWM357 + in-fold top-40 selection** | **+0.047** | **+0.001** | **28/28** |

Selection is applied inside each training fold (no leakage). It *raises* the
discovered core (+0.0385 → +0.047) and *lowers* Alpha158 (+0.045 → +0.037 at
top-40), which is the behaviour you would expect from a separable set of
mechanisms versus a homogeneous engineered bag.

**State self-prediction.** Same weekly panels, one harness, CSI 300: fit an
affine ridge transition operator on each feature state and score out-of-sample
self-prediction, plus the half-life of an autoregressive rollout from a single
anchor (no observations after the anchor).

| State | R² @ 2 wk | R² @ 8 wk | R² @ 26 wk | rollout half-life |
|---|---|---|---|---|
| Alpha158 | 0.26 | 0.05 | 0.01 | 3.8 wk |
| Alpha360 | 0.48 | 0.07 | 0.00 | 4.8 wk |
| **CausalWM357** | **0.77** | **0.50** | **0.21** | **20.2 wk** |

This is the property the search optimized for, and it is the honest reason to
consider the set interesting as a *state* rather than as another alpha bag.

### What this feature set is not

* **It is a two-week signal, not a daily alpha.** At the one-day horizon it
  carries very little: rank IC ≈ 0.007–0.025 depending on protocol. In Qlib's
  own daily pipeline on the public `cn_data` store, under a linear readout, we
  measured 1-day rank IC +0.0085 for this set against −0.0007 (Alpha158) and
  −0.0089 (Alpha360) — i.e. everything is near zero at that horizon. Anyone
  benchmarking daily strategies should expect little from it.
* **The benchmark yaml has not been tuned.** It mirrors the Alpha158 LightGBM
  config so the comparison is structural, not a hyper-parameter contest; the
  only deliberate changes are `ann_scaler: 52` (weekly rows) and the fit-ranged
  `RobustZScoreNorm`.
* **The universe restriction is real.** Requiring a gapless 52-week history per
  instrument drops names that enter or leave mid-span. Per-window dynamic
  universe support is future work, and we are happy to do it in this PR if
  maintainers prefer.
* **We have not re-run the paper's CPCV numbers inside Qlib's workflow.** The
  table above is our harness; the Qlib-pipeline comparison mentioned in the
  1-day bullet is a separate, linear-readout run.

## Alternative, if you prefer

If maintainers would rather not carry a handler with an optional dependency,
the same class ships in the `causalwm` package itself and works today through
`module_path: causalwm.qlib_handler` with no change to qlib. We are proposing it
here because a discovered, weight-free, auditable feature set seems like a
useful third point next to Alpha158 and Alpha360 — but the package route is a
perfectly good outcome and we will close the PR without argument.

## Verification (run 2026-08-01, macOS arm64, Python 3.10, qlib 0.9.7 + torch 2.13.0)

Against a real Qlib CSI 300 store (`~/.qlib/qlib_data/cn_data`):

| Check | Result |
|---|---|
| Handler test-suite (`test_causalwm_handler.py`) | **9 passed, 1 skipped** (the skip is the torch-absent case, unreachable when torch is installed) |
| Column contract vs the reference implementation | `CausalWM357` matches **Alpha158** exactly: `_data` is 2-level, `fetch()` returns 1 level (Qlib's `CS_ALL` drops the outer level), `fetch(col_set=CS_RAW)` is 2-level |
| `qrun workflow_config_lightgbm_CausalWM357.yaml` | **completes end to end**: IC 0.0709, ICIR 0.4732, Rank IC 0.0574, Rank ICIR 0.3273 |
| Causal-lag property (features at *t* use only data <= *t*) | max abs. difference **0.000e+00** over 4,720 shared rows |
| Encoder vs the discovery engine's reference features | **max abs. difference 6.1e-05** over 220,428 windows x 472 features |

The `qrun` figures above are a **smoke test, not a benchmark**: one 2020 test split on a
locally truncated store (it ends 2020-09), Qlib's daily label, LightGBM. They demonstrate
that the workflow runs and produces sane output. The evaluation we stand behind is the
purged-CPCV comparison in the section above.
