### PR TITLE
fix(workflow): make _log_uncommitted_code safe in non-git CWDs

### DIFF
--- a/qlib/workflow/recorder.py
+++ b/qlib/workflow/recorder.py
@@ -369,14 +369,19 @@ class MLflowRecorder(Recorder):
         # Skip silently when CWD is not a git work tree: this is an optional reproducibility
         # hook, not a precondition, and a non-git CWD (containers, CI sandboxes, /tmp) is a
         # legitimate setup — not an error worth three failing subprocess calls per R.start().
+        # A bare repository also exits 0 but prints "false", so the probe checks the output,
+        # not just the exit code.
         try:
-            subprocess.run(
+            probe = subprocess.run(
                 ["git", "rev-parse", "--is-inside-work-tree"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 check=True,
             )
         except (subprocess.CalledProcessError, OSError):
+            logger.debug(f"Skip logging uncommitted code: $CWD({os.getcwd()}) is not a git work tree.")
+            return
+        if probe.stdout.strip() != b"true":
             logger.debug(f"Skip logging uncommitted code: $CWD({os.getcwd()}) is not a git work tree.")
             return
         for cmd_args, fname in [

--- a/qlib/workflow/recorder.py
+++ b/qlib/workflow/recorder.py
@@ -366,16 +366,34 @@ class MLflowRecorder(Recorder):
         """
         # TODO: the sub-directories maybe git repos.
         # So it will be better if we can walk the sub-directories and log the uncommitted changes.
-        for cmd, fname in [
-            ("git diff", "code_diff.txt"),
-            ("git status", "code_status.txt"),
-            ("git diff --cached", "code_cached.txt"),
+        # Skip silently when CWD is not a git work tree: this is an optional reproducibility
+        # hook, not a precondition, and a non-git CWD (containers, CI sandboxes, /tmp) is a
+        # legitimate setup — not an error worth three failing subprocess calls per R.start().
+        try:
+            subprocess.run(
+                ["git", "rev-parse", "--is-inside-work-tree"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=True,
+            )
+        except (subprocess.CalledProcessError, OSError):
+            logger.debug(f"Skip logging uncommitted code: $CWD({os.getcwd()}) is not a git work tree.")
+            return
+        for cmd_args, fname in [
+            (["git", "diff"], "code_diff.txt"),
+            (["git", "status"], "code_status.txt"),
+            (["git", "diff", "--cached"], "code_cached.txt"),
         ]:
             try:
-                out = subprocess.check_output(cmd, shell=True)
-                self.client.log_text(self.id, out.decode(), fname)  # this behaves same as above
+                out = subprocess.run(
+                    cmd_args,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    check=True,
+                )
+                self.client.log_text(self.id, out.stdout.decode(), fname)  # this behaves same as above
             except subprocess.CalledProcessError:
-                logger.info(f"Fail to log the uncommitted code of $CWD({os.getcwd()}) when run {cmd}.")
+                logger.info(f"Fail to log the uncommitted code of $CWD({os.getcwd()}) when run {' '.join(cmd_args)}.")
 
     def end_run(self, status: str = Recorder.STATUS_S):
         assert status in [

--- a/tests/workflow_tests/test_log_uncommitted_code.py
+++ b/tests/workflow_tests/test_log_uncommitted_code.py
@@ -1,0 +1,60 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+import contextlib
+import io
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from qlib.workflow.recorder import MLflowRecorder
+
+
+class LogUncommittedCodeTest(unittest.TestCase):
+    """Regression tests for ``MLflowRecorder._log_uncommitted_code``.
+
+    The function used to run git with ``shell=True`` without capturing stderr, so in a
+    non-git CWD every ``R.start()`` leaked a multi-line git usage banner to the caller's
+    stderr and logged three misleading INFO records. See issue #2252 (secondary defect).
+    """
+
+    def setUp(self):
+        self._tmp = TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+
+    def _make_recorder(self):
+        rec = MLflowRecorder.__new__(MLflowRecorder)  # skip __init__ (needs mlflow client)
+        rec.client = mock.MagicMock()
+        rec.id = "test-id"
+        return rec
+
+    def test_non_git_cwd_is_silent(self):
+        """In a non-git CWD: no stderr leak, no INFO records, no exception."""
+        rec = self._make_recorder()
+        with contextlib.chdir(Path(self._tmp.name)):  # fresh dir, no .git
+            err_buf = io.StringIO()
+            with mock.patch("qlib.workflow.recorder.logger") as mock_logger:
+                with contextlib.redirect_stderr(err_buf):
+                    rec._log_uncommitted_code()
+            self.assertNotIn("usage:", err_buf.getvalue())
+            self.assertNotIn("fatal:", err_buf.getvalue().lower())
+            mock_logger.info.assert_not_called()  # skip is DEBUG-level, not INFO
+
+    def test_git_cwd_still_logs(self):
+        """In a real git work tree the three diff artifacts are still produced."""
+        repo = Path(__file__).resolve().parents[2]
+        self.assertTrue((repo / ".git").exists(), "test must run inside the qlib git checkout")
+        cwd = os.getcwd()
+        os.chdir(repo)
+        self.addCleanup(os.chdir, cwd)
+        rec = self._make_recorder()
+        rec._log_uncommitted_code()
+        names = [c.args[2] for c in rec.client.log_text.call_args_list]
+        self.assertIn("code_diff.txt", names)
+        self.assertIn("code_status.txt", names)
+        self.assertIn("code_cached.txt", names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/workflow_tests/test_log_uncommitted_code.py
+++ b/tests/workflow_tests/test_log_uncommitted_code.py
@@ -3,6 +3,7 @@
 import contextlib
 import io
 import os
+import subprocess
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -40,6 +41,21 @@ class LogUncommittedCodeTest(unittest.TestCase):
             self.assertNotIn("usage:", err_buf.getvalue())
             self.assertNotIn("fatal:", err_buf.getvalue().lower())
             mock_logger.info.assert_not_called()  # skip is DEBUG-level, not INFO
+
+    def test_bare_repo_is_silent(self):
+        """In a bare repository the probe exits 0 but prints 'false' — must skip too."""
+        rec = self._make_recorder()
+        bare = Path(self._tmp.name) / "bare.git"
+        subprocess.run(["git", "init", "--bare", str(bare)], check=True, capture_output=True)
+        with contextlib.chdir(bare):
+            err_buf = io.StringIO()
+            with mock.patch("qlib.workflow.recorder.logger") as mock_logger:
+                with contextlib.redirect_stderr(err_buf):
+                    rec._log_uncommitted_code()
+            self.assertNotIn("usage:", err_buf.getvalue())
+            self.assertNotIn("fatal:", err_buf.getvalue().lower())
+            mock_logger.info.assert_not_called()
+            rec.client.log_text.assert_not_called()  # no artifact from a bare repo
 
     def test_git_cwd_still_logs(self):
         """In a real git work tree the three diff artifacts are still produced."""


### PR DESCRIPTION
## Summary

`MLflowRecorder._log_uncommitted_code` (`qlib/workflow/recorder.py:362`) ran its git commands via `subprocess.check_output(cmd, shell=True)` with no stderr capture. In a non-git working directory (containers, CI sandboxes, `/tmp`, any non-repo checkout), every `R.start()`:

- leaked a multi-line `usage: git diff --no-index ...` banner **straight to the caller's stderr**, bypassing qlib's logger entirely — corrupting structured-stderr consumers (JSONL loggers, CI parsers, anything piping output through `jq`);
- logged three misleading `INFO - "Fail to log the uncommitted code of ..."` records for what is a perfectly legitimate environment.

The git repo in CWD is not load-bearing for experiment correctness — the feature is an optional reproducibility hook, so it should degrade quietly when its environment isn't available.

## Fix

1. **Pre-probe the environment**: run `git rev-parse --is-inside-work-tree` once; on failure, skip at `DEBUG` level instead of running three doomed commands per `R.start()`.
2. **Drop `shell=True`**: pass git commands as argument lists (`["git", "diff"]`, ...). The commands use no shell features, and `shell=True` was a needless injection footgun.
3. **Capture stderr on every call** (`stdout=PIPE, stderr=PIPE`), so git diagnostics can never bypass the logger.

Behavior inside a real git work tree is unchanged: the three artifacts (`code_diff.txt` / `code_status.txt` / `code_cached.txt`) are still logged to the recorder.

## Tests

New `tests/workflow_tests/test_log_uncommitted_code.py`:

- **non-git CWD**: no stderr output, no `INFO` records (skip logs at `DEBUG`), no exception
- **git work tree**: the three diff artifacts are still produced (behavior preserved, verified against the qlib repo checkout itself)

All new and existing workflow tests pass locally (`tests/test_workflow.py` + both new files, 7 passed).

Fixes #2252 (secondary defect). The primary defect — `FileLock` path built CWD-relative — is fixed in PR #2337.
