### PR TITLE
fix(model): resolve cross-day batching issue in DailyBatchSampler

### DIFF
--- a/qlib/contrib/model/pytorch_gats_ts.py
+++ b/qlib/contrib/model/pytorch_gats_ts.py
@@ -26,19 +26,15 @@ from ...contrib.model.pytorch_gru import GRUModel
 class DailyBatchSampler(Sampler):
     def __init__(self, data_source):
         self.data_source = data_source
-        # calculate number of samples in each batch
-        self.daily_count = (
-            pd.Series(index=self.data_source.get_index()).groupby("datetime", group_keys=False).size().values
-        )
-        self.daily_index = np.roll(np.cumsum(self.daily_count), 1)  # calculate begin index of each batch
-        self.daily_index[0] = 0
+        index = data_source.get_index()
+        positions = pd.Series(np.arange(len(index)), index=index.get_level_values("datetime"))
+        self.batches = [g.to_numpy() for _, g in positions.groupby(level=0, sort=True)]
 
     def __iter__(self):
-        for idx, count in zip(self.daily_index, self.daily_count):
-            yield np.arange(idx, idx + count)
+        yield from self.batches
 
     def __len__(self):
-        return len(self.data_source)
+        return len(self.batches)
 
 
 class GATs(Model):
@@ -332,7 +328,7 @@ class GATs(Model):
 
             preds.append(pred)
 
-        return pd.Series(np.concatenate(preds), index=dl_test.get_index())
+        return pd.Series(np.concatenate(preds), index=dl_test.get_index()[np.concatenate(sampler_test.batches)])
 
 
 class GATModel(nn.Module):


### PR DESCRIPTION
## Description
Fixes #2319. `DailyBatchSampler` previously assumed that the dataset rows belonging to the same trading day were contiguous. However, since the dataset is instrument-major, it was silently yielding cross-day batches (one instrument across many consecutive days). 
This PR rewrites `DailyBatchSampler` to explicitly group by the `datetime` index level, yielding batches that are true cross-sectional single days. Additionally, it properly re-aligns the prediction output in the `GATs.predict` method to match the new iteration order of the sampler.

## Motivation and Context
Fixes #2319. Training with cross-day batches completely invalidates cross-sectional models like GATs, as the graph/attention operates over a single stock's history rather than a single day's cross-section.

## How Has This Been Tested?
- [x] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [x] If you are adding a new feature, test on your own test scripts.

## Screenshots of Test Results (if appropriate):
Pipeline test passed successfully. Validated locally via isolated sampler iteration test.

## Types of changes
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation
