### PR TITLE
docs: clarify benchmark weighting semantics

### DIFF
--- a/qlib/backtest/report.py
+++ b/qlib/backtest/report.py
@@ -60,8 +60,12 @@ class PortfolioMetrics:
                             2017-01-09    0.006874
                             2017-01-10   -0.003350
                 - If `benchmark` is list, will use the daily average change of the stock pool in the list as the
-                    'bench'.
-                - If `benchmark` is str, will use the daily change as the 'bench'.
+                    'bench' (an equal-weighted benchmark).
+                - If `benchmark` is str, will use the daily change as the 'bench' for that instrument.
+
+                Note that an equal-weighted strategy compared with a string benchmark (for example, a
+                cap-weighted index) includes a weighting effect in its excess return. Use a benchmark with
+                the same weighting convention when the goal is to isolate strategy alpha.
                 benchmark code, default is SH000300 CSI300
             - start_time : Union[str, pd.Timestamp], optional
                 - If `benchmark` is pd.Series, it will be ignored

--- a/tests/backtest/test_benchmark_weighting.py
+++ b/tests/backtest/test_benchmark_weighting.py
@@ -1,0 +1,35 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from unittest.mock import patch
+
+import pandas as pd
+
+from qlib.backtest.report import PortfolioMetrics
+
+
+class TestBenchmarkWeighting:
+    @patch("qlib.backtest.report.get_higher_eq_freq_feature")
+    def test_list_benchmark_is_equal_weighted(self, get_feature):
+        dates = pd.to_datetime(["2026-01-02", "2026-01-02", "2026-01-05", "2026-01-05"])
+        instruments = ["A", "B", "A", "B"]
+        index = pd.MultiIndex.from_arrays(
+            [instruments, dates], names=["instrument", "datetime"]
+        )
+        returns = pd.DataFrame(
+            {"$close/Ref($close,1)-1": [0.10, 0.00, -0.05, 0.04]},
+            index=index,
+        )
+        get_feature.return_value = (returns, None)
+
+        benchmark = PortfolioMetrics._cal_benchmark(
+            {"benchmark": ["A", "B"]}, freq="day"
+        )
+
+        expected = pd.Series(
+            [0.05, -0.005],
+            index=pd.to_datetime(["2026-01-02", "2026-01-05"]),
+            name="$close/Ref($close,1)-1",
+        )
+        expected.index.name = "datetime"
+        pd.testing.assert_series_equal(benchmark, expected)


### PR DESCRIPTION
## Summary

Related to #2315.

- Clarify that a list benchmark is calculated as an equal-weighted average of the supplied instruments.
- Clarify that a string benchmark uses the return series of one benchmark instrument.
- Document the weighting effect when an equal-weighted strategy is compared with a cap-weighted index.
- Add a regression test covering the list-benchmark equal-weighting semantics.

This pull request intentionally does not change Qlib's default `SH000300` benchmark or historical backtest behavior. A dynamic point-in-time equal-weight benchmark would require a separate design decision.

## Testing

- `git diff --cached --check`
- `python3 -m py_compile qlib/backtest/report.py tests/backtest/test_benchmark_weighting.py`
- `PYTHONPATH=.../.openclaw/tmp/qlib .../.openclaw/tmp/qlib-venv/bin/python -m pytest -q tests/backtest/test_benchmark_weighting.py`

Targeted test result: 1 passed.
