### PR TITLE
Docs: clarify equal-weighted portfolio vs cap-weighted benchmark comp…

### DIFF
--- a/docs/component/strategy.rst
+++ b/docs/component/strategy.rst
@@ -88,6 +88,14 @@ TopkDropoutStrategy
 
 - Generate the order list from the target amount
 
+.. note::
+    `TopkDropoutStrategy` holds an **equal-weighted** portfolio: the available cash is split
+    evenly among the stocks bought on each rebalance. When its results are compared against a
+    capitalization-weighted benchmark such as the default ``SH000300``, the reported excess
+    return also contains the equal- versus cap-weighting spread of the universe, which is a
+    property of the weighting scheme rather than of the signal. Use a benchmark whose weighting
+    scheme matches the strategy if you want to isolate the contribution of the signal.
+
 EnhancedIndexingStrategy
 ------------------------
 `EnhancedIndexingStrategy` Enhanced indexing combines the arts of active management and passive management,

--- a/qlib/contrib/strategy/signal_strategy.py
+++ b/qlib/contrib/strategy/signal_strategy.py
@@ -73,6 +73,24 @@ class BaseSignalStrategy(BaseStrategy, ABC):
 
 
 class TopkDropoutStrategy(BaseSignalStrategy):
+    """
+    An equal-weighted top-k strategy with fixed daily turnover (the ``Topk-Drop`` algorithm).
+
+    .. note::
+        Positions are **equal-weighted**. On each rebalance the available cash is divided
+        evenly among the stocks to be bought (see :meth:`generate_trade_decision`), so the
+        realized portfolio approximates an equal-weighted portfolio of ``topk`` names.
+
+        This is worth keeping in mind when reading the excess return reported by
+        :class:`qlib.workflow.record_temp.PortAnaRecord`, which is a plain difference
+        against a single benchmark instrument. The default benchmark ``SH000300``
+        (CSI 300) is capitalization-weighted, so that difference also contains the return
+        spread between equal- and cap-weighting of the universe, which is a property of
+        the weighting scheme rather than of the signal. To isolate the contribution of the
+        signal, use a benchmark whose weighting scheme matches the strategy, e.g.
+        an equal-weighted portfolio of the same universe run through the same executor.
+    """
+
     # TODO:
     # 1. Supporting leverage the get_range_limit result from the decision
     # 2. Supporting alter_outer_trade_decision

--- a/qlib/workflow/record_temp.py
+++ b/qlib/workflow/record_temp.py
@@ -365,6 +365,20 @@ class PortAnaRecord(ACRecordTemp):
 
         - The return report and detailed positions of the backtest, returned by `qlib/contrib/evaluate.py:backtest`
     - port_analysis.pkl : The risk analysis of your portfolio, returned by `qlib/contrib/evaluate.py:risk_analysis`
+
+    .. note::
+        ``excess_return_without_cost`` and ``excess_return_with_cost`` are computed as a
+        plain arithmetic difference between the portfolio return and the return of the
+        single instrument configured as ``config["backtest"]["benchmark"]``. No adjustment
+        is made for a difference in weighting scheme between the strategy and the benchmark.
+
+        The default configuration pairs an equal-weighted strategy
+        (:class:`~qlib.contrib.strategy.signal_strategy.TopkDropoutStrategy`) with a
+        capitalization-weighted benchmark (``SH000300``). Under that pairing the reported
+        excess return also contains the equal- versus cap-weighting spread of the universe,
+        so it should be read as performance relative to that specific index rather than as
+        the contribution of the signal alone. Choosing a benchmark whose weighting scheme
+        matches the strategy removes that component.
     """
 
     artifact_path = "portfolio_analysis"


### PR DESCRIPTION
## Description

Documentation-only follow-up to #2315. No behavior change.

- `qlib/contrib/strategy/signal_strategy.py` — add a class docstring to `TopkDropoutStrategy` stating that positions are equal-weighted, and noting the implication for benchmark choice. (The class previously had no docstring, only a `# TODO:` block.)
- `qlib/workflow/record_temp.py` — add a note to the `PortAnaRecord` docstring describing how `excess_return_with_cost` / `excess_return_without_cost` are computed, and that no weighting adjustment is applied.
- `docs/component/strategy.rst` — add the same note to the `TopkDropoutStrategy` section.

No code paths, defaults, or outputs are modified.

## Motivation and Context

Related issue: #2315

`TopkDropoutStrategy` sizes new positions by splitting the available cash evenly across the stocks to be bought (`qlib/contrib/strategy/signal_strategy.py:266`), so the realized portfolio is close to equal-weighted. `PortAnaRecord` reports excess return as a plain arithmetic difference against a single benchmark instrument (`qlib/workflow/record_temp.py:507-512`), and the default benchmark is `SH000300` (CSI 300), which is capitalization-weighted.

These two defaults are used together in the default `PortAnaRecord` config and throughout `examples/benchmarks`. Because no adjustment is made for the difference in weighting scheme, the reported excess return contains the equal- versus cap-weighting spread of the universe in addition to the contribution of the signal. #2315 has the measurements: with a zero-alpha signal the offset is material and consistently signed, and it shifts the reported numbers for a real LightGBM + Alpha158 run as well.

This is not a defect in the arithmetic. Excess return against a named index is a legitimate quantity, and it is the right one if the question is "did this beat the CSI 300." It is a gap in what the documentation lets a reader assume, because the same number is routinely read as the contribution of the model. This PR makes the distinction explicit at the three places a user is most likely to be standing when they form that assumption.

### Why documentation first

#2315 sketched two possible directions: changing or parameterizing the comparison, or documenting the current behavior. The second is separable and carries no compatibility risk, so it is offered on its own here rather than bundled. If maintainers prefer the first, an equal-weighted benchmark option is a natural follow-up — `qlib/contrib/report/analysis_position/profit_attribution.py:238` already carries a TODO for exactly that — and I am happy to open it.

## How Has This Been Tested?

- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

Docstrings and reStructuredText only; no executable code paths are touched, so there are no test coverage implications. The change adds lines only (+40 / -0) and does not modify any existing line, so `black` formatting of existing code is unaffected.

## Types of changes

- [ ] Fix bugs
- [ ] Add new feature
- [x] Update documentation