### PR TITLE
fix: mask degenerate expanding rsquare windows

### DIFF
--- a/qlib/data/ops.py
+++ b/qlib/data/ops.py
@@ -1277,6 +1277,7 @@ class Rsquare(Rolling):
         _series = self.feature.load(instrument, start_index, end_index, *args)
         if self.N == 0:
             series = pd.Series(expanding_rsquare(_series.values), index=_series.index)
+            series.loc[np.isclose(_series.expanding(min_periods=1).std(), 0, atol=2e-05)] = np.nan
         else:
             series = pd.Series(rolling_rsquare(_series.values, self.N), index=_series.index)
             series.loc[np.isclose(_series.rolling(self.N, min_periods=1).std(), 0, atol=2e-05)] = np.nan

--- a/tests/ops/test_rolling_operator.py
+++ b/tests/ops/test_rolling_operator.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pandas as pd
+
+from qlib.data.ops import Rsquare
+
+
+class FeatureStub:
+    def __init__(self, values):
+        self.series = pd.Series(values, dtype=float)
+
+    def load(self, instrument, start_index, end_index, *args):
+        return self.series
+
+
+def test_expanding_rsquare_masks_near_constant_windows():
+    values = [100, 100, 100, 100.000001, 100, 100]
+
+    result = Rsquare(FeatureStub(values), 0)._load_internal(None, None, None)
+
+    assert result.isna().all()
+
+
+def test_expanding_rsquare_keeps_varying_windows():
+    values = [1, 2, 4, 8, 16]
+
+    result = Rsquare(FeatureStub(values), 0)._load_internal(None, None, None)
+
+    assert np.isfinite(result.iloc[1:]).all()


### PR DESCRIPTION
## Problem

`Rsquare(feature, 0)` uses the expanding Cython kernel but, unlike the rolling path, does not mask windows where the feature standard deviation is effectively zero. Floating-point cancellation can therefore leak `inf` or misleading finite R-squared values into expanding features.

Fixes #2297.

## Fix

Apply the same `std ~= 0` guard used by rolling R-squared to the expanding path, using `Series.expanding(min_periods=1).std()` so the mask follows each expanding window.

## Test

- Added a regression for the reported near-constant series; every degenerate expanding window is now `NaN`.
- Added a varying-series case to confirm valid expanding R-squared values remain finite.
- `python -m pytest tests/ops/test_rolling_operator.py -q` — 2 passed.
- Black check on the new test file and `git diff --check` passed.

## Risk

Low. The change is limited to the `N == 0` R-squared branch and reuses the existing rolling-path tolerance (`atol=2e-05`). Valid non-degenerate windows and all other rolling operators are unchanged.
