### PR TITLE
fix(strategy): use get_risk_degree() in TopkDropoutStrategy for position sizing

### DIFF
--- a/qlib/contrib/strategy/signal_strategy.py
+++ b/qlib/contrib/strategy/signal_strategy.py
@@ -263,7 +263,7 @@ class TopkDropoutStrategy(BaseSignalStrategy):
         # buy new stock
         # note the current has been changed
         # current_stock_list = current_temp.get_stock_list()
-        value = cash * self.risk_degree / len(buy) if len(buy) > 0 else 0
+        value = cash * self.get_risk_degree(trade_step) / len(buy) if len(buy) > 0 else 0
 
         # open_cost should be considered in the real trading environment, while the backtest in evaluate.py does not
         # consider it as the aim of demo is to accomplish same strategy as evaluate.py, so comment out this line


### PR DESCRIPTION
## Description
Fixes #2276. `TopkDropoutStrategy.generate_trade_decision` was sizing new buys using the raw attribute `self.risk_degree` instead of calling `self.get_risk_degree(trade_step)`. This prevented subclasses from implementing market timing by overriding `get_risk_degree()`. This PR replaces `self.risk_degree` with `self.get_risk_degree(trade_step)`.

## Motivation and Context
Fixes #2276. Using the getter allows subclasses to dynamically adjust the risk degree over time, which is the documented way to implement market timing. 

## How Has This Been Tested?
- [x] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [x] If you are adding a new feature, test on your own test scripts.

## Screenshots of Test Results (if appropriate):
Pipeline test passed successfully.

## Types of changes
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
