### PR TITLE
fix(data): support unary expression negation

### DIFF
--- a/qlib/data/base.py
+++ b/qlib/data/base.py
@@ -29,6 +29,11 @@ class Expression(abc.ABC):
     def __repr__(self):
         return str(self)
 
+    def __neg__(self):
+        from .ops import Sub  # pylint: disable=C0415
+
+        return Sub(0, self)
+
     def __gt__(self, other):
         from .ops import Gt  # pylint: disable=C0415
 

--- a/tests/ops/test_elem_operator.py
+++ b/tests/ops/test_elem_operator.py
@@ -39,6 +39,19 @@ class TestElementOperator(TestMockData):
         golden = change.to_numpy()
         self.assertIsNone(np.testing.assert_allclose(result, golden))
 
+    def test_unary_negation(self):
+        cases = [
+            ("-$close", "0 - $close"),
+            ("-Std($close, 3)", "0 - Std($close, 3)"),
+        ]
+        for field, equivalent in cases:
+            with self.subTest(field=field):
+                result = ExpressionD.expression(self.instrument, field, self.start_time, self.end_time, self.freq)
+                expected = ExpressionD.expression(
+                    self.instrument, equivalent, self.start_time, self.end_time, self.freq
+                )
+                np.testing.assert_allclose(result.to_numpy(), expected.to_numpy(), equal_nan=True)
+
 
 class TestOperatorDataSetting(TestOperatorData):
     def test_setting(self):


### PR DESCRIPTION
## Description

Qlib feature expressions currently raise `TypeError` for Python unary negation, including common forms such as `-$close` and `-Std($close, 20)`. Downstream users have to rewrite these expressions as `0 - ...` before passing them to `D.features`.

This adds `Expression.__neg__` and represents unary negation with the existing `Sub(0, expression)` operator, so it keeps the same loading, rolling-window, and cache behavior as the established workaround.

Regression coverage verifies both a raw feature and a nested rolling expression against their existing `0 - ...` equivalents.

## Motivation and context

This was reproduced in an actual Qlib factor-return pipeline where negative volatility factors must currently be sanitized before evaluation. Supporting Python's standard unary operator removes that downstream compatibility rewrite and makes the expression DSL consistent with its existing binary arithmetic overloads.

## Testing

- `pytest -q -s tests/ops` — 7 passed, 2 subtests passed
- Black 23.7.0, line length 120 — passed
- Flake8 with the repository ignore set — passed
- `git diff --check` — passed

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update