### PR TITLE
fix(backtest): guard zero cost_ratio in _get_buy_amount_by_cash_limit

### DIFF
--- a/qlib/backtest/exchange.py
+++ b/qlib/backtest/exchange.py
@@ -846,6 +846,11 @@ class Exchange:
         """
         max_trade_amount = 0.0
         if cash >= self.min_cost:
+            if cost_ratio <= 0:
+                # Without a proportional fee the service fee is always `min_cost`,
+                # so there is no critical price to compare against.
+                max_trade_amount = (cash - self.min_cost) / trade_price
+                return max_trade_amount
             # critical_price means the stock transaction price when the service fee is equal to min_cost.
             critical_price = self.min_cost / cost_ratio + self.min_cost
             if cash >= critical_price:

--- a/tests/backtest/test_exchange_cost.py
+++ b/tests/backtest/test_exchange_cost.py
@@ -1,0 +1,60 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import unittest
+
+from qlib.backtest.exchange import Exchange
+
+
+def make_exchange(min_cost: float) -> Exchange:
+    """Build an Exchange for testing `_get_buy_amount_by_cash_limit` only.
+
+    The method is pure arithmetic over `min_cost`, so the instance is created
+    without `__init__` to keep the test free of the data layer.
+    """
+    exchange = object.__new__(Exchange)
+    exchange.min_cost = min_cost
+    return exchange
+
+
+class TestBuyAmountByCashLimit(unittest.TestCase):
+    """`_get_buy_amount_by_cash_limit` must handle a zero proportional fee."""
+
+    TRADE_PRICE = 10.0
+    CASH = 1000.0
+
+    def test_default_cost_ratio(self):
+        """With the default fees, the min_cost branch applies at this cash level."""
+        exchange = make_exchange(min_cost=5.0)
+        # critical_price = 5 / 0.0015 + 5 = 3338.3 > cash, so the fee is min_cost.
+        amount = exchange._get_buy_amount_by_cash_limit(self.TRADE_PRICE, self.CASH, cost_ratio=0.0015)
+        self.assertAlmostEqual(amount, (self.CASH - 5.0) / self.TRADE_PRICE)
+
+    def test_cost_ratio_above_critical_price(self):
+        """Above the critical price the proportional fee applies."""
+        exchange = make_exchange(min_cost=5.0)
+        cash = 10_000.0
+        amount = exchange._get_buy_amount_by_cash_limit(self.TRADE_PRICE, cash, cost_ratio=0.0015)
+        self.assertAlmostEqual(amount, cash / 1.0015 / self.TRADE_PRICE)
+
+    def test_zero_cost_ratio_with_min_cost(self):
+        """A zero proportional fee must not divide by zero; min_cost still applies."""
+        exchange = make_exchange(min_cost=5.0)
+        amount = exchange._get_buy_amount_by_cash_limit(self.TRADE_PRICE, self.CASH, cost_ratio=0.0)
+        self.assertAlmostEqual(amount, (self.CASH - 5.0) / self.TRADE_PRICE)
+
+    def test_frictionless(self):
+        """With no fee at all the whole cash balance is investable."""
+        exchange = make_exchange(min_cost=0.0)
+        amount = exchange._get_buy_amount_by_cash_limit(self.TRADE_PRICE, self.CASH, cost_ratio=0.0)
+        self.assertAlmostEqual(amount, self.CASH / self.TRADE_PRICE)
+
+    def test_cash_below_min_cost(self):
+        """Cash that cannot even cover the minimum fee buys nothing."""
+        exchange = make_exchange(min_cost=5.0)
+        amount = exchange._get_buy_amount_by_cash_limit(self.TRADE_PRICE, 1.0, cost_ratio=0.0)
+        self.assertEqual(amount, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

`Exchange._get_buy_amount_by_cash_limit` raises `ZeroDivisionError` whenever the backtest is configured without a proportional trading fee.

The helper works out the cash level at which the proportional fee overtakes the flat `min_cost` floor:

```python
critical_price = self.min_cost / cost_ratio + self.min_cost
```

`cost_ratio` is `open_cost + adj_cost_ratio`, and `adj_cost_ratio` derives from `impact_cost`, which defaults to `0.0`. So `Exchange(open_cost=0, close_cost=0)` makes `cost_ratio` exactly zero and the division raises. Setting `min_cost=0` as well does not help — `0.0 / 0.0` raises too.

When there is no proportional fee the service fee is always `min_cost`, so no critical price exists and the `min_cost` branch is already the correct answer. This PR returns it directly, which leaves every non-zero `cost_ratio` path byte-identical:

```python
if cost_ratio <= 0:
    # Without a proportional fee the service fee is always `min_cost`,
    # so there is no critical price to compare against.
    max_trade_amount = (cash - self.min_cost) / trade_price
    return max_trade_amount
```

## Motivation and Context

No related issue — found while reading the backtest cost model.

The helper is reached from the buy branch of `_calc_trade_info_by_order` when an order is larger than the available cash:

```python
elif cash < trade_val + max(trade_val * cost_ratio, self.min_cost):
    max_buy_amount = self._get_buy_amount_by_cash_limit(trade_price, cash, cost_ratio)
```

With `cost_ratio == 0` that condition reduces to `cash < trade_val + min_cost`, the ordinary "order doesn't quite fit in the account" case — so the crash fires on the first partially-funded buy rather than in some corner of the parameter space.

A zero-cost run is a routine baseline: it is how you separate how much of a strategy's result comes from the signal and how much is being consumed by frictions. That configuration currently cannot complete a backtest.

Minimal reproduction:

```python
from qlib.backtest.exchange import Exchange

ex = object.__new__(Exchange)   # the method is pure arithmetic over min_cost
ex.min_cost = 5.0

ex._get_buy_amount_by_cash_limit(trade_price=10.0, cash=1000.0, cost_ratio=0.0015)  # 99.5
ex._get_buy_amount_by_cash_limit(trade_price=10.0, cash=1000.0, cost_ratio=0.0)     # ZeroDivisionError
```

## How Has This Been Tested?

- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [x] If you are adding a new feature, test on your own test scripts.

I was not able to run `test_all_pipeline.py`, since it needs the official dataset that the README notes is currently disabled. Happy to run it if there is a data source you would like me to use.

Added `tests/backtest/test_exchange_cost.py` — five unit tests, no data dependency:

- the default fee schedule below the critical price (min_cost branch),
- a cash level above the critical price (proportional branch),
- zero `cost_ratio` with a non-zero `min_cost`,
- zero `cost_ratio` with `min_cost=0`, where the full balance is investable,
- cash below `min_cost`, which buys nothing.

## Screenshots of Test Results (if appropriate):

1. Pipeline test: not run — see above.

2. Your own tests:

```
$ python -m pytest tests/backtest/test_exchange_cost.py -q
.....                                                                    [100%]
5 passed in 1.73s
```

Against unpatched `main` the two zero-`cost_ratio` tests fail with `ZeroDivisionError` and the other three pass, which confirms the existing behaviour is unchanged:

```
$ python -m pytest tests/backtest/test_exchange_cost.py -q
FAILED tests/backtest/test_exchange_cost.py::TestBuyAmountByCashLimit::test_frictionless
FAILED tests/backtest/test_exchange_cost.py::TestBuyAmountByCashLimit::test_zero_cost_ratio_with_min_cost
2 failed, 3 passed in 1.51s
```

`black . -l 120 --check --exclude qlib/_version.py` is clean across the repository (334 files unchanged).

## Types of changes

- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
