### PR TITLE
fix: forward delete_old in Yahoo data updates

### DIFF
--- a/scripts/data_collector/yahoo/README.md
+++ b/scripts/data_collector/yahoo/README.md
@@ -189,6 +189,7 @@ pip install -r requirements.txt
       * `region`: region, value from ["CN", "US"], default "CN"
       * `interval`: interval, default "1d"(Currently only supports 1d data)
       * `exists_skip`: exists skip, by default False
+      * `delete_old`: delete existing Qlib data directories before extracting a downloaded base dataset, by default True. Set `--delete_old False` to skip directory deletion; archive extraction can still overwrite existing files. This option only applies when local Qlib data is missing or incomplete and a base dataset is downloaded.
 
 ## Using qlib data
 

--- a/scripts/data_collector/yahoo/collector.py
+++ b/scripts/data_collector/yahoo/collector.py
@@ -937,6 +937,7 @@ class Run(BaseRun):
         check_data_length: int = None,
         delay: float = 1,
         exists_skip: bool = False,
+        delete_old: bool = True,
     ):
         """update yahoo data to bin
 
@@ -953,6 +954,9 @@ class Run(BaseRun):
             time.sleep(delay), default 1
         exists_skip: bool
             exists skip, by default False
+        delete_old: bool
+            delete existing qlib data directories before extracting the downloaded base dataset, by default True.
+            Set to False to skip directory deletion; archive extraction can still overwrite existing files.
         Notes
         -----
             If the data in qlib_data_dir is incomplete, np.nan will be populated to trading_date for the previous trading day
@@ -969,7 +973,11 @@ class Run(BaseRun):
         qlib_data_1d_dir = str(Path(qlib_data_1d_dir).expanduser().resolve())
         if not exists_qlib_data(qlib_data_1d_dir):
             GetData().qlib_data(
-                target_dir=qlib_data_1d_dir, interval=self.interval, region=self.region, exists_skip=exists_skip
+                target_dir=qlib_data_1d_dir,
+                interval=self.interval,
+                region=self.region,
+                exists_skip=exists_skip,
+                delete_old=delete_old,
             )
 
         # start/end date

--- a/tests/test_yahoo_collector.py
+++ b/tests/test_yahoo_collector.py
@@ -1,0 +1,97 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import Mock
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent / "scripts"))
+from data_collector.yahoo import collector
+
+
+@pytest.fixture
+def update_env(tmp_path, monkeypatch):
+    # BaseRun expects the command-line module to be importable as "collector".
+    monkeypatch.setitem(sys.modules, "collector", collector)
+    runner = collector.Run(
+        source_dir=tmp_path / "source",
+        normalize_dir=tmp_path / "normalize",
+        max_workers=2,
+        region="us",
+    )
+    data_dir = tmp_path / "qlib_data"
+    calendar_dir = data_dir / "calendars"
+    calendar_dir.mkdir(parents=True)
+    (calendar_dir / "day.txt").write_text("2022-01-03\n2022-01-04\n", encoding="utf-8")
+
+    download = Mock()
+    monkeypatch.setattr(collector.GetData, "qlib_data", download)
+    monkeypatch.setattr(runner, "download_data", Mock())
+    monkeypatch.setattr(runner, "normalize_data_1d_extend", Mock())
+    monkeypatch.setattr(collector, "DumpDataUpdate", Mock())
+    index_module = ModuleType("data_collector.us_index.collector")
+    index_module.get_instruments = Mock()
+    monkeypatch.setitem(sys.modules, index_module.__name__, index_module)
+    return runner, data_dir, download
+
+
+@pytest.mark.parametrize("exists_skip", [False, True])
+@pytest.mark.parametrize("delete_old", [None, False, True], ids=["default", "keep", "delete"])
+def test_update_data_to_bin_forwards_download_options(update_env, monkeypatch, exists_skip, delete_old):
+    runner, data_dir, download = update_env
+    monkeypatch.setattr(collector, "exists_qlib_data", lambda _: False)
+    kwargs = {} if delete_old is None else {"delete_old": delete_old}
+
+    runner.update_data_to_bin(data_dir, end_date="2022-01-05", exists_skip=exists_skip, **kwargs)
+
+    download.assert_called_once_with(
+        target_dir=str(data_dir.resolve()),
+        interval="1d",
+        region="us",
+        exists_skip=exists_skip,
+        delete_old=True if delete_old is None else delete_old,
+    )
+    runner.download_data.assert_called_once_with(delay=1, start="2022-01-03", end="2022-01-05", check_data_length=None)
+    runner.normalize_data_1d_extend.assert_called_once_with(str(data_dir.resolve()))
+    collector.DumpDataUpdate.return_value.dump.assert_called_once_with()
+
+
+@pytest.mark.parametrize("delete_old", [False, True])
+def test_update_data_to_bin_cli_delete_old(update_env, monkeypatch, delete_old):
+    runner, data_dir, download = update_env
+    monkeypatch.setattr(collector, "exists_qlib_data", lambda _: False)
+
+    collector.fire.Fire(
+        runner,
+        command=[
+            "update_data_to_bin",
+            "--qlib_data_1d_dir",
+            str(data_dir),
+            "--end_date",
+            "2022-01-05",
+            "--delete_old",
+            str(delete_old),
+            "--exists_skip",
+            "True",
+        ],
+    )
+
+    download.assert_called_once_with(
+        target_dir=str(data_dir.resolve()), interval="1d", region="us", exists_skip=True, delete_old=delete_old
+    )
+
+
+@pytest.mark.parametrize("exists_skip", [False, True])
+@pytest.mark.parametrize("delete_old", [False, True])
+def test_update_data_to_bin_skips_download_for_existing_data(update_env, monkeypatch, exists_skip, delete_old):
+    runner, data_dir, download = update_env
+    monkeypatch.setattr(collector, "exists_qlib_data", lambda _: True)
+
+    runner.update_data_to_bin(data_dir, end_date="2022-01-05", exists_skip=exists_skip, delete_old=delete_old)
+
+    download.assert_not_called()
+    runner.download_data.assert_called_once()
+    collector.DumpDataUpdate.return_value.dump.assert_called_once_with()


### PR DESCRIPTION
## Description

Add `delete_old: bool = True` to the end of `Run.update_data_to_bin` and forward it to `GetData.qlib_data` when the base dataset needs to be downloaded. Document the option in the method and Yahoo collector README.

The default remains unchanged. `--delete_old False` skips deletion of existing data directories before archive extraction; it does not prevent archive entries from overwriting matching files. Complete local datasets still skip the base download.

## Motivation and Context

Fixes #1121.

Current main already forwards `exists_skip`, but `delete_old` is still missing from the update method's signature and download call. This addresses the remaining part of the report without changing the existing download condition or update pipeline.

## How Has This Been Tested?

- [x] Added 12 offline cases in `tests/test_yahoo_collector.py`: default/explicit deletion settings, both `exists_skip` values, CLI boolean parsing through Fire, and skipping the base download when data already exists. Downloads, normalization, binary writes, and index collection are mocked; calendar input uses a temporary directory.
- [x] Before the fix, the initial 10 regression cases failed on upstream code (missing argument forwarding or an unexpected `delete_old` keyword).
- [x] `python -m pytest tests/test_yahoo_collector.py tests/misc/test_index_data.py tests/misc/test_sepdf.py -q`: **20 passed**, with one existing pandas `SettingWithCopyWarning` in `test_sepdf.py`.
- [x] `cd tests && python -m pytest test_yahoo_collector.py -q`: **12 passed**, matching the CI working directory.
- [x] `python -m black --check --diff -l 120 scripts/data_collector/yahoo/collector.py tests/test_yahoo_collector.py`: passed.
- [x] Flake8 on the new test file and `git diff --check`: passed. The collector has four existing F841 warnings on lines 116, 146, 175, and 185; compared against upstream and confirmed unchanged.
- [x] Checked that `python scripts/data_collector/yahoo/collector.py update_data_to_bin --help` lists `--delete_old` with default `True`.
- [ ] Full pipeline tests were not run; they require external market datasets and model training. No live Yahoo download was performed.

Environment: macOS arm64, Python 3.12.14, NumPy 1.26.4, pandas 2.3.3, editable source install.

## Types of changes

- [x] Fix bugs
- [ ] Add new feature
- [x] Update documentation
