### PR TITLE
fix(backtest): handle IndexError at right calendar boundary

### DIFF
--- a/qlib/backtest/utils.py
+++ b/qlib/backtest/utils.py
@@ -128,7 +128,16 @@ class TradeCalendarManager:
         if trade_step is None:
             trade_step = self.get_trade_step()
         calendar_index = self.start_index + trade_step - shift
-        return self._calendar[calendar_index], epsilon_change(self._calendar[calendar_index + 1])
+        if calendar_index + 1 < len(self._calendar):
+            right_time = self._calendar[calendar_index + 1]
+        else:
+            delta = (
+                self._calendar[calendar_index] - self._calendar[calendar_index - 1]
+                if calendar_index > 0
+                else pd.Timedelta(days=1)
+            )
+            right_time = self._calendar[calendar_index] + delta
+        return self._calendar[calendar_index], epsilon_change(right_time)
 
     def get_data_cal_range(self, rtype: str = "full") -> Tuple[int, int]:
         """


### PR DESCRIPTION
## Description
Fixes #2278. This adds a bounds check in `get_step_time` when calculating the right endpoint of the step interval to prevent an `IndexError` on the final trading day of the calendar. If the boundary is reached, it uses the previous time delta to safely advance.

## Motivation and Context
Fixes #2278. When backtesting on a dataset without a `future=True` calendar extension, the right interval endpoint on the very last day throws an `IndexError`. This properly handles the boundary condition.

## How Has This Been Tested?
- [x] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [x] If you are adding a new feature, test on your own test scripts.

## Screenshots of Test Results (if appropriate):
Pipeline test passed successfully (3 tests passed).

## Types of changes
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
